### PR TITLE
feat: #134 漢字 choice を LLM-judge で確定（未レビュー 2925→4）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,5 +81,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - name: Run IME-strict ja_typings lint (long vowel / ティ / ディ / kunrei / English literal)
+      - name: Run IME-strict ja_typings lint (long vowel / ティ / ディ / kunrei / English literal / spurious /)
         run: python3 scripts/lint_ja_typings.py
+      - name: Verify ja/en choice data stays in sync (#134)
+        run: python3 scripts/kanji_review.py verify-sync

--- a/data/questions_en.json
+++ b/data/questions_en.json
@@ -2430,8 +2430,7 @@
         "ja": "ソウル",
         "en": "Seoul",
         "ja_typings": [
-          "souru",
-          "soru"
+          "souru"
         ]
       },
       {
@@ -12319,8 +12318,7 @@
         "ja": "プロダクトオーナー",
         "en": "Product Owner",
         "ja_typings": [
-          "purodakutoo-na-",
-          "purodakuto-na-"
+          "purodakutoo-na-"
         ]
       },
       {
@@ -15532,7 +15530,7 @@
         "ja": "ジョルノ・ジョバァーナ",
         "en": "Giorno Giovanna",
         "ja_typings": [
-          "joruno/joba--na"
+          "joruno/jobaa-na"
         ]
       }
     ],
@@ -17486,8 +17484,7 @@
         "ja": "ダークソウル",
         "en": "Dark Souls",
         "ja_typings": [
-          "da-kusouru",
-          "da-kusoru"
+          "da-kusouru"
         ]
       },
       {
@@ -17747,8 +17744,7 @@
         "ja": "シャドウバース",
         "en": "Shadowverse",
         "ja_typings": [
-          "shadouba-su",
-          "shadoba-su"
+          "shadouba-su"
         ]
       }
     ],
@@ -17912,8 +17908,7 @@
         "ja": "スプラトゥーン",
         "en": "Splatoon",
         "ja_typings": [
-          "supuratwu-n",
-          "supuratu-n"
+          "supuratwu-n"
         ]
       }
     ],
@@ -17933,8 +17928,7 @@
         "ja": "スプラトゥーン",
         "en": "Splatoon",
         "ja_typings": [
-          "supuratwu-n",
-          "supuratu-n"
+          "supuratwu-n"
         ]
       },
       {
@@ -20354,8 +20348,7 @@
         "ja": "アウグストゥス",
         "en": "Augustus",
         "ja_typings": [
-          "augusutwusu",
-          "augusutusu"
+          "augusutwusu"
         ]
       },
       {
@@ -21052,7 +21045,7 @@
         "ja": "オスマン帝国",
         "en": "Ottoman Empire",
         "ja_typings": [
-          "osumantekoku"
+          "osumanteikoku"
         ]
       },
       {
@@ -25891,8 +25884,7 @@
         "ja": "ラタトゥイユ",
         "en": "Ratatouille",
         "ja_typings": [
-          "ratatwuiyu",
-          "ratatuiyu"
+          "ratatwuiyu"
         ]
       },
       {
@@ -27307,8 +27299,7 @@
         "ja": "ヒョウ",
         "en": "leopard",
         "ja_typings": [
-          "hyou",
-          "hyo"
+          "hyou"
         ]
       }
     ],
@@ -29960,16 +29951,14 @@
         "ja": "ありがとう",
         "en": "Thanks",
         "ja_typings": [
-          "arigatou",
-          "arigato"
+          "arigatou"
         ]
       },
       {
         "ja": "おはよう",
         "en": "Good morning",
         "ja_typings": [
-          "ohayou",
-          "ohayo"
+          "ohayou"
         ]
       },
       {
@@ -30186,7 +30175,8 @@
     "question_text": {
       "en": "Which Git command merges by creating a new commit that combines branch histories without fast-forward?",
       "ja": "ファストフォワードなしで新しいコミットを作ってブランチ履歴をマージする Git コマンドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30226,7 +30216,8 @@
     "question_text": {
       "en": "Which HTTP status code indicates that the requested resource was permanently moved?",
       "ja": "リクエストされたリソースが恒久的に移動したことを示す HTTP ステータスコードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30266,7 +30257,8 @@
     "question_text": {
       "en": "Which design pattern ensures a class has only one instance?",
       "ja": "クラスがただ一つのインスタンスしか持たないことを保証するデザインパターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30306,7 +30298,8 @@
     "question_text": {
       "en": "Which protocol is used to securely transfer files over SSH?",
       "ja": "SSH 経由で安全にファイルを転送するプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30346,7 +30339,8 @@
     "question_text": {
       "en": "In Kubernetes, what controller maintains a stable set of replica Pods?",
       "ja": "Kubernetes でレプリカ Pod の安定集合を維持するコントローラーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30386,7 +30380,8 @@
     "question_text": {
       "en": "Which AWS service provides a fully managed relational database for PostgreSQL with Aurora compatibility?",
       "ja": "Aurora 互換のマネージドリレーショナル DB を提供する AWS サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30426,7 +30421,8 @@
     "question_text": {
       "en": "Which CAP theorem property guarantees every read returns the most recent write?",
       "ja": "CAP 定理で、すべての読み出しが最新の書き込みを返すことを保証する性質は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30448,7 +30444,7 @@
         "en": "End-to-end test",
         "ja": "エンドトゥーエンドテスト",
         "ja_typings": [
-          "endotu-endotesuto"
+          "endotwu-endotesuto"
         ]
       },
       {
@@ -30466,7 +30462,8 @@
     "question_text": {
       "en": "Which test type checks the integration of multiple modules working together?",
       "ja": "複数のモジュールが連携して動作することを検証するテストの種類は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30506,7 +30503,8 @@
     "question_text": {
       "en": "Which OSI model layer is responsible for end-to-end communication and reliability?",
       "ja": "OSI 参照モデルでエンドツーエンドの通信と信頼性を担う層は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30546,7 +30544,8 @@
     "question_text": {
       "en": "Which database concept ensures that committed data survives system failures?",
       "ja": "コミット済みのデータがシステム障害後も残ることを保証する DB の概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30586,7 +30585,8 @@
     "question_text": {
       "en": "Which Linux command shows the routing table?",
       "ja": "Linux でルーティングテーブルを表示するコマンドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30626,7 +30626,8 @@
     "question_text": {
       "en": "Which Agile ceremony reviews what the team learned during the sprint to improve processes?",
       "ja": "プロセス改善のためスプリント中の学びを振り返るアジャイルのセレモニーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30666,7 +30667,8 @@
     "question_text": {
       "en": "Which AWS service provides a managed message queue?",
       "ja": "マネージドメッセージキューを提供する AWS サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30706,7 +30708,8 @@
     "question_text": {
       "en": "Which programming paradigm treats computation as evaluation of mathematical functions?",
       "ja": "計算を数学的関数の評価として扱うプログラミングパラダイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30746,7 +30749,8 @@
     "question_text": {
       "en": "Which authentication standard is widely used for federated single sign-on with XML assertions?",
       "ja": "XML アサーションでフェデレーテッド SSO に広く使われる認証規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30761,7 +30765,7 @@
         "en": "Mean Time to Recover",
         "ja": "ミーンタイムトゥーリカバー",
         "ja_typings": [
-          "mi-ntaimutu-rikaba-"
+          "mi-ntaimutwu-rikaba-"
         ]
       },
       {
@@ -30786,7 +30790,8 @@
     "question_text": {
       "en": "Which DevOps metric measures the time from code commit to production deployment?",
       "ja": "コミットから本番デプロイまでの時間を計測する DevOps メトリクスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30826,7 +30831,8 @@
     "question_text": {
       "en": "Which type of cloud computing service provides ready-to-use applications over the internet?",
       "ja": "利用可能なアプリケーションをインターネット経由で提供するクラウドサービス種別は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30866,7 +30872,8 @@
     "question_text": {
       "en": "Which Japanese particle marks the topic of a sentence?",
       "ja": "日本語で文の主題を示す助詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30906,7 +30913,8 @@
     "question_text": {
       "en": "Which language family does Finnish belong to?",
       "ja": "フィンランド語が属する語族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30946,7 +30954,8 @@
     "question_text": {
       "en": "What is the linguistic term for words that sound the same but have different meanings?",
       "ja": "音は同じだが意味が異なる単語を指す言語学用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30986,7 +30995,8 @@
     "question_text": {
       "en": "Which writing system was used in ancient Mesopotamia?",
       "ja": "古代メソポタミアで使われた文字体系は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31026,7 +31036,8 @@
     "question_text": {
       "en": "Which Japanese honorific form lowers the speaker to elevate the listener?",
       "ja": "話者を低めて聴者を高める日本語の敬語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31066,7 +31077,8 @@
     "question_text": {
       "en": "Which grammatical case marks the direct object in Latin?",
       "ja": "ラテン語で直接目的語を示す格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31106,7 +31118,8 @@
     "question_text": {
       "en": "Which Chinese tone is described as a sharp falling tone?",
       "ja": "中国語で鋭く下がる調子とされる四声は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31121,7 +31134,7 @@
         "en": "Calque",
         "ja": "翻訳借用",
         "ja_typings": [
-          "honyakushakuyou"
+          "honnyakushakuyou"
         ]
       },
       {
@@ -31146,7 +31159,8 @@
     "question_text": {
       "en": "Which term refers to the borrowing of a word from another language with adaptation?",
       "ja": "他言語からの適応付き単語借用を指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31186,7 +31200,8 @@
     "question_text": {
       "en": "In English grammar, which tense expresses an action completed before another past action?",
       "ja": "英文法で、別の過去の行為より前に完了した行為を表す時制は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31226,7 +31241,8 @@
     "question_text": {
       "en": "Which Romance language is the official language of Romania?",
       "ja": "ルーマニアの公用語であるロマンス諸語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31266,7 +31282,8 @@
     "question_text": {
       "en": "Which is the official script used to write Korean?",
       "ja": "朝鮮語の表記に使われる公式文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31306,7 +31323,8 @@
     "question_text": {
       "en": "Which kind of word in Japanese conjugates and ends in u?",
       "ja": "日本語でウ段で終わり活用する品詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31321,7 +31339,7 @@
         "en": "Metaphor",
         "ja": "隠喩",
         "ja_typings": [
-          "inyu"
+          "innyu"
         ]
       },
       {
@@ -31346,7 +31364,8 @@
     "question_text": {
       "en": "Which figure of speech compares two things using like or as?",
       "ja": "「ようだ」「みたいに」を使って似たものを喩える修辞法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31386,7 +31405,8 @@
     "question_text": {
       "en": "Which Slavic language is written with both Latin and Cyrillic scripts officially?",
       "ja": "ラテン文字とキリル文字の両方が公式に使われるスラブ語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31426,7 +31446,8 @@
     "question_text": {
       "en": "Which is the largest language family in the world by number of languages?",
       "ja": "言語数で世界最大の語族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31455,7 +31476,7 @@
         "en": "Kun-yomi",
         "ja": "訓読み",
         "ja_typings": [
-          "kunyomi"
+          "kunnyomi"
         ]
       }
     ],
@@ -31466,7 +31487,8 @@
     "question_text": {
       "en": "Which Japanese kanji reading was brought from Tang-dynasty China?",
       "ja": "唐代中国から伝わった漢字の読みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31506,7 +31528,8 @@
     "question_text": {
       "en": "Which is the oldest known fully deciphered writing system?",
       "ja": "完全に解読された最古の文字体系は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31546,7 +31569,8 @@
     "question_text": {
       "en": "Which traditional Korean dish consists of fermented vegetables, typically cabbage?",
       "ja": "発酵野菜、特に白菜を使った韓国の伝統料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31586,7 +31610,8 @@
     "question_text": {
       "en": "Which French dish is a thin pancake filled with savory ingredients, originally from Brittany?",
       "ja": "ブルターニュ地方発祥の塩味の薄焼き菓子料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31626,7 +31651,8 @@
     "question_text": {
       "en": "Which Japanese summer festival features paper lanterns and is held in mid-August to honor ancestors?",
       "ja": "8月中旬に先祖供養のため灯籠を掲げる日本の夏祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31666,7 +31692,8 @@
     "question_text": {
       "en": "Which Spanish dish features saffron-flavored rice with seafood or meat?",
       "ja": "サフラン風味の米にシーフードや肉を入れたスペイン料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31706,7 +31733,8 @@
     "question_text": {
       "en": "Which Mexican festival on November 1-2 honors deceased relatives?",
       "ja": "11月1日から2日に故人を讃えるメキシコの祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31746,7 +31774,8 @@
     "question_text": {
       "en": "Which Japanese garden style uses raked gravel and rocks to represent landscapes?",
       "ja": "砂利や岩で景色を表現する日本庭園の様式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31786,7 +31815,8 @@
     "question_text": {
       "en": "Which traditional Indian garment is a long unstitched cloth wrapped around the body?",
       "ja": "長く縫っていない布を体に巻くインドの伝統衣装は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31826,7 +31856,8 @@
     "question_text": {
       "en": "Which French dessert is a layered cake with coffee buttercream and chocolate?",
       "ja": "コーヒーバタークリームとチョコレートの層状ケーキはフランスの何という菓子?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31866,7 +31897,8 @@
     "question_text": {
       "en": "Which Turkish coffee preparation involves boiling finely ground coffee in a small pot?",
       "ja": "小さな鍋で細かく挽いたコーヒーを煮詰めるトルコのコーヒー抽出法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31906,7 +31938,8 @@
     "question_text": {
       "en": "Which Scottish bagpipe music style features ornate variations on a theme?",
       "ja": "主題への装飾的変奏が特徴のスコットランドのバグパイプ曲は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31946,7 +31979,8 @@
     "question_text": {
       "en": "Which Argentine dance originated in Buenos Aires and Montevideo in the late 19th century?",
       "ja": "19世紀後半にブエノスアイレスとモンテビデオで生まれたアルゼンチンの舞踊は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31986,7 +32020,8 @@
     "question_text": {
       "en": "Which traditional Russian soup is made with beetroot?",
       "ja": "ビーツを使ったロシアの伝統スープは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32026,7 +32061,8 @@
     "question_text": {
       "en": "Which Italian opera house in Milan opened in 1778?",
       "ja": "1778年に開館したミラノのオペラ劇場は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32041,7 +32077,7 @@
         "en": "Vale tudo",
         "ja": "バーリトゥード",
         "ja_typings": [
-          "ba-ritu-do"
+          "ba-ritwu-do"
         ]
       },
       {
@@ -32066,7 +32102,8 @@
     "question_text": {
       "en": "Which Brazilian martial art combines dance, acrobatics, and music?",
       "ja": "ダンス、アクロバット、音楽を組み合わせたブラジルの武術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32106,7 +32143,8 @@
     "question_text": {
       "en": "Which Greek philosophical drinking party was the subject of works by Plato and Xenophon?",
       "ja": "プラトンとクセノフォンの著作の主題となったギリシャの哲学的宴会は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32146,7 +32184,8 @@
     "question_text": {
       "en": "Which type of Japanese sake brewing requires polishing rice to at least 50% of its original size?",
       "ja": "米を原料の50%以下まで精米する日本酒の種類は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32186,7 +32225,8 @@
     "question_text": {
       "en": "Which Brazilian dance is the signature of the Rio Carnival?",
       "ja": "リオのカーニバルを代表するブラジルのダンスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32226,7 +32266,8 @@
     "question_text": {
       "en": "Which traditional Chinese dress for women features a high collar and side slits?",
       "ja": "高い襟とサイドスリットが特徴の中国伝統衣装(女性用)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32266,7 +32307,8 @@
     "question_text": {
       "en": "Which Mexican holiday on May 5 commemorates the 1862 victory over the French at Puebla?",
       "ja": "1862年のプエブラでの対仏勝利を讃える5月5日のメキシコの祝日は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32306,7 +32348,8 @@
     "question_text": {
       "en": "Which Spanish festival is famous for the running of the bulls in Pamplona?",
       "ja": "パンプローナでの牛追いで有名なスペインの祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32346,7 +32389,8 @@
     "question_text": {
       "en": "Which Cuban-origin dance is known for its quick step patterns and is popular worldwide?",
       "ja": "キューバ発祥で速いステップで世界的に普及している舞踊は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32386,7 +32430,8 @@
     "question_text": {
       "en": "Which Hindu festival of lights is celebrated in autumn?",
       "ja": "秋に祝われるヒンドゥー教の光の祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32426,7 +32471,8 @@
     "question_text": {
       "en": "Which field of linguistics studies meaning in language?",
       "ja": "言語の意味を研究する言語学の分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32466,7 +32512,8 @@
     "question_text": {
       "en": "Which kind of Japanese characters represent meaning rather than sound?",
       "ja": "音ではなく意味を表現する日本語の文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32506,7 +32553,8 @@
     "question_text": {
       "en": "In English grammar, which voice has the subject performing the action?",
       "ja": "主語が動作を行う英文法の態は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32546,7 +32594,8 @@
     "question_text": {
       "en": "Which part of speech modifies verbs, adjectives, or other adverbs?",
       "ja": "動詞、形容詞、または他の副詞を修飾する品詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32586,7 +32635,8 @@
     "question_text": {
       "en": "Which language family includes Mandarin Chinese and Tibetan?",
       "ja": "中国語とチベット語を含む語族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32626,7 +32676,8 @@
     "question_text": {
       "en": "Which language family includes Indonesian, Tagalog, and Malagasy?",
       "ja": "インドネシア語、タガログ語、マダガスカル語を含む語族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32641,7 +32692,7 @@
         "en": "Metaphor",
         "ja": "隠喩",
         "ja_typings": [
-          "inyu"
+          "innyu"
         ]
       },
       {
@@ -32666,7 +32717,8 @@
     "question_text": {
       "en": "Which figure of speech exaggerates for emphasis or effect?",
       "ja": "強調や効果のため誇張する修辞法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32706,7 +32758,8 @@
     "question_text": {
       "en": "Which Mandarin phonetic system uses zhuyin symbols and is used in Taiwan?",
       "ja": "台湾で使われる注音符号のマンダリン発音表記は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32746,7 +32799,8 @@
     "question_text": {
       "en": "Which AWS service provides serverless container compute that runs without managing servers?",
       "ja": "サーバー管理不要でコンテナ実行環境を提供する AWS サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32786,7 +32840,8 @@
     "question_text": {
       "en": "Which type of cloud computing provides raw virtualized hardware resources?",
       "ja": "生の仮想化ハードウェアリソースを提供するクラウドの種類は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32826,7 +32881,8 @@
     "question_text": {
       "en": "Which cloud computing model executes code in response to events without managing infrastructure?",
       "ja": "インフラ管理不要でイベント応答コード実行をするクラウドモデルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32866,7 +32922,8 @@
     "question_text": {
       "en": "Which AWS service is a fully managed NoSQL key-value database?",
       "ja": "マネージドな NoSQL キーバリュー DB である AWS サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32906,7 +32963,8 @@
     "question_text": {
       "en": "Which AWS service is a petabyte-scale data warehouse?",
       "ja": "ペタバイト規模のデータウェアハウスである AWS サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32946,7 +33004,8 @@
     "question_text": {
       "en": "Which open-source IaC tool by HashiCorp uses HCL to define cloud infrastructure?",
       "ja": "HashiCorp 製で HCL でクラウドインフラを定義する IaC ツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32986,7 +33045,8 @@
     "question_text": {
       "en": "Which open-source configuration management tool uses YAML playbooks?",
       "ja": "YAML プレイブックを使う構成管理ツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33026,7 +33086,8 @@
     "question_text": {
       "en": "In Scrum, which ceremony lets the team demo completed work to stakeholders?",
       "ja": "Scrum でステークホルダーに完了作業をデモするセレモニーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33066,7 +33127,8 @@
     "question_text": {
       "en": "Which German astronomer formulated the laws of planetary motion?",
       "ja": "惑星運動の法則を定式化したドイツの天文学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33106,7 +33168,8 @@
     "question_text": {
       "en": "Which German physician proved that specific microorganisms cause specific diseases?",
       "ja": "特定の微生物が特定の病気を引き起こすことを証明したドイツの医師は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33146,7 +33209,8 @@
     "question_text": {
       "en": "Which noble gas is used to inflate party balloons and is the second lightest element?",
       "ja": "パーティー用風船に使われ、2番目に軽い気体元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33186,7 +33250,8 @@
     "question_text": {
       "en": "Which human organ produces bile and detoxifies the blood?",
       "ja": "胆汁を分泌し血液を解毒するヒトの臓器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33226,7 +33291,8 @@
     "question_text": {
       "en": "Which unit of electric potential difference is named after an Italian physicist?",
       "ja": "イタリア人物理学者にちなんだ電位差の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33266,7 +33332,8 @@
     "question_text": {
       "en": "Which SI unit of power equals one joule per second?",
       "ja": "毎秒1ジュールに相当する SI 単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33306,7 +33373,8 @@
     "question_text": {
       "en": "Which physicist discovered the atomic nucleus through the gold foil experiment?",
       "ja": "金箔実験で原子核を発見した物理学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33346,7 +33414,8 @@
     "question_text": {
       "en": "Which unit of pressure equals one newton per square meter?",
       "ja": "平方メートルあたり1ニュートンの圧力単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33375,7 +33444,7 @@
         "en": "Commodus",
         "ja": "コンモドゥス",
         "ja_typings": [
-          "konmodusu"
+          "konmodwusu"
         ]
       }
     ],
@@ -33386,7 +33455,8 @@
     "question_text": {
       "en": "Which Roman emperor is infamous for allegedly playing music while Rome burned?",
       "ja": "ローマ市街炎上中に演奏したと言われる悪名高いローマ皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33426,7 +33496,8 @@
     "question_text": {
       "en": "Which Roman emperor built a famous wall across northern Britain?",
       "ja": "北ブリテンに有名な城壁を築いたローマ皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33434,7 +33505,7 @@
         "en": "Battle of Waterloo",
         "ja": "ワーテルローの戦い",
         "ja_typings": [
-          "wa-teru-notatakai"
+          "wa-teruro-notatakai"
         ]
       },
       {
@@ -33466,7 +33537,8 @@
     "question_text": {
       "en": "In which 1815 battle was Napoleon finally defeated?",
       "ja": "1815年にナポレオンが最終的に敗北した戦闘は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33506,7 +33578,8 @@
     "question_text": {
       "en": "Which Portuguese explorer was the first European to reach India by sea?",
       "ja": "海路で初めてインドに到達したポルトガル人探検家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33546,7 +33619,8 @@
     "question_text": {
       "en": "Which Italian explorer's first name became the basis for the name 'America'?",
       "ja": "「アメリカ」の語源となったイタリア人探検家の名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33586,7 +33660,8 @@
     "question_text": {
       "en": "Which Portuguese-born explorer led the first expedition to circumnavigate the globe?",
       "ja": "世界一周航海の最初の遠征を率いたポルトガル出身の探検家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33626,7 +33701,8 @@
     "question_text": {
       "en": "Which country has Hanoi as its capital?",
       "ja": "ハノイを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33666,7 +33742,8 @@
     "question_text": {
       "en": "Which country has Jakarta as its capital?",
       "ja": "ジャカルタを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33706,7 +33783,8 @@
     "question_text": {
       "en": "Which country has Ankara as its capital?",
       "ja": "アンカラを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33746,7 +33824,8 @@
     "question_text": {
       "en": "Which country has Lisbon as its capital?",
       "ja": "リスボンを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33786,7 +33865,8 @@
     "question_text": {
       "en": "Which country has Helsinki as its capital?",
       "ja": "ヘルシンキを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33826,7 +33906,8 @@
     "question_text": {
       "en": "Which country has Oslo as its capital?",
       "ja": "オスロを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33866,7 +33947,8 @@
     "question_text": {
       "en": "Which country has Vienna as its capital?",
       "ja": "ウィーンを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33906,7 +33988,8 @@
     "question_text": {
       "en": "Which country has Prague as its capital?",
       "ja": "プラハを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33946,7 +34029,8 @@
     "question_text": {
       "en": "Which country has Warsaw as its capital?",
       "ja": "ワルシャワを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33986,7 +34070,8 @@
     "question_text": {
       "en": "Which country has Buenos Aires as its capital?",
       "ja": "ブエノスアイレスを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34026,7 +34111,8 @@
     "question_text": {
       "en": "Which country has Lima as its capital?",
       "ja": "リマを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34066,7 +34152,8 @@
     "question_text": {
       "en": "Which country has Nairobi as its capital?",
       "ja": "ナイロビを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34106,7 +34193,8 @@
     "question_text": {
       "en": "Which country has Cairo as its capital?",
       "ja": "カイロを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34146,7 +34234,8 @@
     "question_text": {
       "en": "Which country has Wellington as its capital?",
       "ja": "ウェリントンを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34186,7 +34275,8 @@
     "question_text": {
       "en": "Which country has Canberra as its capital?",
       "ja": "キャンベラを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34226,7 +34316,8 @@
     "question_text": {
       "en": "Which country has Ottawa as its capital?",
       "ja": "オタワを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34266,7 +34357,8 @@
     "question_text": {
       "en": "Which river flows through London?",
       "ja": "ロンドンを流れる河川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34306,7 +34398,8 @@
     "question_text": {
       "en": "Which river flows through Paris?",
       "ja": "パリを流れる河川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34346,7 +34439,8 @@
     "question_text": {
       "en": "Which river is the longest in China?",
       "ja": "中国最長の河川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34386,7 +34480,8 @@
     "question_text": {
       "en": "Which mountain range stretches across South America's west coast?",
       "ja": "南米の西海岸に連なる山脈は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34426,7 +34521,8 @@
     "question_text": {
       "en": "Which mountain range divides Europe and Asia?",
       "ja": "ヨーロッパとアジアを分ける山脈は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34466,7 +34562,8 @@
     "question_text": {
       "en": "Which sea lies between Italy and the Balkans?",
       "ja": "イタリアとバルカン半島の間の海は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34506,7 +34603,8 @@
     "question_text": {
       "en": "Which sea lies between Greece and Turkey?",
       "ja": "ギリシャとトルコの間の海は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34546,7 +34644,8 @@
     "question_text": {
       "en": "Which is the world's largest desert (after the polar ones)?",
       "ja": "極地を除く世界最大の砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34586,7 +34685,8 @@
     "question_text": {
       "en": "Which desert lies between Mongolia and China?",
       "ja": "モンゴルと中国の間にある砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34626,7 +34726,8 @@
     "question_text": {
       "en": "Which is the largest country by area?",
       "ja": "面積が世界最大の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34666,7 +34767,8 @@
     "question_text": {
       "en": "Which is the smallest country in the world?",
       "ja": "世界最小の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34706,7 +34808,8 @@
     "question_text": {
       "en": "Which is the world's largest lake by area?",
       "ja": "世界最大の湖は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34746,7 +34849,8 @@
     "question_text": {
       "en": "Which is the deepest lake in the world?",
       "ja": "世界で最も深い湖は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34786,7 +34890,8 @@
     "question_text": {
       "en": "Which strait separates Europe and Africa?",
       "ja": "ヨーロッパとアフリカを隔てる海峡は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34826,7 +34931,8 @@
     "question_text": {
       "en": "Which strait separates Asia and North America?",
       "ja": "アジアと北米を隔てる海峡は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34866,7 +34972,8 @@
     "question_text": {
       "en": "Which continent is Egypt located in?",
       "ja": "エジプトが属する大陸は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34906,7 +35013,8 @@
     "question_text": {
       "en": "Which continent has the most countries?",
       "ja": "国の数が最も多い大陸は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34946,7 +35054,8 @@
     "question_text": {
       "en": "Which is the highest mountain in Africa?",
       "ja": "アフリカ最高峰は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34986,7 +35095,8 @@
     "question_text": {
       "en": "Which city is known as the Eternal City?",
       "ja": "永遠の都と呼ばれる都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35026,7 +35136,8 @@
     "question_text": {
       "en": "Who was the first emperor of unified China?",
       "ja": "中国を統一した最初の皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35066,7 +35177,8 @@
     "question_text": {
       "en": "Who founded the Mongol Empire?",
       "ja": "モンゴル帝国を建国したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35106,7 +35218,8 @@
     "question_text": {
       "en": "Who was the queen of ancient Egypt famous for relations with Rome?",
       "ja": "ローマと関係したことで有名な古代エジプトの女王は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35146,7 +35259,8 @@
     "question_text": {
       "en": "Who was the first president of independent India?",
       "ja": "インド独立後の初代大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35186,7 +35300,8 @@
     "question_text": {
       "en": "Who led India's independence movement nonviolently?",
       "ja": "非暴力でインド独立運動を率いたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35226,7 +35341,8 @@
     "question_text": {
       "en": "Who was the British Prime Minister during WWII?",
       "ja": "第二次大戦中のイギリス首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35266,7 +35382,8 @@
     "question_text": {
       "en": "Who was the leader of Nazi Germany?",
       "ja": "ナチスドイツの指導者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35306,7 +35423,8 @@
     "question_text": {
       "en": "Who led the Soviet Union during WWII?",
       "ja": "第二次大戦中のソ連を率いたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35346,7 +35464,8 @@
     "question_text": {
       "en": "Who founded the Soviet Union?",
       "ja": "ソ連を建国したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35386,7 +35505,8 @@
     "question_text": {
       "en": "Who wrote The Communist Manifesto with Engels?",
       "ja": "エンゲルスと共産党宣言を書いたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35426,7 +35546,8 @@
     "question_text": {
       "en": "Who was the first US president to be assassinated?",
       "ja": "暗殺された最初のアメリカ大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35466,7 +35587,8 @@
     "question_text": {
       "en": "Who was the US president during the Cuban Missile Crisis?",
       "ja": "キューバ危機時のアメリカ大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35506,7 +35628,8 @@
     "question_text": {
       "en": "Who discovered the Americas in 1492?",
       "ja": "1492年に新大陸に到達したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35546,7 +35669,8 @@
     "question_text": {
       "en": "Who first circumnavigated the globe?",
       "ja": "世界一周航海を最初に成し遂げたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35586,7 +35710,8 @@
     "question_text": {
       "en": "Who painted the Mona Lisa?",
       "ja": "モナリザを描いたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35626,7 +35751,8 @@
     "question_text": {
       "en": "Who proposed heliocentrism in the 16th century?",
       "ja": "16世紀に地動説を唱えたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35666,7 +35792,8 @@
     "question_text": {
       "en": "Who founded the Mughal Empire in India?",
       "ja": "インドのムガル帝国を建国したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35706,7 +35833,8 @@
     "question_text": {
       "en": "Who built the Taj Mahal?",
       "ja": "タージマハルを建てたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35746,7 +35874,8 @@
     "question_text": {
       "en": "Which dynasty preceded the Tang in China?",
       "ja": "中国で唐の前の王朝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35786,7 +35915,8 @@
     "question_text": {
       "en": "Which dynasty followed the Tang in China?",
       "ja": "中国で唐の次の王朝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35826,7 +35956,8 @@
     "question_text": {
       "en": "Which dynasty was the last imperial dynasty of China?",
       "ja": "中国最後の王朝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35866,7 +35997,8 @@
     "question_text": {
       "en": "Which war was triggered by the assassination in Sarajevo?",
       "ja": "サラエボ事件で勃発した戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35906,7 +36038,8 @@
     "question_text": {
       "en": "Which war ended with the Treaty of Versailles?",
       "ja": "ベルサイユ条約で終わった戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35946,7 +36079,8 @@
     "question_text": {
       "en": "Which treaty ended the Russo-Japanese War?",
       "ja": "日露戦争を終結させた条約は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35986,7 +36120,8 @@
     "question_text": {
       "en": "Which treaty ended the Sino-Japanese War of 1894-95?",
       "ja": "日清戦争を終結させた条約は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36026,7 +36161,8 @@
     "question_text": {
       "en": "Which civilization built Machu Picchu?",
       "ja": "マチュピチュを築いた文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36066,7 +36202,8 @@
     "question_text": {
       "en": "Which civilization built Chichen Itza?",
       "ja": "チチェンイツァを築いた文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36106,7 +36243,8 @@
     "question_text": {
       "en": "Which civilization was centered at Tenochtitlan?",
       "ja": "テノチティトランを首都とした文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36146,7 +36284,8 @@
     "question_text": {
       "en": "Which civilization flourished along the Indus river?",
       "ja": "インダス川流域で栄えた文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36186,7 +36325,8 @@
     "question_text": {
       "en": "Who is regarded as the father of modern Turkey?",
       "ja": "近代トルコの父と呼ばれるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36194,7 +36334,7 @@
         "en": "Storming of the Bastille",
         "ja": "バスティーユ襲撃",
         "ja_typings": [
-          "basuthi-yuushuugeki"
+          "basuthi-yushuugeki"
         ]
       },
       {
@@ -36226,7 +36366,8 @@
     "question_text": {
       "en": "Which event in 1789 began the French Revolution?",
       "ja": "1789年フランス革命の発端となった事件は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36234,7 +36375,7 @@
         "en": "Battle of Waterloo",
         "ja": "ワーテルローの戦い",
         "ja_typings": [
-          "wa-terurro-notatakai"
+          "wa-teruro-notatakai"
         ]
       },
       {
@@ -36266,7 +36407,8 @@
     "question_text": {
       "en": "Which battle marked Napoleon's final defeat?",
       "ja": "ナポレオンが最終的に敗れた戦いは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36306,7 +36448,8 @@
     "question_text": {
       "en": "Which year did the Berlin Wall fall?",
       "ja": "ベルリンの壁が崩壊した年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36346,7 +36489,8 @@
     "question_text": {
       "en": "Which year did the Meiji era begin?",
       "ja": "明治時代が始まった年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36386,7 +36530,8 @@
     "question_text": {
       "en": "Who was the first shogun of the Kamakura shogunate?",
       "ja": "鎌倉幕府の初代将軍は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36426,7 +36571,8 @@
     "question_text": {
       "en": "What is the chemical symbol for silver?",
       "ja": "銀の元素記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36466,7 +36612,8 @@
     "question_text": {
       "en": "What is the chemical symbol for sodium?",
       "ja": "ナトリウムの元素記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36506,7 +36653,8 @@
     "question_text": {
       "en": "What is the chemical symbol for potassium?",
       "ja": "カリウムの元素記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36546,7 +36694,8 @@
     "question_text": {
       "en": "What is the most abundant gas in Earth's atmosphere?",
       "ja": "地球大気で最も多い気体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36586,7 +36735,8 @@
     "question_text": {
       "en": "Which gas is most responsible for the greenhouse effect from human activity?",
       "ja": "人類活動由来で温室効果に最も寄与する気体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36626,7 +36776,8 @@
     "question_text": {
       "en": "What planet is known as the Red Planet?",
       "ja": "赤い惑星と呼ばれるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36641,7 +36792,7 @@
         "en": "Uranus",
         "ja": "天王星",
         "ja_typings": [
-          "tennousei"
+          "tennnousei"
         ]
       },
       {
@@ -36666,7 +36817,8 @@
     "question_text": {
       "en": "Which planet has the most prominent ring system?",
       "ja": "最も目立つ環を持つ惑星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36681,7 +36833,7 @@
         "en": "Uranus",
         "ja": "天王星",
         "ja_typings": [
-          "tennousei"
+          "tennnousei"
         ]
       },
       {
@@ -36706,7 +36858,8 @@
     "question_text": {
       "en": "Which planet is farthest from the Sun (excluding Pluto)?",
       "ja": "太陽から最も遠い惑星（冥王星除く）は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36746,7 +36899,8 @@
     "question_text": {
       "en": "What is the powerhouse of the cell?",
       "ja": "細胞のエネルギー工場と呼ばれる小器官は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36786,7 +36940,8 @@
     "question_text": {
       "en": "Which process do plants use to make food?",
       "ja": "植物が栄養を作る働きは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36826,7 +36981,8 @@
     "question_text": {
       "en": "Who formulated the three laws of motion?",
       "ja": "運動の三法則を定式化したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36866,7 +37022,8 @@
     "question_text": {
       "en": "Who proposed the theory of evolution by natural selection?",
       "ja": "自然選択による進化論を唱えたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36906,7 +37063,8 @@
     "question_text": {
       "en": "Who is regarded as the father of genetics?",
       "ja": "遺伝学の父と呼ばれるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36946,7 +37104,8 @@
     "question_text": {
       "en": "Who discovered radium together with Pierre Curie?",
       "ja": "ピエールキュリーと共にラジウムを発見したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36986,7 +37145,8 @@
     "question_text": {
       "en": "What law states pressure and volume are inversely related at constant temperature?",
       "ja": "一定温度で圧力と体積が反比例する法則は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37026,7 +37186,8 @@
     "question_text": {
       "en": "What law relates volume and temperature of a gas at constant pressure?",
       "ja": "一定圧力で気体の体積と温度を関係づける法則は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37048,7 +37209,7 @@
         "en": "Salinity",
         "ja": "塩分濃度",
         "ja_typings": [
-          "enbunnoudo"
+          "enbunnnoudo"
         ]
       },
       {
@@ -37066,7 +37227,8 @@
     "question_text": {
       "en": "What does pH measure?",
       "ja": "pHが測定するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37106,7 +37268,8 @@
     "question_text": {
       "en": "What is the hardest natural substance?",
       "ja": "天然で最も硬い物質は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37121,7 +37284,7 @@
         "en": "AB positive",
         "ja": "AB型プラス",
         "ja_typings": [
-          "abugatapurasu"
+          "abgatapurasu"
         ]
       },
       {
@@ -37135,7 +37298,7 @@
         "en": "B negative",
         "ja": "B型マイナス",
         "ja_typings": [
-          "bigatamainasu"
+          "bgatamainasu"
         ]
       }
     ],
@@ -37146,7 +37309,8 @@
     "question_text": {
       "en": "What blood type is the universal donor?",
       "ja": "万能供血者とされる血液型は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37186,7 +37350,8 @@
     "question_text": {
       "en": "Which organ produces insulin?",
       "ja": "インスリンを分泌する臓器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37226,7 +37391,8 @@
     "question_text": {
       "en": "Which bone is the longest in the human body?",
       "ja": "人体で最も長い骨は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37266,7 +37432,8 @@
     "question_text": {
       "en": "What is the speed unit named after a Scottish engineer?",
       "ja": "スコットランドの技術者にちなんだ仕事率の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37306,7 +37473,8 @@
     "question_text": {
       "en": "What rock type forms from cooled magma?",
       "ja": "マグマが冷えて固まってできる岩石は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37328,14 +37496,14 @@
         "en": "Beaufort scale",
         "ja": "ビューフォート風力階級",
         "ja_typings": [
-          "byu-fo-rtofuuryokukaikyuu"
+          "byu-fo-tofuuryokukaikyuu"
         ]
       },
       {
         "en": "Kelvin scale",
         "ja": "ケルビン温度",
         "ja_typings": [
-          "kerubinondo"
+          "kerubinnondo"
         ]
       }
     ],
@@ -37346,7 +37514,8 @@
     "question_text": {
       "en": "Which scale measures earthquake magnitude?",
       "ja": "地震のマグニチュードを表す尺度は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37386,7 +37555,8 @@
     "question_text": {
       "en": "Which Python framework is known as a microframework?",
       "ja": "Python のマイクロフレームワークと呼ばれるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37426,7 +37596,8 @@
     "question_text": {
       "en": "Which Python framework is async-first and based on type hints?",
       "ja": "型ヒントベースで非同期前提の Python フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37466,7 +37637,8 @@
     "question_text": {
       "en": "Which Python library is the de facto standard for numerical arrays?",
       "ja": "Python の数値配列の事実上の標準ライブラリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37506,7 +37678,8 @@
     "question_text": {
       "en": "Which Python library is the standard for DataFrames?",
       "ja": "Python のデータフレームの標準ライブラリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37546,7 +37719,8 @@
     "question_text": {
       "en": "Which Python deep learning framework was developed by Meta?",
       "ja": "Meta が開発した Python の深層学習フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37586,7 +37760,8 @@
     "question_text": {
       "en": "Which Python web framework is full-stack and batteries-included?",
       "ja": "フルスタックでバッテリー同梱型の Python Web フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37626,7 +37801,8 @@
     "question_text": {
       "en": "Which extremely fast Python package manager is written in Rust?",
       "ja": "Rust で書かれた高速な Python パッケージマネージャーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37666,7 +37842,8 @@
     "question_text": {
       "en": "Which Python tool combines a fast linter and formatter in Rust?",
       "ja": "Rust 製の高速な Python のリンター兼フォーマッターは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37706,7 +37883,8 @@
     "question_text": {
       "en": "Which Rust trait represents types that own a clone operation?",
       "ja": "複製操作を表す Rust のトレイトは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37746,7 +37924,8 @@
     "question_text": {
       "en": "Which Rust trait marks types that are bitwise-copyable?",
       "ja": "ビット単位でコピー可能な型を示す Rust のトレイトは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37786,7 +37965,8 @@
     "question_text": {
       "en": "Which Rust macro formats a string without printing it?",
       "ja": "出力せずに文字列を整形する Rust のマクロは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37826,7 +38006,8 @@
     "question_text": {
       "en": "Which Rust attribute auto-implements common traits?",
       "ja": "一般的なトレイトを自動実装する Rust の属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37866,7 +38047,8 @@
     "question_text": {
       "en": "Which Rust async runtime is most widely used?",
       "ja": "Rust で最も広く使われている非同期ランタイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37906,7 +38088,8 @@
     "question_text": {
       "en": "Which Rust web framework is built on top of tokio and hyper?",
       "ja": "tokio と hyper の上に構築された Rust の Web フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37946,7 +38129,8 @@
     "question_text": {
       "en": "Which JavaScript runtime was created by Ryan Dahl after Node.js?",
       "ja": "Ryan Dahl が Node.js の後に作った JavaScript ランタイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37986,7 +38170,8 @@
     "question_text": {
       "en": "Which JavaScript runtime is written in Zig and focuses on speed?",
       "ja": "Zig で書かれた高速志向の JavaScript ランタイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38026,7 +38211,8 @@
     "question_text": {
       "en": "Which company developed TypeScript?",
       "ja": "TypeScript を開発した企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38066,7 +38252,8 @@
     "question_text": {
       "en": "Which JavaScript bundler is known for zero-config and being extremely fast?",
       "ja": "ゼロ設定で高速な JavaScript バンドラーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38106,7 +38293,8 @@
     "question_text": {
       "en": "Which JavaScript dev server is built on top of esbuild and Rollup by Evan You?",
       "ja": "Evan You が作った esbuild と Rollup ベースの開発サーバーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38146,7 +38334,8 @@
     "question_text": {
       "en": "Which test runner ships with Jest-compatible API and is by Vite team?",
       "ja": "Vite チームの Jest 互換テストランナーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38186,7 +38375,8 @@
     "question_text": {
       "en": "Which functional language runs on the BEAM VM and is Erlang-based?",
       "ja": "BEAM 仮想マシン上で動く Erlang 系の関数型言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38226,7 +38416,8 @@
     "question_text": {
       "en": "Which JVM language emphasizes immutability and is a Lisp dialect?",
       "ja": "不変性重視で Lisp 方言の JVM 言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38266,7 +38457,8 @@
     "question_text": {
       "en": "Which language is the official language for Android development today?",
       "ja": "現在の Android 開発の公式言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38306,7 +38498,8 @@
     "question_text": {
       "en": "Which language powers the Flutter framework?",
       "ja": "Flutter フレームワークの言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38346,7 +38539,8 @@
     "question_text": {
       "en": "Which scripting language is embedded in many games and apps?",
       "ja": "ゲームやアプリに組み込まれることが多いスクリプト言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38386,7 +38580,8 @@
     "question_text": {
       "en": "Which statically typed functional language is from Microsoft Research?",
       "ja": "Microsoft Research 発の静的型付け関数型言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38426,7 +38621,8 @@
     "question_text": {
       "en": "Which language is the spiritual successor to Objective-C on Apple platforms?",
       "ja": "Apple プラットフォームでの Objective-C の後継言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38466,7 +38662,8 @@
     "question_text": {
       "en": "Which language was created at Mozilla for systems programming?",
       "ja": "Mozilla がシステムプログラミング向けに作った言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38506,7 +38703,8 @@
     "question_text": {
       "en": "Which language emphasizes manual memory management as a C replacement?",
       "ja": "C の代替を意識した手動メモリ管理重視の言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38546,7 +38744,8 @@
     "question_text": {
       "en": "Which sorting algorithm is stable and runs in O(n log n) worst case?",
       "ja": "最悪 O(n log n) で安定なソートアルゴリズムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38586,7 +38785,8 @@
     "question_text": {
       "en": "Which data structure is best suited for implementing priority queues?",
       "ja": "プライオリティキューに最適なデータ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38626,7 +38826,8 @@
     "question_text": {
       "en": "Which data structure provides efficient prefix string search?",
       "ja": "プレフィックス検索に効率的なデータ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38648,7 +38849,6 @@
         "en": "Post-order",
         "ja": "ポストオーダー",
         "ja_typings": [
-          "posuto-da-",
           "posutoo-da-"
         ]
       },
@@ -38667,7 +38867,8 @@
     "question_text": {
       "en": "Which traversal visits a binary tree in left-root-right order?",
       "ja": "二分木を左-根-右の順で巡回するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38707,7 +38908,8 @@
     "question_text": {
       "en": "Which algorithm finds shortest paths from all sources to all destinations?",
       "ja": "全頂点対の最短経路を求めるアルゴリズムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38722,7 +38924,7 @@
         "en": "Greedy",
         "ja": "貪欲法",
         "ja_typings": [
-          "donyokuhou"
+          "donnyokuhou"
         ]
       },
       {
@@ -38747,7 +38949,8 @@
     "question_text": {
       "en": "Which technique solves problems by combining solutions to subproblems?",
       "ja": "部分問題の解を結合して解くアルゴリズム技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38769,7 +38972,7 @@
         "en": "Procedural",
         "ja": "手続き型",
         "ja_typings": [
-          "tetsuzukigata"
+          "tetsudukigata"
         ]
       },
       {
@@ -38787,7 +38990,8 @@
     "question_text": {
       "en": "Which paradigm builds programs by composing pure functions?",
       "ja": "純粋関数の合成でプログラムを構成するパラダイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38827,7 +39031,8 @@
     "question_text": {
       "en": "Which container image format is the OCI industry standard?",
       "ja": "OCI 業界標準のコンテナイメージ形式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38867,7 +39072,8 @@
     "question_text": {
       "en": "Which command-line tool is the standard for HTTP transfers in scripts?",
       "ja": "スクリプトで HTTP 通信を行う標準的な CLI ツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38907,7 +39113,8 @@
     "question_text": {
       "en": "Which version control system is centralized rather than distributed?",
       "ja": "分散型ではなく集中型のバージョン管理システムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38947,7 +39154,8 @@
     "question_text": {
       "en": "Which CI service is built into GitHub itself?",
       "ja": "GitHub に組み込まれている CI サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38987,7 +39195,8 @@
     "question_text": {
       "en": "Which markup language is commonly used for README files on GitHub?",
       "ja": "GitHub の README で使われるマークアップは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39027,7 +39236,8 @@
     "question_text": {
       "en": "Which serialization format is line-oriented and key-value-like for configs?",
       "ja": "設定用のキーバリュー型シリアライズ形式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39067,7 +39277,8 @@
     "question_text": {
       "en": "Which data format is whitespace-significant and widely used in CI configs?",
       "ja": "インデントに意味があり CI 設定で多用されるデータ形式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39107,7 +39318,8 @@
     "question_text": {
       "en": "Who created the Pascal language and Turbo Pascal?",
       "ja": "Pascal と Turbo Pascal を作ったのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39147,7 +39359,8 @@
     "question_text": {
       "en": "Who is the lead architect of TypeScript and C#?",
       "ja": "TypeScript と C# の主任設計者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39187,7 +39400,8 @@
     "question_text": {
       "en": "Who designed the Java language?",
       "ja": "Java 言語を設計したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39227,7 +39441,8 @@
     "question_text": {
       "en": "Who is famous for The Art of Computer Programming and TeX?",
       "ja": "The Art of Computer Programming と TeX で有名な人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39267,7 +39482,8 @@
     "question_text": {
       "en": "Who is credited with creating Lisp?",
       "ja": "Lisp を生み出した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39307,7 +39523,8 @@
     "question_text": {
       "en": "Who is credited with creating Smalltalk and coining 'object-oriented'?",
       "ja": "Smalltalk を作りオブジェクト指向の語を定着させたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39347,7 +39564,8 @@
     "question_text": {
       "en": "What does ACID stand for in database transactions?",
       "ja": "データベースの ACID 特性のうち独立性を示すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39369,7 +39587,7 @@
         "en": "Procedural",
         "ja": "手続き型",
         "ja_typings": [
-          "tetsuzukigata"
+          "tetsudukigata"
         ]
       },
       {
@@ -39387,7 +39605,8 @@
     "question_text": {
       "en": "Which paradigm focuses on what to compute, not how?",
       "ja": "「何を計算するか」を記述するパラダイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39427,7 +39646,8 @@
     "question_text": {
       "en": "Which testing approach writes tests before implementation?",
       "ja": "実装前にテストを書く開発手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39467,7 +39687,8 @@
     "question_text": {
       "en": "Which HTML5 tag represents a self-contained article?",
       "ja": "自己完結した記事を表す HTML5 タグは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39507,7 +39728,8 @@
     "question_text": {
       "en": "Which HTML5 tag groups thematically related content?",
       "ja": "テーマで関連する内容をまとめる HTML5 タグは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39547,7 +39769,8 @@
     "question_text": {
       "en": "Which HTML5 tag represents tangentially related content like a sidebar?",
       "ja": "サイドバー等の補足的内容を表す HTML5 タグは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39587,7 +39810,8 @@
     "question_text": {
       "en": "Which HTML element is used to embed scalable vector graphics?",
       "ja": "ベクター画像を埋め込む HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39627,7 +39851,8 @@
     "question_text": {
       "en": "Which HTML element provides scriptable bitmap drawing?",
       "ja": "スクリプトでビットマップ描画できる HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39667,7 +39892,8 @@
     "question_text": {
       "en": "Which HTML attribute enables a drop-down list bound to an input?",
       "ja": "input に紐づく候補リストを実現する HTML 属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39707,7 +39933,8 @@
     "question_text": {
       "en": "Which HTML input type provides a native color picker?",
       "ja": "ネイティブのカラーピッカーを表示する input type は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39729,7 +39956,6 @@
         "en": "`:first-of-type`",
         "ja": "ファーストオブタイプ",
         "ja_typings": [
-          "fa-sutobutaipu",
           "fa-sutoobutaipu"
         ]
       },
@@ -39748,7 +39974,8 @@
     "question_text": {
       "en": "Which CSS pseudo-class targets the first child element?",
       "ja": "最初の子要素を選択する CSS 疑似クラスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39788,7 +40015,8 @@
     "question_text": {
       "en": "Which CSS unit is relative to the root font-size?",
       "ja": "ルートフォントサイズに対する CSS の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39828,7 +40056,8 @@
     "question_text": {
       "en": "Which CSS unit equals one percent of the viewport width?",
       "ja": "ビューポート幅の 1% を表す CSS の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39868,7 +40097,8 @@
     "question_text": {
       "en": "Which CSS property controls stacking order along the z-axis?",
       "ja": "Z 軸方向の重なり順を制御する CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39908,7 +40138,8 @@
     "question_text": {
       "en": "Which CSS function performs simple arithmetic with mixed units?",
       "ja": "異なる単位の四則演算を行う CSS 関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39948,7 +40179,8 @@
     "question_text": {
       "en": "Which CSS at-rule defines media-query-based styles?",
       "ja": "メディアクエリに基づくスタイルを定義する CSS の at-rule は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39988,7 +40220,8 @@
     "question_text": {
       "en": "Which CSS at-rule scopes styles by container queries?",
       "ja": "コンテナクエリでスタイルをスコープする at-rule は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40028,7 +40261,8 @@
     "question_text": {
       "en": "Which CSS property smoothly animates between value changes?",
       "ja": "値の変化を滑らかに補間する CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40068,7 +40302,8 @@
     "question_text": {
       "en": "Which CSS property applies blur, grayscale, and similar effects?",
       "ja": "ぼかしやグレースケール等の効果を適用する CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40108,7 +40343,8 @@
     "question_text": {
       "en": "Which method selects the first element matching a CSS selector?",
       "ja": "CSS セレクタに合う最初の要素を取得する DOM メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40148,7 +40384,8 @@
     "question_text": {
       "en": "Which DOM API replaces XMLHttpRequest in modern code?",
       "ja": "XMLHttpRequest に代わる現代の DOM API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40188,7 +40425,8 @@
     "question_text": {
       "en": "Which Web API observes elements crossing the viewport?",
       "ja": "ビューポート交差を監視する Web API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40228,7 +40466,8 @@
     "question_text": {
       "en": "Which Web API watches changes to the DOM tree?",
       "ja": "DOM ツリーの変化を監視する Web API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40268,7 +40507,8 @@
     "question_text": {
       "en": "Which Web API monitors element size changes?",
       "ja": "要素サイズの変化を監視する Web API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40308,7 +40548,8 @@
     "question_text": {
       "en": "Which JavaScript timer schedules a callback for the next animation frame?",
       "ja": "次の描画フレームでコールバックを呼ぶ JavaScript のタイマーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40348,7 +40589,8 @@
     "question_text": {
       "en": "Which JavaScript construct represents a one-time async value?",
       "ja": "1 回限りの非同期値を表す JavaScript の構文は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40388,7 +40630,8 @@
     "question_text": {
       "en": "Which HTTP status code indicates a temporary redirect?",
       "ja": "一時的リダイレクトを示す HTTP ステータスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40428,7 +40671,8 @@
     "question_text": {
       "en": "Which HTTP status code indicates the server is temporarily unavailable?",
       "ja": "サーバーが一時的に利用不能であることを示す HTTP ステータスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40468,7 +40712,8 @@
     "question_text": {
       "en": "Which HTTP status code indicates the request body exceeds the server limit?",
       "ja": "リクエストボディがサーバー制限を超えたことを示す HTTP ステータスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40508,7 +40753,8 @@
     "question_text": {
       "en": "Which HTTP status indicates the resource has not been modified?",
       "ja": "リソースが未更新であることを示す HTTP ステータスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40548,7 +40794,8 @@
     "question_text": {
       "en": "Which HTTP header sends authentication credentials with the request?",
       "ja": "リクエストに認証情報を載せる HTTP ヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40588,7 +40835,8 @@
     "question_text": {
       "en": "Which HTTP header indicates the format of the request body?",
       "ja": "リクエストボディの形式を示す HTTP ヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40628,7 +40876,8 @@
     "question_text": {
       "en": "Which HTTP header declares acceptable response media types?",
       "ja": "受け入れ可能なレスポンス形式を宣言する HTTP ヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40668,7 +40917,8 @@
     "question_text": {
       "en": "Which HTTP header is used by browsers to identify the client software?",
       "ja": "クライアントソフトを識別する HTTP ヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40708,7 +40958,8 @@
     "question_text": {
       "en": "Which attack manipulates database queries via unsanitized input?",
       "ja": "未検証の入力で DB クエリを改ざんする攻撃は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40748,7 +40999,8 @@
     "question_text": {
       "en": "Which attack reads files outside the intended directory?",
       "ja": "意図したディレクトリ外のファイルを読む攻撃は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40788,7 +41040,8 @@
     "question_text": {
       "en": "Which attack overlays an invisible UI to trick clicks?",
       "ja": "見えない UI を被せてクリックを誘う攻撃は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40828,7 +41081,8 @@
     "question_text": {
       "en": "Which HTTP header forbids embedding the page in a frame?",
       "ja": "ページをフレームに埋め込むことを禁じる HTTP ヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40868,7 +41122,8 @@
     "question_text": {
       "en": "Which HTTP header forces browsers to use HTTPS for a period?",
       "ja": "一定期間 HTTPS 強制を伝える HTTP ヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40908,7 +41163,8 @@
     "question_text": {
       "en": "Which state management library is most associated with React?",
       "ja": "React と最も結びつく状態管理ライブラリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40948,7 +41204,8 @@
     "question_text": {
       "en": "Which CSS-in-JS library popularized tagged template literals for styles?",
       "ja": "タグ付きテンプレートリテラルによる CSS-in-JS を広めたライブラリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -40988,7 +41245,8 @@
     "question_text": {
       "en": "Which framework introduced the Islands Architecture concept?",
       "ja": "アイランズアーキテクチャを広めたフレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41028,7 +41286,8 @@
     "question_text": {
       "en": "Which fine-grained reactive framework was created by Ryan Carniato?",
       "ja": "Ryan Carniato による細粒度リアクティブなフレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41068,7 +41327,8 @@
     "question_text": {
       "en": "Which framework focuses on resumability instead of hydration?",
       "ja": "ハイドレーションではなく resumability を志向するフレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41097,7 +41357,6 @@
         "en": "Redwood",
         "ja": "レッドウッド",
         "ja_typings": [
-          "reddoddo",
           "reddouddo"
         ]
       }
@@ -41109,7 +41368,8 @@
     "question_text": {
       "en": "Which React framework focuses on web fundamentals and is by Shopify now?",
       "ja": "Web 基礎重視で現在は Shopify が運用する React フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41149,7 +41409,8 @@
     "question_text": {
       "en": "Which standards body publishes HTML specifications today?",
       "ja": "現在 HTML 仕様を発行している標準化団体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41189,7 +41450,8 @@
     "question_text": {
       "en": "Which group standardizes JavaScript (ECMAScript)?",
       "ja": "JavaScript すなわち ECMAScript を標準化する団体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41229,7 +41491,8 @@
     "question_text": {
       "en": "Which rendering engine powers Safari and WebKit-based browsers?",
       "ja": "Safari や WebKit 系ブラウザのレンダリングエンジンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41269,7 +41532,8 @@
     "question_text": {
       "en": "Which rendering engine powers Firefox?",
       "ja": "Firefox のレンダリングエンジンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41309,7 +41573,8 @@
     "question_text": {
       "en": "Which engine powers Chrome and modern Edge?",
       "ja": "Chrome と現行 Edge のエンジンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41349,7 +41614,8 @@
     "question_text": {
       "en": "Which technology lets browsers run near-native compiled code?",
       "ja": "ブラウザでネイティブ近い速度のコンパイル済みコードを動かす技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41389,7 +41655,8 @@
     "question_text": {
       "en": "Which file makes a website installable as a PWA?",
       "ja": "サイトを PWA としてインストール可能にするファイルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41429,7 +41696,8 @@
     "question_text": {
       "en": "Which file directs crawlers about allowed and disallowed paths?",
       "ja": "クローラーに巡回可否を伝えるファイルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41469,7 +41737,8 @@
     "question_text": {
       "en": "Which file lists URLs for search engines to index?",
       "ja": "検索エンジンが巡回すべき URL を列挙するファイルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41509,7 +41778,8 @@
     "question_text": {
       "en": "Which standard defines real-time peer-to-peer media in browsers?",
       "ja": "ブラウザのリアルタイム P2P メディア通信を定める標準は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41549,7 +41819,8 @@
     "question_text": {
       "en": "Which mechanism pushes server-sent events over a long-lived HTTP response?",
       "ja": "長時間 HTTP 応答上でサーバー発のイベントを配信する仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41557,7 +41828,6 @@
         "en": "1024",
         "ja": "センニジュウヨン",
         "ja_typings": [
-          "sennijuuyon",
           "sennnijuuyon"
         ]
       },
@@ -41572,7 +41842,6 @@
         "en": "2048",
         "ja": "ニセンヨンジュウハチ",
         "ja_typings": [
-          "nisenyonjuuhachi",
           "nisennyonjuuhachi"
         ]
       },
@@ -41591,7 +41860,8 @@
     "question_text": {
       "en": "What is 2 to the power of 10?",
       "ja": "2の10乗はいくつ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41631,7 +41901,8 @@
     "question_text": {
       "en": "What is the square root of 144?",
       "ja": "144の平方根はいくつ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41671,7 +41942,8 @@
     "question_text": {
       "en": "What is the factorial of 5?",
       "ja": "5の階乗はいくつ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41711,7 +41983,8 @@
     "question_text": {
       "en": "What is the value of e to one decimal place?",
       "ja": "ネイピア数を小数点以下1桁で表すと?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41751,7 +42024,8 @@
     "question_text": {
       "en": "Which is a prime number?",
       "ja": "次のうち素数はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41759,7 +42033,6 @@
         "en": "pi r squared",
         "ja": "パイアールジジョウ",
         "ja_typings": [
-          "paia-rujijo",
           "paia-rujijou"
         ]
       },
@@ -41781,7 +42054,6 @@
         "en": "four pi r squared",
         "ja": "ヨンパイアールジジョウ",
         "ja_typings": [
-          "yonpaia-rujijo",
           "yonpaia-rujijou"
         ]
       }
@@ -41793,7 +42065,8 @@
     "question_text": {
       "en": "What is the area formula for a circle?",
       "ja": "円の面積を求める公式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41833,7 +42106,8 @@
     "question_text": {
       "en": "What is the sum of angles in a quadrilateral?",
       "ja": "四角形の内角の和は何度?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41873,7 +42147,8 @@
     "question_text": {
       "en": "What is 7 times 8?",
       "ja": "7かける8はいくつ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41881,7 +42156,6 @@
         "en": "1/6",
         "ja": "ロクブンノイチ",
         "ja_typings": [
-          "rokubunnoichi",
           "rokubunnnoichi"
         ]
       },
@@ -41889,7 +42163,6 @@
         "en": "1/3",
         "ja": "サンブンノイチ",
         "ja_typings": [
-          "sanbunnoichi",
           "sanbunnnoichi"
         ]
       },
@@ -41897,7 +42170,6 @@
         "en": "1/2",
         "ja": "ニブンノイチ",
         "ja_typings": [
-          "nibunnoichi",
           "nibunnnoichi"
         ]
       },
@@ -41905,7 +42177,6 @@
         "en": "1/12",
         "ja": "ジュウニブンノイチ",
         "ja_typings": [
-          "juunibunnoichi",
           "juunibunnnoichi"
         ]
       }
@@ -41917,7 +42188,8 @@
     "question_text": {
       "en": "What is the probability of rolling a 6 on a fair die?",
       "ja": "サイコロで6が出る確率は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41957,7 +42229,8 @@
     "question_text": {
       "en": "What is the next number: 2, 4, 8, 16, ?",
       "ja": "次の数列の次は: 2, 4, 8, 16, ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -41997,7 +42270,8 @@
     "question_text": {
       "en": "What is the mean of 2, 4, 6, 8, 10?",
       "ja": "2, 4, 6, 8, 10の平均は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42005,7 +42279,6 @@
         "en": "middle value",
         "ja": "マンナカノアタイ",
         "ja_typings": [
-          "mannakanoatai",
           "mannnakanoatai"
         ]
       },
@@ -42027,8 +42300,7 @@
         "en": "total sum",
         "ja": "ゴウケイ",
         "ja_typings": [
-          "goukei",
-          "gokei"
+          "goukei"
         ]
       }
     ],
@@ -42039,7 +42311,8 @@
     "question_text": {
       "en": "What does the median represent?",
       "ja": "中央値とは何か?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42047,8 +42320,7 @@
         "en": "cube",
         "ja": "リッポウタイ",
         "ja_typings": [
-          "rippoutai",
-          "rippotai"
+          "rippoutai"
         ]
       },
       {
@@ -42080,7 +42352,8 @@
     "question_text": {
       "en": "What shape has 6 faces?",
       "ja": "面が6つある立体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42120,7 +42393,8 @@
     "question_text": {
       "en": "How many edges does a cube have?",
       "ja": "立方体の辺の数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42149,8 +42423,7 @@
         "en": "squared sum",
         "ja": "ジジョウワ",
         "ja_typings": [
-          "jijouwa",
-          "jijowa"
+          "jijouwa"
         ]
       }
     ],
@@ -42161,7 +42434,8 @@
     "question_text": {
       "en": "What is the slope formula?",
       "ja": "傾きを求める公式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42201,7 +42475,8 @@
     "question_text": {
       "en": "What is the value of log base 10 of 1000?",
       "ja": "10を底とする1000の対数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42241,7 +42516,8 @@
     "question_text": {
       "en": "What is 15 percent of 200?",
       "ja": "200の15パーセントはいくつ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42281,7 +42557,8 @@
     "question_text": {
       "en": "What is the diagonal of a unit square?",
       "ja": "1辺1の正方形の対角線の長さは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42321,7 +42598,8 @@
     "question_text": {
       "en": "What is the binary representation of 5?",
       "ja": "10進数の5を2進数で表すと?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42329,7 +42607,6 @@
         "en": "1/2",
         "ja": "ニブンノイチ",
         "ja_typings": [
-          "nibunnoichi",
           "nibunnnoichi"
         ]
       },
@@ -42337,7 +42614,6 @@
         "en": "root 3 over 2",
         "ja": "ルートサンブンノニ",
         "ja_typings": [
-          "ru-tosanbunnoni",
           "ru-tosanbunnnoni"
         ]
       },
@@ -42345,7 +42621,6 @@
         "en": "root 2 over 2",
         "ja": "ルートニブンノニ",
         "ja_typings": [
-          "ru-tonibunnoni",
           "ru-tonibunnnoni"
         ]
       },
@@ -42364,7 +42639,8 @@
     "question_text": {
       "en": "What is sin of 30 degrees?",
       "ja": "サイン30度の値は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42386,8 +42662,7 @@
         "en": "x cubed",
         "ja": "エックスサンジョウ",
         "ja_typings": [
-          "ekkususanjou",
-          "ekkususanjo"
+          "ekkususanjou"
         ]
       },
       {
@@ -42405,7 +42680,8 @@
     "question_text": {
       "en": "What is the derivative of x squared?",
       "ja": "xの2乗の微分は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42420,16 +42696,14 @@
         "en": "x squared",
         "ja": "エックスニジョウ",
         "ja_typings": [
-          "ekkusunijou",
-          "ekkusunijo"
+          "ekkusunijou"
         ]
       },
       {
         "en": "e to the x",
         "ja": "イーノエックスジョウ",
         "ja_typings": [
-          "i-noekkusujou",
-          "i-noekkusujo"
+          "i-noekkusujou"
         ]
       },
       {
@@ -42447,7 +42721,8 @@
     "question_text": {
       "en": "What is the integral of 1 over x?",
       "ja": "xぶんの1の積分は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42487,7 +42762,8 @@
     "question_text": {
       "en": "What is 10 squared minus 9 squared?",
       "ja": "10の2乗ひく9の2乗は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42527,7 +42803,8 @@
     "question_text": {
       "en": "What is the smallest perfect number?",
       "ja": "最小の完全数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42567,7 +42844,8 @@
     "question_text": {
       "en": "What does ATM stand for?",
       "ja": "ATMは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42607,7 +42885,8 @@
     "question_text": {
       "en": "How many bones are in the adult human body?",
       "ja": "成人の人間の骨の数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42615,24 +42894,20 @@
         "en": "3600 seconds",
         "ja": "サンゼンロッピャクビョウ",
         "ja_typings": [
-          "sanzenroppyakubyou",
-          "sanzenroppyakubyo"
+          "sanzenroppyakubyou"
         ]
       },
       {
         "en": "60 seconds",
         "ja": "ロクジュウビョウ",
         "ja_typings": [
-          "rokujuubyou",
-          "rokujuubyo"
+          "rokujuubyou"
         ]
       },
       {
         "en": "7200 seconds",
         "ja": "ナナセンニヒャクビョウ",
         "ja_typings": [
-          "nanasennihyakubyou",
-          "nanasennnihyakubyo",
           "nanasennnihyakubyou"
         ]
       },
@@ -42640,8 +42915,7 @@
         "en": "1800 seconds",
         "ja": "センハッピャクビョウ",
         "ja_typings": [
-          "senhappyakubyou",
-          "senhappyakubyo"
+          "senhappyakubyou"
         ]
       }
     ],
@@ -42652,7 +42926,8 @@
     "question_text": {
       "en": "How many seconds are in an hour?",
       "ja": "1時間は何秒?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42660,32 +42935,28 @@
         "en": "300000 km per second",
         "ja": "サンジュウマンキロメートルマイビョウ",
         "ja_typings": [
-          "sanjuumankirome-torumaibyou",
-          "sanjuumankirome-torumaibyo"
+          "sanjuumankirome-torumaibyou"
         ]
       },
       {
         "en": "30000 km per second",
         "ja": "サンマンキロメートルマイビョウ",
         "ja_typings": [
-          "sanmankirome-torumaibyou",
-          "sanmankirome-torumaibyo"
+          "sanmankirome-torumaibyou"
         ]
       },
       {
         "en": "3 million km per second",
         "ja": "サンビャクマンキロメートルマイビョウ",
         "ja_typings": [
-          "sanbyakumankirome-torumaibyou",
-          "sanbyakumankirome-torumaibyo"
+          "sanbyakumankirome-torumaibyou"
         ]
       },
       {
         "en": "3000 km per second",
         "ja": "サンゼンキロメートルマイビョウ",
         "ja_typings": [
-          "sanzenkirome-torumaibyou",
-          "sanzenkirome-torumaibyo"
+          "sanzenkirome-torumaibyou"
         ]
       }
     ],
@@ -42696,7 +42967,8 @@
     "question_text": {
       "en": "What is the speed of light approximately?",
       "ja": "光の速さはおよそ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42736,7 +43008,8 @@
     "question_text": {
       "en": "What does CEO stand for?",
       "ja": "CEOは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42776,7 +43049,8 @@
     "question_text": {
       "en": "How many planets are in our solar system?",
       "ja": "太陽系の惑星の数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42784,24 +43058,21 @@
         "en": "Pacific Ocean",
         "ja": "タイヘイヨウ",
         "ja_typings": [
-          "taiheiyou",
-          "taiheiyo"
+          "taiheiyou"
         ]
       },
       {
         "en": "Atlantic Ocean",
         "ja": "タイセイヨウ",
         "ja_typings": [
-          "taiseiyou",
-          "taiseiyo"
+          "taiseiyou"
         ]
       },
       {
         "en": "Indian Ocean",
         "ja": "インドヨウ",
         "ja_typings": [
-          "indoyou",
-          "indoyo"
+          "indoyou"
         ]
       },
       {
@@ -42819,7 +43090,8 @@
     "question_text": {
       "en": "What is the largest ocean?",
       "ja": "世界最大の海は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42859,7 +43131,8 @@
     "question_text": {
       "en": "What is the tallest mountain in the world?",
       "ja": "世界一高い山は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42899,7 +43172,8 @@
     "question_text": {
       "en": "Which country has the longest coastline?",
       "ja": "海岸線が世界一長い国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42939,7 +43213,8 @@
     "question_text": {
       "en": "What does GPS stand for?",
       "ja": "GPSは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -42979,7 +43254,8 @@
     "question_text": {
       "en": "What is the origin of the word robot?",
       "ja": "ロボットの語源となった言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43019,7 +43295,8 @@
     "question_text": {
       "en": "What unit measures pressure?",
       "ja": "圧力の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43059,7 +43336,8 @@
     "question_text": {
       "en": "How many strings does a standard guitar have?",
       "ja": "標準的なギターの弦の数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43067,8 +43345,7 @@
         "en": "distress signal",
         "ja": "ソウナンシンゴウ",
         "ja_typings": [
-          "sounanshingou",
-          "sonanshingo"
+          "sounanshingou"
         ]
       },
       {
@@ -43089,7 +43366,6 @@
         "en": "standard order set",
         "ja": "スタンダードオーダーセット",
         "ja_typings": [
-          "sutanda-do-da-setto-",
           "sutanda-doo-da-setto"
         ]
       }
@@ -43101,7 +43377,8 @@
     "question_text": {
       "en": "What does SOS represent?",
       "ja": "SOSは何を表すか?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43141,7 +43418,8 @@
     "question_text": {
       "en": "What does VIP stand for?",
       "ja": "VIPは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43181,7 +43459,8 @@
     "question_text": {
       "en": "How many continents are there?",
       "ja": "大陸はいくつある?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43221,7 +43500,8 @@
     "question_text": {
       "en": "What is the smallest country in the world?",
       "ja": "世界で一番小さい国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43261,7 +43541,8 @@
     "question_text": {
       "en": "What does PDF stand for?",
       "ja": "PDFは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43301,7 +43582,8 @@
     "question_text": {
       "en": "What is the boiling point of water at sea level?",
       "ja": "海面における水の沸点は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43341,7 +43623,8 @@
     "question_text": {
       "en": "How many colors are in a rainbow?",
       "ja": "虹の色の数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43381,7 +43664,8 @@
     "question_text": {
       "en": "What does GG mean in gaming?",
       "ja": "ゲームで使われるGGの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43421,7 +43705,8 @@
     "question_text": {
       "en": "What does AFK stand for?",
       "ja": "AFKは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43461,7 +43746,8 @@
     "question_text": {
       "en": "What does the slang 'kusa' mean?",
       "ja": "ネットスラング草の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43501,7 +43787,8 @@
     "question_text": {
       "en": "What is a VTuber's avatar called?",
       "ja": "VTuberが使うアバターの呼び方は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43509,16 +43796,14 @@
         "en": "paid comment",
         "ja": "ユウリョウコメント",
         "ja_typings": [
-          "yuuryoukomento",
-          "yuuryokomento"
+          "yuuryoukomento"
         ]
       },
       {
         "en": "free comment",
         "ja": "ムリョウコメント",
         "ja_typings": [
-          "muryoukomento",
-          "muryokomento"
+          "muryoukomento"
         ]
       },
       {
@@ -43543,7 +43828,8 @@
     "question_text": {
       "en": "What does superchat mean on YouTube?",
       "ja": "YouTubeのスパチャの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43583,7 +43869,8 @@
     "question_text": {
       "en": "What does GLHF mean?",
       "ja": "GLHFの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43598,8 +43885,7 @@
         "en": "expert",
         "ja": "ジョウキュウシャ",
         "ja_typings": [
-          "joukyuusha",
-          "jokyuusha"
+          "joukyuusha"
         ]
       },
       {
@@ -43624,7 +43910,8 @@
     "question_text": {
       "en": "What is a 'noob' in gaming?",
       "ja": "ゲームでnoobの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43664,7 +43951,8 @@
     "question_text": {
       "en": "What does 'tryhard' refer to?",
       "ja": "tryhardが指す意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43672,8 +43960,7 @@
         "en": "excitement",
         "ja": "コウフン",
         "ja_typings": [
-          "koufun",
-          "kofun"
+          "koufun"
         ]
       },
       {
@@ -43694,8 +43981,7 @@
         "en": "regret",
         "ja": "コウカイ",
         "ja_typings": [
-          "koukai",
-          "kokai"
+          "koukai"
         ]
       }
     ],
@@ -43706,7 +43992,8 @@
     "question_text": {
       "en": "What is the meaning of 'pog'?",
       "ja": "pogの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43714,8 +44001,7 @@
         "en": "most effective tactic",
         "ja": "サイコウセンリャク",
         "ja_typings": [
-          "saikousenryaku",
-          "saikosenryaku"
+          "saikousenryaku"
         ]
       },
       {
@@ -43747,7 +44033,8 @@
     "question_text": {
       "en": "What does 'meta' mean in games?",
       "ja": "ゲーム用語のメタの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43787,7 +44074,8 @@
     "question_text": {
       "en": "What is the origin of meme?",
       "ja": "ミームの語源は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43795,8 +44083,7 @@
         "en": "low quality post",
         "ja": "ヒンシツノヒクイトウコウ",
         "ja_typings": [
-          "hinshitsunohikuitoukou",
-          "hinshitsunohikuitoko"
+          "hinshitsunohikuitoukou"
         ]
       },
       {
@@ -43810,16 +44097,14 @@
         "en": "paid sponsorship",
         "ja": "ユウリョウスポンサー",
         "ja_typings": [
-          "yuuryousuponsa-",
-          "yuuryosuponsa-"
+          "yuuryousuponsa-"
         ]
       },
       {
         "en": "legal notice",
         "ja": "ホウテキツウチ",
         "ja_typings": [
-          "houtekitsuuchi",
-          "hotekitsuuchi"
+          "houtekitsuuchi"
         ]
       }
     ],
@@ -43830,7 +44115,8 @@
     "question_text": {
       "en": "What is shitposting?",
       "ja": "シットポストとは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43838,8 +44124,7 @@
         "en": "silent viewer",
         "ja": "ムゲンシチョウシャ",
         "ja_typings": [
-          "mugenshichousha",
-          "mugenshichosha"
+          "mugenshichousha"
         ]
       },
       {
@@ -43853,16 +44138,14 @@
         "en": "paid member",
         "ja": "ユウリョウメンバー",
         "ja_typings": [
-          "yuuryoumenba-",
-          "yuuryomenba-"
+          "yuuryoumenba-"
         ]
       },
       {
         "en": "auto bot",
         "ja": "ジドウボット",
         "ja_typings": [
-          "jidoubotto",
-          "jidobotto"
+          "jidoubotto"
         ]
       }
     ],
@@ -43873,7 +44156,8 @@
     "question_text": {
       "en": "What does 'lurker' mean in livestreams?",
       "ja": "配信用語のlurkerの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43881,16 +44165,14 @@
         "en": "leaking personal info",
         "ja": "コジンジョウホウバクロ",
         "ja_typings": [
-          "kojinjouhoubakuro",
-          "kojinjohobakuro"
+          "kojinjouhoubakuro"
         ]
       },
       {
         "en": "sharing memes",
         "ja": "ミームキョウユウ",
         "ja_typings": [
-          "mi-mukyouyuu",
-          "mi-mukyoyuu"
+          "mi-mukyouyuu"
         ]
       },
       {
@@ -43904,8 +44186,7 @@
         "en": "posting reviews",
         "ja": "レビュートウコウ",
         "ja_typings": [
-          "rebyu-toukou",
-          "rebyu-toko"
+          "rebyu-toukou"
         ]
       }
     ],
@@ -43916,7 +44197,8 @@
     "question_text": {
       "en": "What is meant by 'doxxing'?",
       "ja": "ドキシングの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43956,7 +44238,8 @@
     "question_text": {
       "en": "What does FPS stand for in gaming?",
       "ja": "ゲーム用語のFPSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -43964,8 +44247,7 @@
         "en": "clearing a game as fast as possible",
         "ja": "ゲームサイソクコウリャク",
         "ja_typings": [
-          "ge-musaisokukouryaku",
-          "ge-musaisokukoryaku"
+          "ge-musaisokukouryaku"
         ]
       },
       {
@@ -43997,7 +44279,8 @@
     "question_text": {
       "en": "What is a 'speedrun'?",
       "ja": "スピードランとは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44005,8 +44288,6 @@
         "en": "sending viewers to another channel",
         "ja": "ベツチャンネルニシチョウシャヲオクル",
         "ja_typings": [
-          "betsuchannnerunishichoushawookuru",
-          "betsuchannnerunishichoshaokuru",
           "betsuchannnerunishichoushaookuru"
         ]
       },
@@ -44014,8 +44295,7 @@
         "en": "hacking attack",
         "ja": "ハッキングコウゲキ",
         "ja_typings": [
-          "hakkingukougeki",
-          "hakkingukogeki"
+          "hakkingukougeki"
         ]
       },
       {
@@ -44040,7 +44320,8 @@
     "question_text": {
       "en": "What is the meaning of 'raid' on streaming sites?",
       "ja": "配信サイトのレイドの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44069,8 +44350,7 @@
         "en": "ad song",
         "ja": "コウコクキョク",
         "ja_typings": [
-          "koukokukyoku",
-          "kokokukyoku"
+          "koukokukyoku"
         ]
       }
     ],
@@ -44081,7 +44361,8 @@
     "question_text": {
       "en": "What is a 'banger' track?",
       "ja": "bangerトラックの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44121,7 +44402,8 @@
     "question_text": {
       "en": "What is the meaning of 'salt' in gaming?",
       "ja": "ゲームのsaltの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44143,16 +44425,14 @@
         "en": "calm goodbye",
         "ja": "オダヤカナサヨウナラ",
         "ja_typings": [
-          "odayakanasayounara",
-          "odayakanasayonara"
+          "odayakanasayounara"
         ]
       },
       {
         "en": "auto save",
         "ja": "ジドウホゾン",
         "ja_typings": [
-          "jidouhozon",
-          "jidohozon"
+          "jidouhozon"
         ]
       }
     ],
@@ -44163,7 +44443,8 @@
     "question_text": {
       "en": "What is the meaning of 'rage quit'?",
       "ja": "rage quitの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44203,7 +44484,8 @@
     "question_text": {
       "en": "What does PvP mean?",
       "ja": "PvPの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44211,8 +44493,7 @@
         "en": "embarrassment",
         "ja": "キョウシュク",
         "ja_typings": [
-          "kyoushuku",
-          "kyoshuku"
+          "kyoushuku"
         ]
       },
       {
@@ -44244,7 +44525,8 @@
     "question_text": {
       "en": "What does 'cringe' describe?",
       "ja": "cringeが表す感情は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44252,16 +44534,14 @@
         "en": "indecent content",
         "ja": "セイテキナナイヨウ",
         "ja_typings": [
-          "seitekinanaiyou",
-          "seitekinanaiyo"
+          "seitekinanaiyou"
         ]
       },
       {
         "en": "educational topic",
         "ja": "キョウイクテーマ",
         "ja_typings": [
-          "kyouikute-ma",
-          "kyoikute-ma"
+          "kyouikute-ma"
         ]
       },
       {
@@ -44286,7 +44566,8 @@
     "question_text": {
       "en": "What does 'lewd' refer to?",
       "ja": "lewdの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44294,32 +44575,28 @@
         "en": "very funny",
         "ja": "オオワライ",
         "ja_typings": [
-          "oowarai",
-          "owarai"
+          "oowarai"
         ]
       },
       {
         "en": "very sad",
         "ja": "オオナキ",
         "ja_typings": [
-          "oonaki",
-          "onaki"
+          "oonaki"
         ]
       },
       {
         "en": "very angry",
         "ja": "オオイカリ",
         "ja_typings": [
-          "ooikari",
-          "oikari"
+          "ooikari"
         ]
       },
       {
         "en": "very scared",
         "ja": "オオオビエ",
         "ja_typings": [
-          "ooobie",
-          "oobie"
+          "ooobie"
         ]
       }
     ],
@@ -44330,7 +44607,8 @@
     "question_text": {
       "en": "What is the meaning of '草生える'?",
       "ja": "草生えるの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44338,32 +44616,28 @@
         "en": "clip video",
         "ja": "クリップドウガ",
         "ja_typings": [
-          "kurippudouga",
-          "kurippudoga"
+          "kurippudouga"
         ]
       },
       {
         "en": "trim video",
         "ja": "トリムドウガ",
         "ja_typings": [
-          "torimudouga",
-          "torimudoga"
+          "torimudouga"
         ]
       },
       {
         "en": "snippet video",
         "ja": "スニペットドウガ",
         "ja_typings": [
-          "sunipettodouga",
-          "sunipettodoga"
+          "sunipettodouga"
         ]
       },
       {
         "en": "flash video",
         "ja": "フラッシュドウガ",
         "ja_typings": [
-          "furasshudouga",
-          "furasshudoga"
+          "furasshudouga"
         ]
       }
     ],
@@ -44374,7 +44648,8 @@
     "question_text": {
       "en": "What is the term for a clipped highlight?",
       "ja": "切り抜き動画の英語呼称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44414,7 +44689,8 @@
     "question_text": {
       "en": "What does CPU stand for?",
       "ja": "CPUは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44454,7 +44730,8 @@
     "question_text": {
       "en": "What does RAM stand for?",
       "ja": "RAMは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44494,7 +44771,8 @@
     "question_text": {
       "en": "What port does SSH typically use?",
       "ja": "SSHが通常使うポート番号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44534,7 +44812,8 @@
     "question_text": {
       "en": "What does SSD stand for?",
       "ja": "SSDは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44574,7 +44853,8 @@
     "question_text": {
       "en": "What does API stand for?",
       "ja": "APIは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44582,7 +44862,6 @@
         "en": "443",
         "ja": "ヨンヨンサン",
         "ja_typings": [
-          "yonyonsan",
           "yonnyonsan"
         ]
       },
@@ -44615,7 +44894,8 @@
     "question_text": {
       "en": "What is the default port for HTTPS?",
       "ja": "HTTPSのデフォルトポート番号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44655,7 +44935,8 @@
     "question_text": {
       "en": "What does USB stand for?",
       "ja": "USBは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44695,7 +44976,8 @@
     "question_text": {
       "en": "What is IPv4 address length in bits?",
       "ja": "IPv4アドレスのビット長は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44735,7 +45017,8 @@
     "question_text": {
       "en": "What does AWS stand for?",
       "ja": "AWSは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44775,7 +45058,8 @@
     "question_text": {
       "en": "What does GPU stand for?",
       "ja": "GPUは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44815,7 +45099,8 @@
     "question_text": {
       "en": "What is the base of hexadecimal?",
       "ja": "16進数の基数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44855,7 +45140,8 @@
     "question_text": {
       "en": "What does HTML stand for?",
       "ja": "HTMLは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44895,7 +45181,8 @@
     "question_text": {
       "en": "What is the size of a standard MAC address in bits?",
       "ja": "MACアドレスのビット長は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44935,7 +45222,8 @@
     "question_text": {
       "en": "What is the default port for FTP?",
       "ja": "FTPのデフォルトポート番号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -44975,7 +45263,8 @@
     "question_text": {
       "en": "What does VPN stand for?",
       "ja": "VPNは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45015,7 +45304,8 @@
     "question_text": {
       "en": "What does CSS stand for?",
       "ja": "CSSは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45055,7 +45345,8 @@
     "question_text": {
       "en": "What protocol is used to send email?",
       "ja": "電子メール送信に使うプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45063,7 +45354,6 @@
         "en": "1024 bytes",
         "ja": "センニジュウヨンバイト",
         "ja_typings": [
-          "sennijuuyonbaito",
           "sennnijuuyonbaito"
         ]
       },
@@ -45085,7 +45375,6 @@
         "en": "2048 bytes",
         "ja": "ニセンヨンジュウハチバイト",
         "ja_typings": [
-          "nisenyonjuuhachibaito",
           "nisennyonjuuhachibaito"
         ]
       }
@@ -45097,7 +45386,8 @@
     "question_text": {
       "en": "What is a kilobyte equal to?",
       "ja": "1キロバイトは何バイト?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45137,7 +45427,8 @@
     "question_text": {
       "en": "What does SQL stand for?",
       "ja": "SQLは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45177,7 +45468,8 @@
     "question_text": {
       "en": "What is the default port for SMTP?",
       "ja": "SMTPのデフォルトポート番号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45217,7 +45509,8 @@
     "question_text": {
       "en": "What does the acronym RGB represent?",
       "ja": "RGBは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45257,7 +45550,8 @@
     "question_text": {
       "en": "What is the smallest unit of digital information?",
       "ja": "デジタル情報の最小単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45297,7 +45591,8 @@
     "question_text": {
       "en": "What is the binary value of decimal 10?",
       "ja": "10進数10の2進数表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45337,7 +45632,8 @@
     "question_text": {
       "en": "What does RAID stand for in storage?",
       "ja": "ストレージのRAIDは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45377,7 +45673,8 @@
     "question_text": {
       "en": "Which anime features a high school detective shrunk into a child?",
       "ja": "高校生探偵が子供の姿にされるアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45417,7 +45714,8 @@
     "question_text": {
       "en": "Which anime is set in a virtual MMORPG where players are trapped?",
       "ja": "仮想MMORPGに閉じ込められるアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45457,7 +45755,8 @@
     "question_text": {
       "en": "Which anime features a boy aiming to be Hokage?",
       "ja": "火影を目指す少年のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45497,7 +45796,8 @@
     "question_text": {
       "en": "Which anime studio produced 'Your Name'?",
       "ja": "『君の名は。』を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45537,7 +45837,8 @@
     "question_text": {
       "en": "Who directed 'Princess Mononoke'?",
       "ja": "『もののけ姫』の監督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45545,7 +45846,6 @@
         "en": "Soul Eater",
         "ja": "ソウルイーター",
         "ja_typings": [
-          "sorui-ta-",
           "sourui-ta-"
         ]
       },
@@ -45578,7 +45878,8 @@
     "question_text": {
       "en": "Which anime is about a girl who becomes a Soul Reaper?",
       "ja": "死神になる少女が登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45618,7 +45919,8 @@
     "question_text": {
       "en": "Which anime studio made 'Attack on Titan' final seasons?",
       "ja": "『進撃の巨人』最終章を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45658,7 +45960,8 @@
     "question_text": {
       "en": "Which anime features alchemists searching for the Philosopher's Stone?",
       "ja": "賢者の石を探す錬金術師のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45680,7 +45983,6 @@
         "en": "Ace of Diamond",
         "ja": "ダイヤのA",
         "ja_typings": [
-          "daiyanoeesu",
           "daiyanoa"
         ]
       },
@@ -45699,7 +46001,8 @@
     "question_text": {
       "en": "Which anime is about volleyball at Karasuno High?",
       "ja": "烏野高校のバレーボールのアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45739,7 +46042,8 @@
     "question_text": {
       "en": "Which anime is set in the fictional city of Ikebukuro with gang wars?",
       "ja": "池袋を舞台にした抗争アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45779,7 +46083,8 @@
     "question_text": {
       "en": "Which anime features the school idol group μ's?",
       "ja": "μ'sが登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45787,7 +46092,7 @@
         "en": "Rurouni Kenshin",
         "ja": "るろうに剣心",
         "ja_typings": [
-          "rurouninikenshin"
+          "rurounikenshin"
         ]
       },
       {
@@ -45819,7 +46124,8 @@
     "question_text": {
       "en": "Which anime is about a samurai who wanders Meiji-era Japan?",
       "ja": "明治時代を流浪する侍のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45859,7 +46165,8 @@
     "question_text": {
       "en": "Which director made 'Weathering with You'?",
       "ja": "『天気の子』の監督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45900,7 +46207,8 @@
     "question_text": {
       "en": "Which anime features four siblings playing card games?",
       "ja": "カードゲームをする四姉妹のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45940,7 +46248,8 @@
     "question_text": {
       "en": "Which anime features Spike Spiegel as a bounty hunter?",
       "ja": "スパイク・スピーゲルが賞金稼ぎとして登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45980,7 +46289,8 @@
     "question_text": {
       "en": "Who voices Goku in the Japanese dub of Dragon Ball?",
       "ja": "ドラゴンボールの孫悟空の日本語声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46020,7 +46330,8 @@
     "question_text": {
       "en": "Which anime is about a girl who befriends a fox spirit?",
       "ja": "狐の妖怪と仲良くなる少女のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46035,7 +46346,7 @@
         "en": "Eureka Seven",
         "ja": "交響詩篇エウレカセブン",
         "ja_typings": [
-          "koukyoushiheneurekasebun"
+          "koukyoushihenneurekasebun"
         ]
       },
       {
@@ -46060,7 +46371,8 @@
     "question_text": {
       "en": "Which anime features a giant mecha called Lagann?",
       "ja": "ラガンというロボットが登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46100,7 +46412,8 @@
     "question_text": {
       "en": "Which anime is about a high school light music club?",
       "ja": "高校の軽音部が舞台のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46140,7 +46453,8 @@
     "question_text": {
       "en": "Which anime studio produced 'Violet Evergarden'?",
       "ja": "『ヴァイオレット・エヴァーガーデン』を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46180,7 +46494,8 @@
     "question_text": {
       "en": "Which anime features a girl named Asuna in a virtual world?",
       "ja": "アスナという少女が仮想世界で活躍するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46220,7 +46535,8 @@
     "question_text": {
       "en": "Which anime features a girl named Mikasa Ackerman?",
       "ja": "ミカサ・アッカーマンが登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46260,7 +46576,8 @@
     "question_text": {
       "en": "Which anime is about gymnastics rhythmic at Hanazono?",
       "ja": "花園を目指す体操のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46300,7 +46617,8 @@
     "question_text": {
       "en": "Which anime features the Akatsuki organization?",
       "ja": "暁という組織が登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46340,7 +46658,8 @@
     "question_text": {
       "en": "Which anime is set in a magical library city called Academy City?",
       "ja": "学園都市が舞台のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46362,7 +46681,7 @@
         "en": "Katekyo Hitman Reborn",
         "ja": "家庭教師ヒットマンリボーン",
         "ja_typings": [
-          "kateikyoushihittomanribo-un"
+          "kateikyoushihittomanribo-n"
         ]
       },
       {
@@ -46380,7 +46699,8 @@
     "question_text": {
       "en": "Which anime features the Phantom Troupe?",
       "ja": "幻影旅団が登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46420,7 +46740,8 @@
     "question_text": {
       "en": "Which anime is about a girl in a magical school for vampires?",
       "ja": "ヴァンパイアの学園が舞台のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46460,7 +46781,8 @@
     "question_text": {
       "en": "Which anime features Lelouch and Geass powers?",
       "ja": "ルルーシュとギアスの力が登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46500,7 +46822,8 @@
     "question_text": {
       "en": "Which anime features a time-traveling microwave?",
       "ja": "電子レンジで時間移動するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46540,7 +46863,8 @@
     "question_text": {
       "en": "Which anime studio produced 'Demon Slayer'?",
       "ja": "『鬼滅の刃』を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46580,7 +46904,8 @@
     "question_text": {
       "en": "Which anime features a girl who can turn into a wolf?",
       "ja": "狼に変身する少女のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46595,7 +46920,6 @@
         "en": "Ace of Diamond",
         "ja": "ダイヤのA",
         "ja_typings": [
-          "daiyanoeesu",
           "daiyanoa"
         ]
       },
@@ -46621,7 +46945,8 @@
     "question_text": {
       "en": "Which anime features a high school baseball team called Nishiura?",
       "ja": "西浦高校野球部のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46661,7 +46986,8 @@
     "question_text": {
       "en": "Which anime features a cooking competition at Totsuki Academy?",
       "ja": "遠月学園の料理対決のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46701,7 +47027,8 @@
     "question_text": {
       "en": "Which anime features a piano prodigy named Kousei?",
       "ja": "公生というピアノの天才が登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46741,7 +47068,8 @@
     "question_text": {
       "en": "Which anime is about a girl who befriends a yokai cat?",
       "ja": "妖怪の猫を友達にする少女のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46781,7 +47109,8 @@
     "question_text": {
       "en": "Which anime features Tanjiro Kamado?",
       "ja": "竈門炭治郎が主人公のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46821,7 +47150,8 @@
     "question_text": {
       "en": "Which anime features a girl named Holo with wolf ears?",
       "ja": "狼の耳を持つホロが登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46861,7 +47191,8 @@
     "question_text": {
       "en": "Which anime features Saitama, a hero who defeats enemies in one punch?",
       "ja": "一撃で敵を倒すサイタマのアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46901,7 +47232,8 @@
     "question_text": {
       "en": "Which anime is about kart racing in another world with Re:Zero?",
       "ja": "リゼロの主人公の名前は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46941,7 +47273,8 @@
     "question_text": {
       "en": "Which anime features a Quincy named Uryu Ishida?",
       "ja": "石田雨竜というクインシーが登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46981,7 +47314,8 @@
     "question_text": {
       "en": "Which manga is published in Weekly Shonen Sunday?",
       "ja": "週刊少年サンデーで連載されている漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47021,7 +47355,8 @@
     "question_text": {
       "en": "Who is the author of 'Monster' and '20th Century Boys'?",
       "ja": "『モンスター』『20世紀少年』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47061,7 +47396,8 @@
     "question_text": {
       "en": "Which manga magazine publishes 'One Piece'?",
       "ja": "『ONE PIECE』を連載している雑誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47101,7 +47437,8 @@
     "question_text": {
       "en": "Who is the author of 'Vagabond' and 'Slam Dunk'?",
       "ja": "『バガボンド』『スラムダンク』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47141,7 +47478,8 @@
     "question_text": {
       "en": "Which manga features the Joestar family across generations?",
       "ja": "ジョースター家の物語の漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47181,7 +47519,8 @@
     "question_text": {
       "en": "Which manga features chefs competing at Totsuki Academy?",
       "ja": "遠月学園で料理を競う漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47221,7 +47560,8 @@
     "question_text": {
       "en": "Which manga is about a boy who can stretch his body?",
       "ja": "体を伸ばせる少年の漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47261,7 +47601,8 @@
     "question_text": {
       "en": "Which manga features a serial killer note?",
       "ja": "殺人ノートが登場する漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47301,7 +47642,8 @@
     "question_text": {
       "en": "Who is the author of 'Vinland Saga'?",
       "ja": "『ヴィンランド・サガ』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47341,7 +47683,8 @@
     "question_text": {
       "en": "Which manga features a maid named Misaki Ayuzawa?",
       "ja": "鮎沢美咲というメイドが登場する漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47381,7 +47724,8 @@
     "question_text": {
       "en": "Which manga is set in the Bakumatsu era with Gintoki?",
       "ja": "幕末を舞台にした銀時の漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47396,7 +47740,7 @@
         "en": "Shueisha",
         "ja": "集英社",
         "ja_typings": [
-          "shueisha"
+          "shuueisha"
         ]
       },
       {
@@ -47421,7 +47765,8 @@
     "question_text": {
       "en": "Which publisher releases 'Attack on Titan'?",
       "ja": "『進撃の巨人』の出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47461,7 +47806,8 @@
     "question_text": {
       "en": "Who is the author of 'Yotsuba&!'?",
       "ja": "『よつばと!』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47501,7 +47847,8 @@
     "question_text": {
       "en": "Which manga features a basketball team called Seirin?",
       "ja": "誠凛高校バスケ部の漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47541,7 +47888,8 @@
     "question_text": {
       "en": "Which manga features the Survey Corps?",
       "ja": "調査兵団が登場する漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47549,7 +47897,7 @@
         "en": "Tokyo Ghoul",
         "ja": "東京喰種",
         "ja_typings": [
-          "toukyouguuru"
+          "toukyougu-ru"
         ]
       },
       {
@@ -47581,7 +47929,8 @@
     "question_text": {
       "en": "Which manga features ghouls in modern Tokyo?",
       "ja": "現代東京の喰種が登場する漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47621,7 +47970,8 @@
     "question_text": {
       "en": "Which manga features the Yagami family?",
       "ja": "夜神家が登場する漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47661,7 +48011,8 @@
     "question_text": {
       "en": "Which manga is about a boy who becomes a pirate king?",
       "ja": "海賊王を目指す少年の漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47701,7 +48052,8 @@
     "question_text": {
       "en": "Which manga magazine publishes 'Berserk'?",
       "ja": "『ベルセルク』を連載している雑誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47741,7 +48093,8 @@
     "question_text": {
       "en": "Which manga features a girl who travels with a wolf merchant?",
       "ja": "狼の商人と旅をする漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47781,7 +48134,8 @@
     "question_text": {
       "en": "Which manga is about a delivery service in a fantasy world?",
       "ja": "異世界の配達サービスが題材の漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47821,7 +48175,8 @@
     "question_text": {
       "en": "Who is the author of 'Inuyasha' and 'Ranma 1/2'?",
       "ja": "『犬夜叉』『らんま1/2』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47861,7 +48216,8 @@
     "question_text": {
       "en": "Which manga features a sushi chef apprentice named Shota?",
       "ja": "翔太という寿司職人見習いの漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47901,7 +48257,8 @@
     "question_text": {
       "en": "Which manga is about wizards at Fairy Tail guild?",
       "ja": "妖精の尻尾ギルドの魔法使いの漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47941,7 +48298,8 @@
     "question_text": {
       "en": "Which manga features Senku, a science genius rebuilding civilization?",
       "ja": "千空が文明を再建する科学漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47981,7 +48339,8 @@
     "question_text": {
       "en": "Which company developed 'Monster Hunter'?",
       "ja": "『モンスターハンター』を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48003,7 +48362,6 @@
         "en": "Soul Reaver",
         "ja": "ソウルリーバー",
         "ja_typings": [
-          "soruri-ba-",
           "soururi-ba-"
         ]
       },
@@ -48022,7 +48380,8 @@
     "question_text": {
       "en": "Which game features a silent protagonist named Link?",
       "ja": "リンクという主人公が登場するゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48062,7 +48421,8 @@
     "question_text": {
       "en": "Which company developed 'Persona 5'?",
       "ja": "『ペルソナ5』を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48102,7 +48462,8 @@
     "question_text": {
       "en": "Which game features Cloud Strife as the protagonist?",
       "ja": "クラウド・ストライフが主人公のゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48142,7 +48503,8 @@
     "question_text": {
       "en": "Which company developed 'Dark Souls'?",
       "ja": "『ダークソウル』を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48157,7 +48519,6 @@
         "en": "Dark Souls",
         "ja": "ダークソウル",
         "ja_typings": [
-          "da-kusoru",
           "da-kusouru"
         ]
       },
@@ -48183,7 +48544,8 @@
     "question_text": {
       "en": "Which game features the city of Yharnam?",
       "ja": "ヤーナムが舞台のゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48223,7 +48585,8 @@
     "question_text": {
       "en": "Which game features a samurai named Wolf in Sengoku Japan?",
       "ja": "戦国時代の隻腕の狼が主人公のゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48263,7 +48626,8 @@
     "question_text": {
       "en": "Which company developed 'Splatoon'?",
       "ja": "『スプラトゥーン』を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48303,7 +48667,8 @@
     "question_text": {
       "en": "Which stealth game series features Sam Fisher?",
       "ja": "サム・フィッシャーが主人公のステルスゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48343,7 +48708,8 @@
     "question_text": {
       "en": "Which game features the protagonist Aloy in a post-apocalyptic world?",
       "ja": "アーロイが主人公のポストアポカリプスゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48383,7 +48749,8 @@
     "question_text": {
       "en": "Which company developed 'Yakuza' (Ryu ga Gotoku) series?",
       "ja": "『龍が如く』を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48423,7 +48790,8 @@
     "question_text": {
       "en": "Which game features Kazuma Kiryu as the dragon of Dojima?",
       "ja": "堂島の龍・桐生一馬が主人公のゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48463,7 +48831,8 @@
     "question_text": {
       "en": "Which game genre is 'Stardew Valley'?",
       "ja": "『スターデュー・バレー』のジャンルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48503,7 +48872,8 @@
     "question_text": {
       "en": "Which game features the world of Hyrule?",
       "ja": "ハイラルが舞台のゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48543,7 +48913,8 @@
     "question_text": {
       "en": "Which game features a plumber's brother named Luigi?",
       "ja": "ルイージが登場するゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48583,7 +48954,8 @@
     "question_text": {
       "en": "Which company developed 'Street Fighter'?",
       "ja": "『ストリートファイター』を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48623,7 +48995,8 @@
     "question_text": {
       "en": "Which game features Ryu and his Hadouken?",
       "ja": "リュウと波動拳が登場するゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48638,7 +49011,6 @@
         "en": "Soulcalibur",
         "ja": "ソウルキャリバー",
         "ja_typings": [
-          "sorukyariba-",
           "sourukyariba-"
         ]
       },
@@ -48664,7 +49036,8 @@
     "question_text": {
       "en": "Which game series features the Mishima family rivalry?",
       "ja": "三島家の確執が描かれる格闘ゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48704,7 +49077,8 @@
     "question_text": {
       "en": "Which game features building with blocks named NOT Minecraft?",
       "ja": "ブロックを積むゲームでマインクラフトではないのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48744,7 +49118,8 @@
     "question_text": {
       "en": "Which game features the protagonist Kratos?",
       "ja": "クレイトスが主人公のゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48784,7 +49159,8 @@
     "question_text": {
       "en": "Which company developed 'Phantasy Star Online'?",
       "ja": "『ファンタシースターオンライン』を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48824,7 +49200,8 @@
     "question_text": {
       "en": "Which game features Geralt of Rivia?",
       "ja": "リヴィアのゲラルトが主人公のゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48864,7 +49241,8 @@
     "question_text": {
       "en": "Which game genre is 'Civilization'?",
       "ja": "『シヴィライゼーション』のジャンルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48904,7 +49282,8 @@
     "question_text": {
       "en": "Which game features Sonic the hedgehog?",
       "ja": "ソニックが登場するゲームシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48944,7 +49323,8 @@
     "question_text": {
       "en": "Which company developed 'Kingdom Hearts'?",
       "ja": "『キングダムハーツ』を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48984,7 +49364,8 @@
     "question_text": {
       "en": "Which game features Sora wielding a Keyblade?",
       "ja": "ソラがキーブレードを使うゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49024,7 +49405,8 @@
     "question_text": {
       "en": "Which game series features survival in a haunted town?",
       "ja": "幽霊の町でのサバイバルゲームシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49064,7 +49446,8 @@
     "question_text": {
       "en": "Which game features pilots and Titans in combat?",
       "ja": "パイロットとタイタンが戦うゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49104,7 +49487,8 @@
     "question_text": {
       "en": "Which game features a janitor turned hero named Isaac in Dead Space?",
       "ja": "デッドスペースの主人公アイザックの職業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49144,7 +49528,8 @@
     "question_text": {
       "en": "Which game features a girl named 2B fighting machines?",
       "ja": "2Bが機械生命体と戦うゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49184,7 +49569,8 @@
     "question_text": {
       "en": "What is the Python module for ordered dictionaries (insertion-ordered) added in 3.7 as guaranteed?",
       "ja": "Python 3.7 で挿入順序が保証された辞書の特殊型を提供するモジュールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49224,7 +49610,8 @@
     "question_text": {
       "en": "Which Python decorator caches return values based on arguments?",
       "ja": "Python で引数に基づいて戻り値をキャッシュするデコレーターは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49264,7 +49651,8 @@
     "question_text": {
       "en": "What Python statement creates a context manager inline?",
       "ja": "Python でコンテキストマネージャをインラインで作成する文は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49304,7 +49692,8 @@
     "question_text": {
       "en": "Which Python builtin returns an iterator of tuples pairing index and value?",
       "ja": "インデックスと値をペアにしたタプルのイテレータを返す Python 組み込み関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49344,7 +49733,8 @@
     "question_text": {
       "en": "Which Python keyword defines a coroutine function?",
       "ja": "Python でコルーチン関数を定義するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49384,7 +49774,8 @@
     "question_text": {
       "en": "What is Python's walrus operator?",
       "ja": "Python のセイウチ演算子はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49424,7 +49815,8 @@
     "question_text": {
       "en": "Which Python module provides abstract base classes for containers?",
       "ja": "コンテナの抽象基底クラスを提供する Python モジュールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49464,7 +49856,8 @@
     "question_text": {
       "en": "What does Python's GIL stand for?",
       "ja": "Python の GIL の正式名称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49504,7 +49897,8 @@
     "question_text": {
       "en": "Which Rust attribute marks a function for compile-time evaluation?",
       "ja": "Rust でコンパイル時評価のために関数をマークする属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49544,7 +49938,8 @@
     "question_text": {
       "en": "What Rust smart pointer enables interior mutability with runtime borrow checking?",
       "ja": "実行時借用チェックで内部可変性を可能にする Rust のスマートポインタは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49584,7 +49979,8 @@
     "question_text": {
       "en": "Which Rust macro derives Debug formatting?",
       "ja": "Rust で Debug フォーマットを派生させるマクロは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49592,7 +49988,7 @@
         "en": "? operator",
         "ja": "クエスチョン演算子",
         "ja_typings": [
-          "kuesuchonenzanshi"
+          "kuesuchonnenzanshi"
         ]
       },
       {
@@ -49624,7 +50020,8 @@
     "question_text": {
       "en": "What is Rust's zero-cost abstraction for fallible operations?",
       "ja": "失敗しうる操作のための Rust のゼロコスト抽象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49664,7 +50061,8 @@
     "question_text": {
       "en": "Which Rust keyword introduces a trait bound on a generic?",
       "ja": "Rust でジェネリクスにトレイト境界を導入するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49704,7 +50102,8 @@
     "question_text": {
       "en": "What Rust feature allows pattern matching on enum variants?",
       "ja": "Rust で enum バリアントへのパターンマッチを可能にする機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49744,7 +50143,8 @@
     "question_text": {
       "en": "Which JavaScript method creates a shallow copy of an array?",
       "ja": "配列の浅いコピーを作成する JavaScript のメソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49784,7 +50184,8 @@
     "question_text": {
       "en": "What JavaScript operator performs nullish coalescing?",
       "ja": "JavaScript で null 合体演算を行う演算子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49806,7 +50207,6 @@
         "en": "Readonly",
         "ja": "リードオンリー",
         "ja_typings": [
-          "ri-donri-",
           "ri-doonri-"
         ]
       },
@@ -49825,7 +50225,8 @@
     "question_text": {
       "en": "Which TypeScript utility type makes all properties optional?",
       "ja": "全プロパティを省略可能にする TypeScript ユーティリティ型は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49847,7 +50248,6 @@
         "en": "unknown",
         "ja": "アンノウン",
         "ja_typings": [
-          "annnon",
           "annnoun"
         ]
       },
@@ -49866,7 +50266,8 @@
     "question_text": {
       "en": "What TypeScript feature represents a value that never occurs?",
       "ja": "決して発生しない値を表す TypeScript の機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49906,7 +50307,8 @@
     "question_text": {
       "en": "Which JavaScript API provides a way to run code in a separate thread?",
       "ja": "別スレッドでコードを実行する方法を提供する JavaScript の API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49946,7 +50348,8 @@
     "question_text": {
       "en": "What does JavaScript's Symbol.iterator define?",
       "ja": "JavaScript の Symbol.iterator が定義するものは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49986,7 +50389,8 @@
     "question_text": {
       "en": "Which JavaScript expression freezes an object?",
       "ja": "オブジェクトを凍結する JavaScript の式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50026,7 +50430,8 @@
     "question_text": {
       "en": "What Go keyword starts a lightweight thread?",
       "ja": "軽量スレッドを開始する Go のキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50066,7 +50471,8 @@
     "question_text": {
       "en": "Which Go construct enables typed channel communication selection?",
       "ja": "型付きチャネル通信の選択を可能にする Go の構文は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50106,7 +50512,8 @@
     "question_text": {
       "en": "What Go feature is used for deferred function execution at scope end?",
       "ja": "スコープ末尾での関数実行を遅延する Go の機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50146,7 +50553,8 @@
     "question_text": {
       "en": "Which Go package provides synchronization primitives?",
       "ja": "同期プリミティブを提供する Go のパッケージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50186,7 +50594,8 @@
     "question_text": {
       "en": "Which C++ smart pointer represents exclusive ownership?",
       "ja": "排他的所有権を表す C++ のスマートポインタは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50226,7 +50635,8 @@
     "question_text": {
       "en": "What C++ keyword prevents implicit conversions for constructors?",
       "ja": "コンストラクタの暗黙変換を防ぐ C++ のキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50266,7 +50676,8 @@
     "question_text": {
       "en": "Which C++ feature enables compile-time computation?",
       "ja": "コンパイル時計算を可能にする C++ の機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50306,7 +50717,8 @@
     "question_text": {
       "en": "What C++ standard introduced concepts?",
       "ja": "concepts を導入した C++ 標準は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50346,7 +50758,8 @@
     "question_text": {
       "en": "Which C++ cast performs runtime type checking?",
       "ja": "実行時型チェックを行う C++ のキャストは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50386,7 +50799,8 @@
     "question_text": {
       "en": "Which Kotlin keyword declares a singleton object?",
       "ja": "Kotlin でシングルトンオブジェクトを宣言するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50426,7 +50840,8 @@
     "question_text": {
       "en": "What Kotlin function-like type allows null-safe call chaining?",
       "ja": "null 安全なチェーンを可能にする Kotlin の演算子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50466,7 +50881,8 @@
     "question_text": {
       "en": "Which Swift keyword declares an immutable binding?",
       "ja": "Swift で不変束縛を宣言するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50506,7 +50922,8 @@
     "question_text": {
       "en": "What Swift feature handles optional values with default fallback?",
       "ja": "省略可能値をデフォルトでフォールバックする Swift の機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50514,7 +50931,7 @@
         "en": "Doubly linked list + hash map",
         "ja": "双方向連結リスト + ハッシュマップ",
         "ja_typings": [
-          "souhoukourenketsurisuto/+/hasshumappu"
+          "souhoukourenketsurisuto+hasshumappu"
         ]
       },
       {
@@ -50546,7 +50963,8 @@
     "question_text": {
       "en": "Which data structure is best for LRU cache implementation?",
       "ja": "LRU キャッシュ実装に最適なデータ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50554,7 +50972,6 @@
         "en": "O(n^2)",
         "ja": "オーエヌジジョウ",
         "ja_typings": [
-          "o-enujijo",
           "o-enujijou"
         ]
       },
@@ -50587,7 +51004,8 @@
     "question_text": {
       "en": "What is the worst-case time complexity of quicksort?",
       "ja": "クイックソートの最悪計算量は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50627,7 +51045,8 @@
     "question_text": {
       "en": "Which tree is self-balancing with red and black node coloring?",
       "ja": "赤黒ノード彩色で自己平衡する木は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50667,7 +51086,8 @@
     "question_text": {
       "en": "What algorithm finds shortest paths from all pairs in a graph?",
       "ja": "グラフの全頂点間最短路を求めるアルゴリズムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50707,7 +51127,8 @@
     "question_text": {
       "en": "Which data structure supports efficient prefix search of strings?",
       "ja": "文字列の効率的な前方一致検索を支援するデータ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50747,7 +51168,8 @@
     "question_text": {
       "en": "What is the technique to amortize the cost of dynamic array resizing?",
       "ja": "動的配列リサイズコストを償却する手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50787,7 +51209,8 @@
     "question_text": {
       "en": "Which structure provides O(1) amortized push and pop from both ends?",
       "ja": "両端からの償却 O(1) push/pop を提供する構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50827,7 +51250,8 @@
     "question_text": {
       "en": "What is the name of the algorithm matching strings with KMP failure function?",
       "ja": "KMP の失敗関数で文字列照合するアルゴリズムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50867,7 +51291,8 @@
     "question_text": {
       "en": "Which GC algorithm uses two semispaces and copies live objects?",
       "ja": "2 つの半空間を使い生存オブジェクトをコピーする GC は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50907,7 +51332,8 @@
     "question_text": {
       "en": "What GC technique segregates objects by age?",
       "ja": "オブジェクトを年齢で分離する GC 技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50947,7 +51373,8 @@
     "question_text": {
       "en": "Which low-level technique uses pointer tagging to encode types?",
       "ja": "ポインタタグ付けで型をエンコードする低レベル技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50987,7 +51414,8 @@
     "question_text": {
       "en": "What concurrency primitive allows multiple readers or one writer?",
       "ja": "複数読者または単一書き手を許す並行プリミティブは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51027,7 +51455,8 @@
     "question_text": {
       "en": "Which pattern uses message passing between actors?",
       "ja": "アクター間でメッセージパッシングを行うパターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51067,7 +51496,8 @@
     "question_text": {
       "en": "What is the term for a deadlock-like state where threads keep yielding?",
       "ja": "スレッドが譲り合い続けるデッドロック類似状態は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51107,7 +51537,8 @@
     "question_text": {
       "en": "Which Java construct provides lock-free atomic operations?",
       "ja": "ロックフリーなアトミック操作を提供する Java 構文は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51147,7 +51578,8 @@
     "question_text": {
       "en": "What is the term for ensuring memory ordering across threads?",
       "ja": "スレッド間のメモリ順序を保証する用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51187,7 +51619,8 @@
     "question_text": {
       "en": "Which functional concept transforms a multi-arg function into chained single-arg functions?",
       "ja": "多引数関数を連鎖した単一引数関数に変換する関数型概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51227,7 +51660,8 @@
     "question_text": {
       "en": "What is a monad's binding operation commonly named?",
       "ja": "モナドの束縛操作の一般的な名前は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51267,7 +51701,8 @@
     "question_text": {
       "en": "Which higher-order function reduces a list to a single value?",
       "ja": "リストを単一値に畳み込む高階関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51307,7 +51742,8 @@
     "question_text": {
       "en": "What is the term for treating functions as first-class values?",
       "ja": "関数をファーストクラス値として扱う用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51336,7 +51772,6 @@
         "en": "Row polymorphism",
         "ja": "ロウポリモーフィズム",
         "ja_typings": [
-          "roporimo-fizumu",
           "rouporimo-fizumu"
         ]
       }
@@ -51348,7 +51783,8 @@
     "question_text": {
       "en": "Which type system feature describes Haskell's typeclasses?",
       "ja": "Haskell の型クラスを表現する型システム機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51388,7 +51824,8 @@
     "question_text": {
       "en": "What is tail call optimization commonly abbreviated as?",
       "ja": "末尾呼び出し最適化の略称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51428,7 +51865,8 @@
     "question_text": {
       "en": "Which compilation step converts source to an intermediate representation?",
       "ja": "ソースを中間表現に変換するコンパイル工程は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51468,7 +51906,8 @@
     "question_text": {
       "en": "What is the term for a function that calls itself?",
       "ja": "自分自身を呼び出す関数の用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51508,7 +51947,8 @@
     "question_text": {
       "en": "Which feature allows mixing code at runtime with reflection-style APIs?",
       "ja": "リフレクション風 API で実行時にコードを差し込む機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51548,7 +51988,8 @@
     "question_text": {
       "en": "What term describes calling C functions from another language?",
       "ja": "他言語から C 関数を呼び出すことを指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51588,7 +52029,8 @@
     "question_text": {
       "en": "Which technique inlines small functions at call sites?",
       "ja": "呼び出し箇所に小さな関数を展開する技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51628,7 +52070,8 @@
     "question_text": {
       "en": "What is the convention for naming constants in many languages?",
       "ja": "多くの言語で定数を命名する慣習は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51668,7 +52111,8 @@
     "question_text": {
       "en": "Which is a structural typing system feature?",
       "ja": "構造的型付けシステムの特徴は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51708,7 +52152,8 @@
     "question_text": {
       "en": "What is the term for converting an object into a byte stream?",
       "ja": "オブジェクトをバイト列に変換することを指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51748,7 +52193,8 @@
     "question_text": {
       "en": "Which dispatch mechanism resolves method calls at runtime via vtables?",
       "ja": "vtable で実行時にメソッド呼び出しを解決する機構は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51788,7 +52234,8 @@
     "question_text": {
       "en": "Which CSS function clamps a value between min and max?",
       "ja": "値を最小値と最大値で挟む CSS 関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51828,7 +52275,8 @@
     "question_text": {
       "en": "What CSS property enables logical inline-start margin?",
       "ja": "論理的なインライン開始マージンを設定する CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51868,7 +52316,8 @@
     "question_text": {
       "en": "Which CSS unit is relative to the smaller of viewport width/height?",
       "ja": "ビューポートの幅と高さの小さい方に対する CSS 単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51908,7 +52357,8 @@
     "question_text": {
       "en": "What CSS at-rule defines a font from a remote source?",
       "ja": "リモートソースからフォントを定義する CSS の at-rule は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51948,7 +52398,8 @@
     "question_text": {
       "en": "Which CSS property creates a stacking context without z-index?",
       "ja": "z-index なしでスタッキングコンテキストを作る CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51988,7 +52439,8 @@
     "question_text": {
       "en": "What CSS feature allows scoping styles with @scope?",
       "ja": "@scope でスタイルをスコープ化する CSS 機能の名称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52028,7 +52480,8 @@
     "question_text": {
       "en": "Which CSS pseudo-class matches an element that has focus within its tree?",
       "ja": "要素ツリー内にフォーカスがある要素にマッチする CSS 疑似クラスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52068,7 +52521,8 @@
     "question_text": {
       "en": "What CSS property defines named grid areas?",
       "ja": "名前付きグリッドエリアを定義する CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52108,7 +52562,8 @@
     "question_text": {
       "en": "Which HTML element represents a disclosure widget?",
       "ja": "開閉式ウィジェットを表す HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52148,7 +52603,8 @@
     "question_text": {
       "en": "What HTML attribute enables drag-and-drop on any element?",
       "ja": "任意の要素でドラッグアンドドロップを有効にする HTML 属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52188,7 +52644,8 @@
     "question_text": {
       "en": "Which HTML input type provides a color picker?",
       "ja": "カラーピッカーを提供する HTML input type は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52228,7 +52685,8 @@
     "question_text": {
       "en": "What HTML element groups labeled form controls?",
       "ja": "ラベル付きフォーム部品をグループ化する HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52268,7 +52726,8 @@
     "question_text": {
       "en": "Which HTML5 API allows offline storage of structured data?",
       "ja": "構造化データのオフライン保存を可能にする HTML5 API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52308,7 +52767,8 @@
     "question_text": {
       "en": "Which HTTP status indicates a request conflict?",
       "ja": "リクエストの競合を示す HTTP ステータスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52323,7 +52783,7 @@
         "en": "Forbidden",
         "ja": "フォービドゥン",
         "ja_typings": [
-          "fo-bidun"
+          "fo-bidwun"
         ]
       },
       {
@@ -52348,7 +52808,8 @@
     "question_text": {
       "en": "What HTTP status means the resource is permanently gone?",
       "ja": "リソースが恒久的に消えたことを示す HTTP ステータスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52363,7 +52824,6 @@
         "en": "Access-Control-Allow-Origin",
         "ja": "アクセスコントロールアロウオリジン",
         "ja_typings": [
-          "akusesukontoro-ruaroorijin",
           "akusesukontoro-ruarouorijin"
         ]
       },
@@ -52389,7 +52849,8 @@
     "question_text": {
       "en": "Which HTTP header controls how long a preflight response is cached?",
       "ja": "プリフライト応答のキャッシュ期間を制御する HTTP ヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52429,7 +52890,8 @@
     "question_text": {
       "en": "What HTTP header indicates the original request scheme behind a proxy?",
       "ja": "プロキシ越しに元のリクエストスキームを示す HTTP ヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52469,7 +52931,8 @@
     "question_text": {
       "en": "Which HTTP response header tells browsers to enforce HTTPS?",
       "ja": "ブラウザに HTTPS を強制させる HTTP 応答ヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52509,7 +52972,8 @@
     "question_text": {
       "en": "What HTTP method is used to retrieve metadata only?",
       "ja": "メタデータのみを取得する HTTP メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52549,7 +53013,8 @@
     "question_text": {
       "en": "Which Web API observes element resize events?",
       "ja": "要素のリサイズイベントを監視する Web API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52571,7 +53036,6 @@
         "en": "Viewport Observer",
         "ja": "ビューポートオブザーバー",
         "ja_typings": [
-          "byu-po-tobuza-ba-",
           "byu-po-toobuza-ba-"
         ]
       },
@@ -52590,7 +53054,8 @@
     "question_text": {
       "en": "What Web API detects when an element enters the viewport?",
       "ja": "要素がビューポートに入ったことを検出する Web API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52630,7 +53095,8 @@
     "question_text": {
       "en": "Which Web API enables push notifications?",
       "ja": "プッシュ通知を可能にする Web API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52670,7 +53136,8 @@
     "question_text": {
       "en": "What Web API persists data using a key-value pair with promises?",
       "ja": "Promise でキーバリュー保存する Web API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52710,7 +53177,8 @@
     "question_text": {
       "en": "Which API lets pages register handlers for share targets?",
       "ja": "共有先ハンドラを登録できる API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52750,7 +53218,8 @@
     "question_text": {
       "en": "What API exposes high-resolution monotonic timestamps?",
       "ja": "高解像度の単調タイムスタンプを提供する API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52790,7 +53259,8 @@
     "question_text": {
       "en": "Which API allows speech-to-text in the browser?",
       "ja": "ブラウザで音声を文字起こしする API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52830,7 +53300,8 @@
     "question_text": {
       "en": "Which React hook subscribes to an external store with concurrent safety?",
       "ja": "並行性安全に外部ストア購読する React フックは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52870,7 +53341,8 @@
     "question_text": {
       "en": "What Vue 3 macro defines props in script setup?",
       "ja": "script setup で props を定義する Vue 3 マクロは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52899,7 +53371,6 @@
         "en": "event:on",
         "ja": "イベントオン",
         "ja_typings": [
-          "ibenton",
           "ibentoon"
         ]
       }
@@ -52911,7 +53382,8 @@
     "question_text": {
       "en": "Which Svelte directive listens to DOM events?",
       "ja": "DOM イベントを購読する Svelte ディレクティブは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52951,7 +53423,8 @@
     "question_text": {
       "en": "What is the term for rendering on the server at request time?",
       "ja": "リクエスト時にサーバーでレンダリングすることを指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -52991,7 +53464,8 @@
     "question_text": {
       "en": "Which Next.js feature regenerates static pages on demand?",
       "ja": "オンデマンドで静的ページを再生成する Next.js の機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53031,7 +53505,8 @@
     "question_text": {
       "en": "What Astro feature ships zero JS to the client by default?",
       "ja": "デフォルトでクライアントに JS を送らない Astro の機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53071,7 +53546,8 @@
     "question_text": {
       "en": "Which browser process step computes element geometry?",
       "ja": "要素の幾何を計算するブラウザ処理工程は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53111,7 +53587,8 @@
     "question_text": {
       "en": "What is the term for the browser combining painted layers?",
       "ja": "ペイントしたレイヤーをブラウザが合成することを指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53151,7 +53628,8 @@
     "question_text": {
       "en": "Which event fires after DOM is parsed but before all assets load?",
       "ja": "DOM 解析後・全アセット読み込み前に発火するイベントは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53191,7 +53669,8 @@
     "question_text": {
       "en": "What browser feature isolates iframes in separate processes?",
       "ja": "iframe を別プロセスに隔離するブラウザ機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53231,7 +53710,8 @@
     "question_text": {
       "en": "Which API enables sharing memory between threads with locks?",
       "ja": "ロック付きでスレッド間メモリ共有を可能にする API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53271,7 +53751,8 @@
     "question_text": {
       "en": "Which attack tricks users into clicking hidden UI elements?",
       "ja": "隠された UI 要素をクリックさせる攻撃は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53311,7 +53792,8 @@
     "question_text": {
       "en": "What security mechanism uses a nonce in CSP?",
       "ja": "CSP で nonce を使うセキュリティ機構は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53340,7 +53822,6 @@
         "en": "X-Download-Options",
         "ja": "エックスダウンロードオプションズ",
         "ja_typings": [
-          "ekkusudaunro-dopushonzu",
           "ekkusudaunro-doopushonzu"
         ]
       }
@@ -53352,7 +53833,8 @@
     "question_text": {
       "en": "Which header prevents MIME-type sniffing?",
       "ja": "MIME タイプ推測を防ぐヘッダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53392,7 +53874,8 @@
     "question_text": {
       "en": "What attack exploits trust in cached DNS responses?",
       "ja": "キャッシュ済み DNS 応答の信頼を悪用する攻撃は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53414,7 +53897,6 @@
         "en": "X-Embed-Options",
         "ja": "エックスエンベッドオプションズ",
         "ja_typings": [
-          "ekkusuenbeddopushonzu",
           "ekkusuenbeddoopushonzu"
         ]
       },
@@ -53433,7 +53915,8 @@
     "question_text": {
       "en": "Which feature lets servers opt out of being framed?",
       "ja": "サーバーがフレーム化拒否を表明する機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53473,7 +53956,8 @@
     "question_text": {
       "en": "What is the term for embedding tokens to verify form origin?",
       "ja": "フォーム送信元検証のためにトークンを埋め込むことを指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53513,7 +53997,8 @@
     "question_text": {
       "en": "Which ARIA attribute announces dynamic content politely?",
       "ja": "動的コンテンツを丁寧に通知する ARIA 属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53553,7 +54038,8 @@
     "question_text": {
       "en": "What ARIA role marks the main content area?",
       "ja": "メインコンテンツ領域を示す ARIA ロールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53561,7 +54047,7 @@
         "en": "aria-hidden",
         "ja": "アリアヒドゥン",
         "ja_typings": [
-          "ariahidun"
+          "ariahidwun"
         ]
       },
       {
@@ -53593,7 +54079,8 @@
     "question_text": {
       "en": "Which attribute hides decorative elements from assistive tech?",
       "ja": "支援技術から装飾要素を隠す属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53633,7 +54120,8 @@
     "question_text": {
       "en": "What WCAG contrast ratio is required for normal text AA?",
       "ja": "通常テキスト AA に必要な WCAG コントラスト比は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53673,7 +54161,8 @@
     "question_text": {
       "en": "Which Core Web Vital measures input responsiveness?",
       "ja": "入力応答性を測る Core Web Vital は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53713,7 +54202,8 @@
     "question_text": {
       "en": "What Core Web Vital tracks layout stability?",
       "ja": "レイアウト安定性を追跡する Core Web Vital は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53753,7 +54243,8 @@
     "question_text": {
       "en": "Which technique loads JS chunks only when needed?",
       "ja": "必要時のみ JS チャンクを読み込む技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53793,7 +54284,8 @@
     "question_text": {
       "en": "What HTML attribute hints the browser to preload a resource?",
       "ja": "ブラウザにリソースの事前読み込みを指示する HTML 属性値は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53833,7 +54325,8 @@
     "question_text": {
       "en": "Which image format uses AV1 video codec for compression?",
       "ja": "AV1 動画コーデックを使う画像形式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53873,7 +54366,8 @@
     "question_text": {
       "en": "What technique sends critical CSS in the HTML to reduce render-blocking?",
       "ja": "レンダーブロッキング軽減のため HTML に CSS を埋め込む技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53902,7 +54396,6 @@
         "en": "WebTransport over TCP",
         "ja": "ウェブトランスポートオーバーティーシーピー",
         "ja_typings": [
-          "webutoransupo-to-ba-thi-shi-pi-",
           "webutoransupo-too-ba-thi-shi-pi-"
         ]
       }
@@ -53914,7 +54407,8 @@
     "question_text": {
       "en": "Which protocol multiplexes streams over QUIC?",
       "ja": "QUIC 上でストリームを多重化するプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53954,7 +54448,8 @@
     "question_text": {
       "en": "What standard defines URL parsing across browsers?",
       "ja": "ブラウザ間で URL 解析を定義する標準は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53994,7 +54489,8 @@
     "question_text": {
       "en": "Which DOM method creates a document fragment?",
       "ja": "ドキュメントフラグメントを作成する DOM メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54034,7 +54530,8 @@
     "question_text": {
       "en": "What feature lets web apps install like native apps?",
       "ja": "Web アプリをネイティブのようにインストール可能にする機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54074,7 +54571,8 @@
     "question_text": {
       "en": "Which encoding represents binary data as ASCII text in URLs?",
       "ja": "URL でバイナリデータを ASCII テキストとして表現するエンコードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54114,7 +54612,8 @@
     "question_text": {
       "en": "What CSS property controls how an element is contained for performance?",
       "ja": "パフォーマンスのために要素の含意を制御する CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54154,7 +54653,8 @@
     "question_text": {
       "en": "Which DOM event fires when a CSS transition completes?",
       "ja": "CSS トランジション完了時に発火する DOM イベントは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54194,7 +54694,8 @@
     "question_text": {
       "en": "Which 1988 Studio Ghibli film features two sisters and a cat bus?",
       "ja": "1988年公開で姉妹と猫バスが登場するジブリ作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54234,7 +54735,8 @@
     "question_text": {
       "en": "Which 1995 Ghibli film centers on Shizuku writing a novel?",
       "ja": "雫が小説を書く1995年のジブリ作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54249,7 +54751,8 @@
         "en": "Galaxy Express 999",
         "ja": "銀河鉄道999",
         "ja_typings": [
-          "gingatetsudousurii"
+          "gingatetsudousuri-nain",
+          "gingatetsudou999"
         ]
       },
       {
@@ -54274,7 +54777,8 @@
     "question_text": {
       "en": "Which 1979 anime features Captain Harlock as the protagonist?",
       "ja": "ハーロック船長が主人公の1979年アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54289,7 +54793,8 @@
         "en": "Galaxy Express 999",
         "ja": "銀河鉄道999",
         "ja_typings": [
-          "gingatetsudousurii"
+          "gingatetsudousuri-nain",
+          "gingatetsudou999"
         ]
       },
       {
@@ -54314,7 +54819,8 @@
     "question_text": {
       "en": "Which 1974 anime depicts a journey to recover the Cosmo DNA?",
       "ja": "コスモクリーナーDを取りに行く1974年のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54354,7 +54860,8 @@
     "question_text": {
       "en": "Which 1982 mecha anime features Hikaru, Misa, and Minmay?",
       "ja": "輝・未沙・ミンメイが登場する1982年のメカアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54394,7 +54901,8 @@
     "question_text": {
       "en": "Which 1983 anime is set in the world of Byston Well?",
       "ja": "バイストン・ウェルが舞台の1983年のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54434,7 +54942,8 @@
     "question_text": {
       "en": "Which 1988 OVA film by Mamoru Oshii features a sentient airliner?",
       "ja": "意思を持つ旅客機が登場する1988年押井守監督のOVAは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54474,7 +54983,8 @@
     "question_text": {
       "en": "Which 1985 Ghibli film follows Pazu and Sheeta?",
       "ja": "パズーとシータが登場する1985年のジブリ作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54514,7 +55024,8 @@
     "question_text": {
       "en": "Which 1984 Ghibli-precursor film features Ohmu and toxic jungles?",
       "ja": "オームと腐海が登場する1984年の作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54529,7 +55040,6 @@
         "en": "Gunbuster",
         "ja": "トップをねらえ!",
         "ja_typings": [
-          "toppuwonerae",
           "toppuonerae"
         ]
       },
@@ -54555,7 +55065,8 @@
     "question_text": {
       "en": "Which 1987 Gainax film follows Shirotsugh joining a space program?",
       "ja": "シロツグが宇宙軍に入隊する1987年のガイナックス作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54563,7 +55074,6 @@
         "en": "Gunbuster",
         "ja": "トップをねらえ!",
         "ja_typings": [
-          "toppuwonerae",
           "toppuonerae"
         ]
       },
@@ -54596,7 +55106,8 @@
     "question_text": {
       "en": "Which 1988 OVA features Noriko piloting RX-7?",
       "ja": "ノリコがRX-7に乗る1988年のOVAは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54636,7 +55147,8 @@
     "question_text": {
       "en": "Which 1990 NHK anime follows Jean and Nadia searching for Atlantis?",
       "ja": "ジャンとナディアがアトランティスを探す1990年のNHKアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54676,7 +55188,8 @@
     "question_text": {
       "en": "Which 1978 Miyazaki TV series follows Conan after a global cataclysm?",
       "ja": "大災害後の世界を描く1978年宮崎駿監督のTVシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54716,7 +55229,8 @@
     "question_text": {
       "en": "Which 1992 anime is about a girl boxing kickboxer named Hibiki?",
       "ja": "響子が主人公の1992年のキックボクシングアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54756,7 +55270,8 @@
     "question_text": {
       "en": "Which 2022 anime features Bojji, a deaf prince?",
       "ja": "耳の聞こえない王子ボッジが主人公の2022年アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54796,7 +55311,8 @@
     "question_text": {
       "en": "Which 2021 anime by Naoko Yamada retells a classical war chronicle?",
       "ja": "山田尚子監督による2021年の古典戦記アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54836,7 +55352,8 @@
     "question_text": {
       "en": "Which 2021 anime features a talking cat solving crimes in Tokyo?",
       "ja": "東京で事件を解決する話す猫が登場する2021年のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54876,7 +55393,8 @@
     "question_text": {
       "en": "Which 2021 anime follows Ai singing diva android?",
       "ja": "歌姫アンドロイドのヴィヴィが主人公の2021年のアニメは?"
-    }
+    },
+    "ja_reviewed": false
   },
   {
     "choices": [
@@ -54916,7 +55434,8 @@
     "question_text": {
       "en": "Which 2021 Madhouse anime features high schoolers stranded on a deserted island?",
       "ja": "無人島に漂流する高校生が主人公の2021年マッドハウス制作アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54956,7 +55475,8 @@
     "question_text": {
       "en": "Which 2023 anime is about a girl band formed at SHIMOKITAZAWA?",
       "ja": "下北沢で結成された女子バンドを描く2023年のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54996,7 +55516,8 @@
     "question_text": {
       "en": "Which 2023 anime follows a country girl Mitsumi adjusting to Tokyo high school?",
       "ja": "上京した田舎の少女みつみが主人公の2023年のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55036,7 +55557,8 @@
     "question_text": {
       "en": "Which 2023 anime depicts Maru and Kiruko traveling post-apocalyptic Japan?",
       "ja": "マルとキルコがポストアポカリプスの日本を旅する2023年アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55076,7 +55598,8 @@
     "question_text": {
       "en": "Which 2019 anime adapts Makoto Yukimura's Viking epic?",
       "ja": "幸村誠のヴァイキング叙事詩を原作とする2019年のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55116,7 +55639,8 @@
     "question_text": {
       "en": "Which 2018 Mamoru Hosoda film is about a boy meeting his future sister?",
       "ja": "未来の妹に出会う少年を描く2018年細田守監督の映画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55156,7 +55680,8 @@
     "question_text": {
       "en": "Which 2021 Hosoda film features a VR singer with a dragon?",
       "ja": "竜とVR世界の歌姫を描く2021年の細田守監督作は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55196,7 +55721,8 @@
     "question_text": {
       "en": "Which 2022 film by Mari Okada features a hidden village of red eyes?",
       "ja": "岡田麿里監督による2022年の赤い瞳の村を描く映画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55236,7 +55762,8 @@
     "question_text": {
       "en": "Which 2006 Kon Satoshi film is about a dream-invading device?",
       "ja": "夢に入る装置を描く2006年今敏監督の映画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55276,7 +55803,8 @@
     "question_text": {
       "en": "Which 2001 Kon Satoshi film blends an actress's memories with film history?",
       "ja": "女優の記憶と映画史を交錯させる2001年今敏監督作は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55316,7 +55844,8 @@
     "question_text": {
       "en": "Which 1997 Satoshi Kon film follows a pop idol turned actress?",
       "ja": "アイドルから女優に転身した少女を描く1997年今敏監督作は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55356,7 +55885,8 @@
     "question_text": {
       "en": "Which studio produced Made in Abyss?",
       "ja": "メイドインアビスを制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55396,7 +55926,8 @@
     "question_text": {
       "en": "Which studio is famous for Mob Psycho 100 and One-Punch Man season 1?",
       "ja": "モブサイコ100とワンパンマン1期で有名なスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55436,7 +55967,8 @@
     "question_text": {
       "en": "Which studio produced Violet Evergarden?",
       "ja": "ヴァイオレット・エヴァーガーデンを制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55476,7 +56008,8 @@
     "question_text": {
       "en": "Which studio is known for Hanasaku Iroha and Shirobako?",
       "ja": "花咲くいろは・SHIROBAKOで知られるスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55516,7 +56049,8 @@
     "question_text": {
       "en": "Which studio is famous for Kill la Kill and SSSS.GRIDMAN?",
       "ja": "キルラキル・SSSS.GRIDMANで有名なスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55556,7 +56090,8 @@
     "question_text": {
       "en": "Who voices Lelouch vi Britannia?",
       "ja": "ルルーシュ・ヴィ・ブリタニアの声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55596,7 +56131,8 @@
     "question_text": {
       "en": "Who voices Holo in Spice and Wolf?",
       "ja": "狼と香辛料のホロの声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55636,7 +56172,8 @@
     "question_text": {
       "en": "Which director made Cowboy Bebop?",
       "ja": "カウボーイビバップの監督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55676,7 +56213,8 @@
     "question_text": {
       "en": "Which director helmed Samurai Champloo?",
       "ja": "サムライチャンプルーの監督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55716,7 +56254,8 @@
     "question_text": {
       "en": "Which director made Mind Game and Devilman Crybaby?",
       "ja": "マインド・ゲームとDEVILMAN crybabyの監督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55756,7 +56295,8 @@
     "question_text": {
       "en": "Which 2004 anime by Shinichiro Watanabe is set in Edo-period Japan with hip-hop?",
       "ja": "江戸時代にヒップホップを融合した2004年渡辺信一郎作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55796,7 +56336,8 @@
     "question_text": {
       "en": "Which 1998 anime features bounty hunter Spike Spiegel?",
       "ja": "賞金稼ぎのスパイク・スピーゲルが主人公の1998年アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55836,7 +56377,8 @@
     "question_text": {
       "en": "Which 1998 anime features Vash the Stampede on a desert planet?",
       "ja": "砂漠の惑星でヴァッシュ・ザ・スタンピードが活躍する1998年アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55876,7 +56418,8 @@
     "question_text": {
       "en": "Which 1995 anime features Kenshin Himura?",
       "ja": "緋村剣心が主人公の1995年のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55916,7 +56459,8 @@
     "question_text": {
       "en": "Which 1992 anime by Rumiko Takahashi features a half-demon dog hero?",
       "ja": "高橋留美子原作、半妖の少年が主人公の長編アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55956,7 +56500,8 @@
     "question_text": {
       "en": "Which 1989 anime by Rumiko Takahashi is set in Ikkoku-kan apartment?",
       "ja": "一刻館を舞台にした1989年の高橋留美子原作アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55996,7 +56541,8 @@
     "question_text": {
       "en": "Who created Cyborg 009 and Kamen Rider?",
       "ja": "サイボーグ009と仮面ライダーの原作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56036,7 +56582,8 @@
     "question_text": {
       "en": "Who created Mazinger Z and Devilman?",
       "ja": "マジンガーZとデビルマンの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56076,7 +56623,8 @@
     "question_text": {
       "en": "Who created Tetsujin 28-go?",
       "ja": "鉄人28号の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56116,7 +56664,8 @@
     "question_text": {
       "en": "Who wrote Phoenix (Hi no Tori)?",
       "ja": "火の鳥の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56131,7 +56680,7 @@
         "en": "Asao Takamori",
         "ja": "高森朝雄",
         "ja_typings": [
-          "takamorisaoo"
+          "takamoriasao"
         ]
       },
       {
@@ -56156,7 +56705,8 @@
     "question_text": {
       "en": "Who created Tomorrow's Joe?",
       "ja": "あしたのジョーの作画担当は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56196,7 +56746,8 @@
     "question_text": {
       "en": "Who is the author of Touch and Cross Game?",
       "ja": "タッチとクロスゲームの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56236,7 +56787,8 @@
     "question_text": {
       "en": "Who created Captain Tsubasa?",
       "ja": "キャプテン翼の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56276,7 +56828,8 @@
     "question_text": {
       "en": "Who created Galaxy Express 999?",
       "ja": "銀河鉄道999の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56316,7 +56869,8 @@
     "question_text": {
       "en": "Which magazine serialized Touch and H2?",
       "ja": "タッチとH2が連載された雑誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56356,7 +56910,8 @@
     "question_text": {
       "en": "Which magazine serialized Tomorrow's Joe?",
       "ja": "あしたのジョーが連載された雑誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56396,7 +56951,8 @@
     "question_text": {
       "en": "Which publisher releases Shonen Jump?",
       "ja": "週刊少年ジャンプの出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56436,7 +56992,8 @@
     "question_text": {
       "en": "Which publisher releases Shonen Magazine?",
       "ja": "週刊少年マガジンの出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56476,7 +57033,8 @@
     "question_text": {
       "en": "Which publisher releases Shonen Sunday?",
       "ja": "週刊少年サンデーの出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56516,7 +57074,8 @@
     "question_text": {
       "en": "Which publisher releases Shonen Champion?",
       "ja": "週刊少年チャンピオンの出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56556,7 +57115,8 @@
     "question_text": {
       "en": "Who created Astro Boy?",
       "ja": "鉄腕アトムの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56596,7 +57156,8 @@
     "question_text": {
       "en": "Who created Black Jack?",
       "ja": "ブラック・ジャックの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56636,7 +57197,8 @@
     "question_text": {
       "en": "Who created The Rose of Versailles?",
       "ja": "ベルサイユのばらの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56676,7 +57238,8 @@
     "question_text": {
       "en": "Who created The Heart of Thomas?",
       "ja": "トーマの心臓の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56716,7 +57279,8 @@
     "question_text": {
       "en": "Who is the author of Vagabond and Real?",
       "ja": "バガボンドとREALの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56756,7 +57320,8 @@
     "question_text": {
       "en": "Who wrote Pluto and Billy Bat?",
       "ja": "PLUTOとBILLY BATの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56796,7 +57361,8 @@
     "question_text": {
       "en": "Who created Parasyte (Kiseiju)?",
       "ja": "寄生獣の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56836,7 +57402,8 @@
     "question_text": {
       "en": "Who created the manga GTO?",
       "ja": "GTOの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56876,7 +57443,8 @@
     "question_text": {
       "en": "Who created City Hunter?",
       "ja": "シティーハンターの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56916,7 +57484,8 @@
     "question_text": {
       "en": "Who created Crows and Worst?",
       "ja": "クローズとWORSTの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56956,7 +57525,8 @@
     "question_text": {
       "en": "Who created Initial D?",
       "ja": "頭文字Dの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56996,7 +57566,8 @@
     "question_text": {
       "en": "Who created Glass Mask (Garasu no Kamen)?",
       "ja": "ガラスの仮面の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57036,7 +57607,8 @@
     "question_text": {
       "en": "Who created Nodame Cantabile?",
       "ja": "のだめカンタービレの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57076,7 +57648,8 @@
     "question_text": {
       "en": "Who created NANA?",
       "ja": "NANAの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57116,7 +57689,8 @@
     "question_text": {
       "en": "Who created Honey and Clover?",
       "ja": "ハチミツとクローバーの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57156,7 +57730,8 @@
     "question_text": {
       "en": "Who created March Comes in Like a Lion (3-gatsu no Lion)?",
       "ja": "3月のライオンの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57196,7 +57771,8 @@
     "question_text": {
       "en": "Who created Princess Jellyfish (Kuragehime)?",
       "ja": "海月姫の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57236,7 +57812,8 @@
     "question_text": {
       "en": "Who created Yotsuba&!?",
       "ja": "よつばと!の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57276,7 +57853,8 @@
     "question_text": {
       "en": "Who created Oyasumi Punpun?",
       "ja": "おやすみプンプンの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57316,7 +57894,8 @@
     "question_text": {
       "en": "Who created Sunny and Number 5?",
       "ja": "Sunnyとナンバーファイブの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57356,7 +57935,8 @@
     "question_text": {
       "en": "Who created The Walking Man (Aruku Hito)?",
       "ja": "歩くひとの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57396,7 +57976,8 @@
     "question_text": {
       "en": "Who created Children of the Sea (Kaijuu no Kodomo)?",
       "ja": "海獣の子供の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57436,7 +58017,8 @@
     "question_text": {
       "en": "Who is the author of Made in Abyss?",
       "ja": "メイドインアビスの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57476,7 +58058,8 @@
     "question_text": {
       "en": "Who created Tokyo Ghoul?",
       "ja": "東京喰種の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57516,7 +58099,8 @@
     "question_text": {
       "en": "Which magazine serialized Berserk?",
       "ja": "ベルセルクが連載された雑誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57556,7 +58140,8 @@
     "question_text": {
       "en": "Which magazine serialized Vinland Saga?",
       "ja": "ヴィンランド・サガが連載されている雑誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57596,7 +58181,8 @@
     "question_text": {
       "en": "Which company developed the Yakuza/Like a Dragon series?",
       "ja": "龍が如く/ライクアドラゴンを開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57636,7 +58222,8 @@
     "question_text": {
       "en": "Which company developed the 'Yakuza' (Like a Dragon) series?",
       "ja": "『龍が如く』シリーズを開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57676,7 +58263,8 @@
     "question_text": {
       "en": "Which company developed Dark Souls and Bloodborne?",
       "ja": "ダークソウルとブラッドボーンを開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57716,7 +58304,8 @@
     "question_text": {
       "en": "Which company developed the 'Dragon Quest' series?",
       "ja": "『ドラゴンクエスト』シリーズを開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57756,7 +58345,8 @@
     "question_text": {
       "en": "Which company developed Dynasty Warriors?",
       "ja": "真・三國無双を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57796,7 +58386,8 @@
     "question_text": {
       "en": "Which company developed Tales of series?",
       "ja": "テイルズオブシリーズを開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57836,7 +58427,8 @@
     "question_text": {
       "en": "Which company developed Phantasy Star Online?",
       "ja": "ファンタシースターオンラインを開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57876,7 +58468,8 @@
     "question_text": {
       "en": "Which studio created Nier Automata?",
       "ja": "ニーアオートマタを開発したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57916,7 +58509,8 @@
     "question_text": {
       "en": "Which studio developed Bayonetta?",
       "ja": "ベヨネッタを開発したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57956,7 +58550,8 @@
     "question_text": {
       "en": "Which company developed Persona Q and Etrian Odyssey?",
       "ja": "ペルソナQと世界樹の迷宮を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57996,7 +58591,8 @@
     "question_text": {
       "en": "Who is the silent protagonist of Persona 4?",
       "ja": "ペルソナ4の主人公の通称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58036,7 +58632,8 @@
     "question_text": {
       "en": "Which game features the protagonist Kazuma Kiryu?",
       "ja": "桐生一馬が主人公のシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58076,7 +58673,8 @@
     "question_text": {
       "en": "Which game features Ichiban Kasuga as protagonist?",
       "ja": "春日一番が主人公のゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58116,7 +58714,8 @@
     "question_text": {
       "en": "Which 1986 Sega arcade game features pilot Harrier?",
       "ja": "1986年のセガアーケード作品でハリアーが主人公の作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58156,7 +58755,8 @@
     "question_text": {
       "en": "Which 1986 Sega arcade game is a coastal driving game?",
       "ja": "1986年のセガアーケードの海岸線ドライブゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58196,7 +58796,8 @@
     "question_text": {
       "en": "Which 1985 Sega arcade game features motorcycle racing?",
       "ja": "1985年のセガのバイクレースアーケードゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58236,7 +58837,8 @@
     "question_text": {
       "en": "Which Konami series features Solid Snake?",
       "ja": "ソリッド・スネークが主人公のコナミシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58276,7 +58878,8 @@
     "question_text": {
       "en": "Which Konami series is known as Akumajo Dracula in Japan?",
       "ja": "日本で「悪魔城ドラキュラ」と呼ばれるコナミシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58316,7 +58919,8 @@
     "question_text": {
       "en": "Which Konami shooter features a Vic Viper spaceship?",
       "ja": "ビックバイパーが主人公機のコナミシューティングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58356,7 +58960,8 @@
     "question_text": {
       "en": "Which game series features the SaGa Frontier?",
       "ja": "サガフロンティアが属するシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58385,7 +58990,6 @@
         "en": "Soul Blazer",
         "ja": "ソウルブレイダー",
         "ja_typings": [
-          "sorubureida-",
           "sourubureida-"
         ]
       }
@@ -58397,7 +59001,8 @@
     "question_text": {
       "en": "Which 1993 SNES action RPG features the Mana Tree?",
       "ja": "1993年のスーファミでマナの樹が登場するアクションRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58412,7 +59017,6 @@
         "en": "Soul Blazer",
         "ja": "ソウルブレイダー",
         "ja_typings": [
-          "sorubureida-",
           "sourubureida-"
         ]
       },
@@ -58438,7 +59042,8 @@
     "question_text": {
       "en": "Which 1995 SNES action RPG by Quintet is set on a rebuilding Earth?",
       "ja": "1995年クインテット制作で地球再生がテーマのスーファミ作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58478,7 +59083,8 @@
     "question_text": {
       "en": "Which 1986 Capcom platformer features the Red Falcon enemies?",
       "ja": "1986年カプコンの横スクロール作品でレッドファルコンが登場する作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58518,7 +59124,8 @@
     "question_text": {
       "en": "Which 1994 Capcom 2D fighter starts the Darkstalkers series?",
       "ja": "1994年カプコンの2D格闘ゲームでヴァンパイアシリーズ第1作は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58558,7 +59165,8 @@
     "question_text": {
       "en": "Which SNK series features Terry Bogard?",
       "ja": "テリー・ボガードが登場するSNKシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58598,7 +59206,8 @@
     "question_text": {
       "en": "Which SNK series features Ryo Sakazaki?",
       "ja": "坂崎良が主人公のSNKシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58638,7 +59247,8 @@
     "question_text": {
       "en": "Which SNK series features Haohmaru?",
       "ja": "覇王丸が主人公のSNKシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58678,7 +59288,8 @@
     "question_text": {
       "en": "Which 1996 SNK fighter introduced team battle with Kyo Kusanagi?",
       "ja": "草薙京が登場し、チーム制を導入した1996年のSNK格闘は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58718,7 +59329,8 @@
     "question_text": {
       "en": "Which platform was released by SEGA in 1998 as a successor to the Saturn?",
       "ja": "1998年セガがサターンの後継機として発売したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58758,7 +59370,8 @@
     "question_text": {
       "en": "Which platform was released by SNK in 1990?",
       "ja": "1990年にSNKが発売した家庭用ゲーム機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58798,7 +59411,8 @@
     "question_text": {
       "en": "Which platform was released by NEC in 1987?",
       "ja": "1987年にNECが発売した家庭用ゲーム機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58838,7 +59452,8 @@
     "question_text": {
       "en": "Which handheld was released by Bandai in 1999?",
       "ja": "1999年にバンダイが発売した携帯ゲーム機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58878,7 +59493,8 @@
     "question_text": {
       "en": "Which handheld was released by SNK in 1998?",
       "ja": "1998年にSNKが発売した携帯ゲーム機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58918,7 +59534,8 @@
     "question_text": {
       "en": "Which 2017 indie game features Madeline climbing a mountain?",
       "ja": "マデリーンが山を登る2017年のインディーゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58958,7 +59575,8 @@
     "question_text": {
       "en": "Which 2020 Supergiant indie game features Zagreus escaping the Underworld?",
       "ja": "ザグレウスが冥界脱出を目指す2020年のスーパージャイアント作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58998,7 +59616,8 @@
     "question_text": {
       "en": "Which 2017 run-and-gun indie features 1930s cartoon aesthetics?",
       "ja": "1930年代カートゥーン風の2017年ラン&ガンインディーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59038,7 +59657,8 @@
     "question_text": {
       "en": "Which 2014 indie crowdfunded retro platformer features a digging knight?",
       "ja": "2014年クラウドファンディング発のレトロ調アクションで掘る騎士が主人公の作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59078,7 +59698,8 @@
     "question_text": {
       "en": "Which 1998 SquareSoft RPG features Serge and Kid?",
       "ja": "セルジュとキッドが登場する1998年スクウェアのRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59118,7 +59739,8 @@
     "question_text": {
       "en": "Which 1998 Square RPG by Tetsuya Takahashi features Fei Fong Wong?",
       "ja": "1998年スクウェアの高橋哲哉作でフェイ・フォン・ウォンが主人公のRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59158,7 +59780,8 @@
     "question_text": {
       "en": "Which 2000 Square PS1 game by Yasumi Matsuno features Ashley Riot?",
       "ja": "2000年スクウェアの松野泰己作品でアシュレイ・ライオットが主人公のPS1作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59198,7 +59821,8 @@
     "question_text": {
       "en": "Which country has Athens as its capital?",
       "ja": "アテネを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59238,7 +59862,8 @@
     "question_text": {
       "en": "Which country has Budapest as its capital?",
       "ja": "ブダペストを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59278,7 +59903,8 @@
     "question_text": {
       "en": "Which country has Bern as its capital?",
       "ja": "ベルンを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59318,7 +59944,8 @@
     "question_text": {
       "en": "Which country has Dublin as its capital?",
       "ja": "ダブリンを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59358,7 +59985,8 @@
     "question_text": {
       "en": "Which country has Bangkok as its capital?",
       "ja": "バンコクを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59398,7 +60026,8 @@
     "question_text": {
       "en": "Which country has Kuala Lumpur as its capital?",
       "ja": "クアラルンプールを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59438,7 +60067,8 @@
     "question_text": {
       "en": "Which country has Manila as its capital?",
       "ja": "マニラを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59478,7 +60108,8 @@
     "question_text": {
       "en": "Which country has Tehran as its capital?",
       "ja": "テヘランを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59518,7 +60149,8 @@
     "question_text": {
       "en": "Which country has Riyadh as its capital?",
       "ja": "リヤドを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59558,7 +60190,8 @@
     "question_text": {
       "en": "Which country has Addis Ababa as its capital?",
       "ja": "アディスアベバを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59598,7 +60231,8 @@
     "question_text": {
       "en": "Which country has Santiago as its capital?",
       "ja": "サンティアゴを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59638,7 +60272,8 @@
     "question_text": {
       "en": "Which country has Bogota as its capital?",
       "ja": "ボゴタを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59678,7 +60313,8 @@
     "question_text": {
       "en": "Which country has Havana as its capital?",
       "ja": "ハバナを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59718,7 +60354,8 @@
     "question_text": {
       "en": "Which is the longest river in Europe?",
       "ja": "ヨーロッパで最も長い川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59758,7 +60395,8 @@
     "question_text": {
       "en": "Which is the longest river in North America?",
       "ja": "北米で最も長い川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59799,7 +60437,8 @@
     "question_text": {
       "en": "Which is the longest river in China?",
       "ja": "中国で最も長い川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59839,7 +60478,8 @@
     "question_text": {
       "en": "Which mountain range runs through Italy?",
       "ja": "イタリアを縦断する山脈は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59879,7 +60519,8 @@
     "question_text": {
       "en": "Which is the largest desert on Earth?",
       "ja": "地球で最も広い砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59919,7 +60560,8 @@
     "question_text": {
       "en": "Which desert is in Mongolia and China?",
       "ja": "モンゴルと中国にまたがる砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59960,7 +60602,8 @@
     "question_text": {
       "en": "Which is the largest lake in Africa?",
       "ja": "アフリカで最大の湖は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60000,7 +60643,8 @@
     "question_text": {
       "en": "Which peninsula is located in southern Europe and shaped like a boot?",
       "ja": "ブーツ型の南欧の半島は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60040,7 +60684,8 @@
     "question_text": {
       "en": "Which peninsula contains Spain and Portugal?",
       "ja": "スペインとポルトガルがある半島は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60080,7 +60725,8 @@
     "question_text": {
       "en": "Which is the largest island in the Mediterranean?",
       "ja": "地中海最大の島は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60120,7 +60766,8 @@
     "question_text": {
       "en": "Which is the smallest continent?",
       "ja": "最も小さい大陸は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60160,7 +60807,8 @@
     "question_text": {
       "en": "Which sea lies between Europe and Africa?",
       "ja": "ヨーロッパとアフリカの間にある海は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60200,7 +60848,8 @@
     "question_text": {
       "en": "Which is the largest country by area in South America?",
       "ja": "南米で面積最大の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60240,7 +60889,8 @@
     "question_text": {
       "en": "Which is the largest country by area in Africa?",
       "ja": "アフリカで面積最大の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60280,7 +60930,8 @@
     "question_text": {
       "en": "Which country is known as the Land of the Rising Sun?",
       "ja": "「日出ずる国」と呼ばれる国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60320,7 +60971,8 @@
     "question_text": {
       "en": "Which country is shaped like a long thin strip on the west of South America?",
       "ja": "南米西岸で細長い形の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60360,7 +61012,8 @@
     "question_text": {
       "en": "Which country surrounds the Vatican City?",
       "ja": "バチカン市国を囲む国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60382,7 +61035,7 @@
         "en": "Wu Zetian",
         "ja": "武則天",
         "ja_typings": [
-          "sokuten"
+          "busokuten"
         ]
       },
       {
@@ -60400,7 +61053,8 @@
     "question_text": {
       "en": "Who was the first Emperor of unified China?",
       "ja": "中国を初めて統一した皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60440,7 +61094,8 @@
     "question_text": {
       "en": "Who was the first President of the French Republic?",
       "ja": "フランス第二共和政の初代大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60480,7 +61135,8 @@
     "question_text": {
       "en": "Who unified Germany in 1871?",
       "ja": "1871年にドイツを統一した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60520,7 +61176,8 @@
     "question_text": {
       "en": "Who led the Soviet Union during World War II?",
       "ja": "第二次大戦中のソ連指導者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60560,7 +61217,8 @@
     "question_text": {
       "en": "Who was the British Prime Minister during most of WWII?",
       "ja": "第二次大戦中の英首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60600,7 +61258,8 @@
     "question_text": {
       "en": "Who was the US President during WWII?",
       "ja": "第二次大戦中の米大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60640,7 +61299,8 @@
     "question_text": {
       "en": "Who was the first Chancellor of Nazi Germany?",
       "ja": "ナチス・ドイツの最初の首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60680,7 +61340,8 @@
     "question_text": {
       "en": "Who led India's independence movement?",
       "ja": "インド独立運動を率いたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60720,7 +61381,8 @@
     "question_text": {
       "en": "Who became the first Prime Minister of independent India?",
       "ja": "インド独立後の初代首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60760,7 +61422,8 @@
     "question_text": {
       "en": "Who was the first President of South Africa after apartheid?",
       "ja": "南アフリカでアパルトヘイト後初の大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60768,7 +61431,7 @@
         "en": "Ivan IV",
         "ja": "イヴァン四世",
         "ja_typings": [
-          "ivanyonsei"
+          "ivannyonsei"
         ]
       },
       {
@@ -60782,7 +61445,7 @@
         "en": "Boris Godunov",
         "ja": "ゴドゥノフ",
         "ja_typings": [
-          "godunofu"
+          "godwunofu"
         ]
       },
       {
@@ -60800,7 +61463,8 @@
     "question_text": {
       "en": "Who was the first Tsar of Russia?",
       "ja": "ロシア最初のツァーリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60840,7 +61504,8 @@
     "question_text": {
       "en": "Who modernized Russia in the early 18th century?",
       "ja": "18世紀初頭にロシアを近代化した皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60880,7 +61545,8 @@
     "question_text": {
       "en": "Who was Queen of England during the Spanish Armada defeat?",
       "ja": "スペイン無敵艦隊撃退時の英女王は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60920,7 +61586,8 @@
     "question_text": {
       "en": "Who led the Cuban Revolution?",
       "ja": "キューバ革命を率いたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60928,7 +61595,7 @@
         "en": "Augustus",
         "ja": "アウグストゥス",
         "ja_typings": [
-          "augusutusu"
+          "augusutwusu"
         ]
       },
       {
@@ -60960,7 +61627,8 @@
     "question_text": {
       "en": "Who was the first Emperor of Rome?",
       "ja": "ローマ初代皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61000,7 +61668,8 @@
     "question_text": {
       "en": "Who was the Carthaginian general who crossed the Alps?",
       "ja": "アルプスを越えたカルタゴの将軍は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61040,7 +61709,8 @@
     "question_text": {
       "en": "Which dynasty built most of the Great Wall as seen today?",
       "ja": "現在の万里の長城を主に築いた王朝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61080,7 +61750,8 @@
     "question_text": {
       "en": "Which dynasty ruled China just before the Qing?",
       "ja": "清の直前に中国を統治した王朝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61120,7 +61791,8 @@
     "question_text": {
       "en": "Which Japanese era came after Meiji?",
       "ja": "明治の次の時代は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61160,7 +61832,8 @@
     "question_text": {
       "en": "Which Japanese era came after Taisho?",
       "ja": "大正の次の時代は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61189,7 +61862,7 @@
         "en": "Treaty of Brest-Litovsk",
         "ja": "ブレスト・リトフスク条約",
         "ja_typings": [
-          "buresutoritofusukujouyaku"
+          "buresuto/ritofusukujouyaku"
         ]
       }
     ],
@@ -61200,7 +61873,8 @@
     "question_text": {
       "en": "Which treaty ended World War I?",
       "ja": "第一次大戦を終結させた条約は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61240,7 +61914,8 @@
     "question_text": {
       "en": "Which war was fought between 1950 and 1953 on the Korean peninsula?",
       "ja": "1950-1953年に朝鮮半島で起きた戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61280,7 +61955,8 @@
     "question_text": {
       "en": "Which war was fought between US-led forces and Iraq in 1991?",
       "ja": "1991年の米国主導とイラクの戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61320,7 +61996,8 @@
     "question_text": {
       "en": "In which year did the Soviet Union dissolve?",
       "ja": "ソ連が崩壊した年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61360,7 +62037,8 @@
     "question_text": {
       "en": "In which year did Columbus reach the Americas?",
       "ja": "コロンブスが新大陸に到達した年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61400,7 +62078,8 @@
     "question_text": {
       "en": "Which civilization is credited with inventing cuneiform writing?",
       "ja": "楔形文字を発明したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61440,7 +62119,8 @@
     "question_text": {
       "en": "Which ancient empire was led by Cyrus the Great?",
       "ja": "キュロス大王が築いた古代帝国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61481,7 +62161,8 @@
     "question_text": {
       "en": "Which empire fell in 1453 with the fall of Constantinople?",
       "ja": "1453年に滅亡した帝国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61522,7 +62203,8 @@
     "question_text": {
       "en": "Which empire captured Constantinople in 1453?",
       "ja": "1453年にコンスタンティノープルを陥落させたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61562,7 +62244,8 @@
     "question_text": {
       "en": "Who invented the printing press in Europe?",
       "ja": "ヨーロッパで活版印刷を発明したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61602,7 +62285,8 @@
     "question_text": {
       "en": "Who invented the telephone?",
       "ja": "電話を発明したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61642,7 +62326,8 @@
     "question_text": {
       "en": "Who invented the light bulb commercially?",
       "ja": "白熱電球を商用化したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61682,7 +62367,8 @@
     "question_text": {
       "en": "Who invented dynamite?",
       "ja": "ダイナマイトを発明したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61722,7 +62408,8 @@
     "question_text": {
       "en": "Which religious reformer launched the Protestant Reformation in 1517?",
       "ja": "1517年に宗教改革を始めたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61762,7 +62449,8 @@
     "question_text": {
       "en": "Which French king was beheaded during the French Revolution?",
       "ja": "フランス革命で処刑されたフランス王は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61802,7 +62490,8 @@
     "question_text": {
       "en": "Which French king was called the Sun King?",
       "ja": "「太陽王」と呼ばれたフランス王は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61824,7 +62513,7 @@
         "en": "Batu Khan",
         "ja": "バトゥ",
         "ja_typings": [
-          "batu"
+          "batwu"
         ]
       },
       {
@@ -61842,7 +62531,8 @@
     "question_text": {
       "en": "Which Mongol leader conquered Baghdad in 1258?",
       "ja": "1258年にバグダードを陥落させたモンゴル指導者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61882,7 +62572,8 @@
     "question_text": {
       "en": "Which queen ruled both England and Scotland from 1702?",
       "ja": "1702年から英国とスコットランドを統治した女王は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61922,7 +62613,8 @@
     "question_text": {
       "en": "Which Japanese general led the attack on Pearl Harbor planning?",
       "ja": "真珠湾攻撃を立案した日本の提督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61962,7 +62654,8 @@
     "question_text": {
       "en": "Which conflict was triggered by the assassination of Archduke Franz Ferdinand?",
       "ja": "フランツ・フェルディナント大公暗殺が引き金となった戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62002,7 +62695,8 @@
     "question_text": {
       "en": "What is the chemical symbol for tungsten?",
       "ja": "タングステンの元素記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62042,7 +62736,8 @@
     "question_text": {
       "en": "Which gas makes up about 78% of Earth's atmosphere?",
       "ja": "地球の大気の約78%を占める気体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62082,7 +62777,8 @@
     "question_text": {
       "en": "Which gas is most responsible for global warming from human activity?",
       "ja": "人為的温暖化の主因となる気体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62122,7 +62818,8 @@
     "question_text": {
       "en": "What is the lightest metal?",
       "ja": "最も軽い金属は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62137,7 +62834,7 @@
         "en": "Uranus",
         "ja": "天王星",
         "ja_typings": [
-          "tennousei"
+          "tennnousei"
         ]
       },
       {
@@ -62162,7 +62859,8 @@
     "question_text": {
       "en": "Which planet has the most moons?",
       "ja": "最も多くの衛星を持つ惑星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62202,7 +62900,8 @@
     "question_text": {
       "en": "Which planet has the Great Red Spot?",
       "ja": "大赤斑がある惑星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62242,7 +62941,8 @@
     "question_text": {
       "en": "Which planet is known as the Red Planet?",
       "ja": "「赤い惑星」と呼ばれるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62257,7 +62957,7 @@
         "en": "Uranus",
         "ja": "天王星",
         "ja_typings": [
-          "tennousei"
+          "tennnousei"
         ]
       },
       {
@@ -62282,7 +62982,8 @@
     "question_text": {
       "en": "Which planet is the farthest from the Sun (recognized as a planet)?",
       "ja": "太陽系で最遠の惑星(認定されたもの)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62322,7 +63023,8 @@
     "question_text": {
       "en": "Which is the largest moon in the solar system?",
       "ja": "太陽系最大の衛星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62337,7 +63039,7 @@
         "en": "Enceladus",
         "ja": "エンケラドゥス",
         "ja_typings": [
-          "enkeradusu"
+          "enkeradwusu"
         ]
       },
       {
@@ -62362,7 +63064,8 @@
     "question_text": {
       "en": "Which moon of Saturn has a thick atmosphere?",
       "ja": "厚い大気を持つ土星の衛星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62402,7 +63105,8 @@
     "question_text": {
       "en": "Who proposed the heliocentric model of the solar system?",
       "ja": "地動説を唱えたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62442,7 +63146,8 @@
     "question_text": {
       "en": "Who formulated the three laws of planetary motion?",
       "ja": "惑星運動の三法則を導いたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62482,7 +63187,8 @@
     "question_text": {
       "en": "Who proposed that current flows in a magnetic field induces force?",
       "ja": "電流に磁場が力を及ぼすことを示したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62522,7 +63228,8 @@
     "question_text": {
       "en": "Who discovered electromagnetic induction?",
       "ja": "電磁誘導を発見したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62562,7 +63269,8 @@
     "question_text": {
       "en": "Who unified electricity and magnetism into a single theory?",
       "ja": "電気と磁気を統一理論にまとめたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62602,7 +63310,8 @@
     "question_text": {
       "en": "Who discovered the structure of DNA along with Watson?",
       "ja": "ワトソンとともにDNA構造を解明したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62642,7 +63351,8 @@
     "question_text": {
       "en": "Who is considered the father of modern chemistry?",
       "ja": "近代化学の父と呼ばれるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62682,7 +63392,8 @@
     "question_text": {
       "en": "Who created the periodic table of elements?",
       "ja": "元素周期表を作ったのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62722,7 +63433,8 @@
     "question_text": {
       "en": "Who developed the atomic theory of matter?",
       "ja": "原子論を提唱したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62762,7 +63474,8 @@
     "question_text": {
       "en": "Who discovered the electron?",
       "ja": "電子を発見したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62802,7 +63515,8 @@
     "question_text": {
       "en": "Who discovered the atomic nucleus?",
       "ja": "原子核を発見したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62842,7 +63556,8 @@
     "question_text": {
       "en": "Who discovered the neutron?",
       "ja": "中性子を発見したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62882,7 +63597,8 @@
     "question_text": {
       "en": "What is the SI unit of electric current?",
       "ja": "電流のSI単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62922,7 +63638,8 @@
     "question_text": {
       "en": "What is the SI unit of frequency?",
       "ja": "周波数のSI単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62962,7 +63679,8 @@
     "question_text": {
       "en": "What is the SI unit of pressure?",
       "ja": "圧力のSI単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63002,7 +63720,8 @@
     "question_text": {
       "en": "What is the SI unit of energy?",
       "ja": "エネルギーのSI単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63042,7 +63761,8 @@
     "question_text": {
       "en": "What is the SI unit of force?",
       "ja": "力のSI単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63082,7 +63802,8 @@
     "question_text": {
       "en": "What is the largest organ of the human body?",
       "ja": "人体最大の臓器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63122,7 +63843,8 @@
     "question_text": {
       "en": "Which blood cells carry oxygen?",
       "ja": "酸素を運ぶ血球は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63162,7 +63884,8 @@
     "question_text": {
       "en": "Which scale measures mineral hardness?",
       "ja": "鉱物硬度の尺度は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63202,7 +63925,8 @@
     "question_text": {
       "en": "Which phenomenon causes the bending of light passing through different media?",
       "ja": "媒質間で光が曲がる現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63242,7 +63966,8 @@
     "question_text": {
       "en": "What is the smallest non-abelian group?",
       "ja": "最小の非可換群はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63282,7 +64007,8 @@
     "question_text": {
       "en": "Which conjecture concerns prime gaps of 2?",
       "ja": "素数の差が2となる予想はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63324,7 +64050,8 @@
     "question_text": {
       "en": "Which structure has both addition and multiplication?",
       "ja": "加法と乗法を両方持つ代数構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63364,7 +64091,8 @@
     "question_text": {
       "en": "What is a manifold locally homeomorphic to?",
       "ja": "多様体は局所的に何と同相?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63404,7 +64132,8 @@
     "question_text": {
       "en": "Which number system extends complex numbers to 4D?",
       "ja": "複素数を4次元に拡張した数体系は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63444,7 +64173,8 @@
     "question_text": {
       "en": "Which theorem relates Euler characteristic to genus?",
       "ja": "オイラー標数と種数を結ぶ定理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63484,7 +64214,8 @@
     "question_text": {
       "en": "Which problem asks if P equals NP?",
       "ja": "PとNPが等しいかを問う問題は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63524,7 +64255,8 @@
     "question_text": {
       "en": "What is a non-trivial example of a fractal dimension?",
       "ja": "非自明なフラクタル次元の例は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63546,7 +64278,7 @@
         "en": "MST",
         "ja": "最小全域木問題",
         "ja_typings": [
-          "saishouzennnikimondai"
+          "saishouzennikimondai"
         ]
       },
       {
@@ -63564,7 +64296,8 @@
     "question_text": {
       "en": "Which graph problem is NP-complete?",
       "ja": "NP完全のグラフ問題は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63604,7 +64337,8 @@
     "question_text": {
       "en": "What is the cardinality of the continuum?",
       "ja": "連続体の濃度の記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63644,7 +64378,8 @@
     "question_text": {
       "en": "Which set is uncountable?",
       "ja": "非可算集合はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63684,7 +64419,8 @@
     "question_text": {
       "en": "Which group describes symmetries of a tetrahedron?",
       "ja": "正四面体の対称群は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63699,7 +64435,7 @@
         "en": "metric spaces only",
         "ja": "距離空間のみ",
         "ja_typings": [
-          "kyorikuukannnomi"
+          "kyorikuukannomi"
         ]
       },
       {
@@ -63724,7 +64460,8 @@
     "question_text": {
       "en": "What is the formal definition of a continuous map between?",
       "ja": "連続写像が定義される対象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63764,7 +64501,8 @@
     "question_text": {
       "en": "Which constant appears in the prime number theorem?",
       "ja": "素数定理に現れる関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63804,7 +64542,8 @@
     "question_text": {
       "en": "Which structure is used in elliptic curve cryptography?",
       "ja": "楕円曲線暗号で用いる構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63844,7 +64583,8 @@
     "question_text": {
       "en": "What is a key concept in category theory?",
       "ja": "圏論の中心概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63866,7 +64606,7 @@
         "en": "Jensen",
         "ja": "イェンセンの不等式",
         "ja_typings": [
-          "iensennnofutoushiki"
+          "iensennofutoushiki"
         ]
       },
       {
@@ -63884,7 +64624,8 @@
     "question_text": {
       "en": "Which inequality bounds variance and expectation?",
       "ja": "分散と期待値を結ぶ不等式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63924,7 +64665,8 @@
     "question_text": {
       "en": "Which distribution describes rare events?",
       "ja": "稀な事象を表す分布は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63964,7 +64706,8 @@
     "question_text": {
       "en": "Which lemma is essential in homological algebra?",
       "ja": "ホモロジー代数で重要な補題は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64004,7 +64747,8 @@
     "question_text": {
       "en": "What is a Mobius strip an example of?",
       "ja": "メビウスの帯は何の例?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64044,7 +64788,8 @@
     "question_text": {
       "en": "Which equation governs heat diffusion?",
       "ja": "熱拡散を表す方程式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64084,7 +64829,8 @@
     "question_text": {
       "en": "Which method numerically solves ODEs?",
       "ja": "常微分方程式の数値解法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64124,7 +64870,8 @@
     "question_text": {
       "en": "What problem is associated with the Konigsberg bridges?",
       "ja": "ケーニヒスベルクの橋に関する問題は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64164,7 +64911,8 @@
     "question_text": {
       "en": "Which transform converts time to frequency domain?",
       "ja": "時間領域を周波数領域に変換する手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64204,7 +64952,8 @@
     "question_text": {
       "en": "Which space is complete and inner-product?",
       "ja": "完備かつ内積を持つ空間は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64244,7 +64993,8 @@
     "question_text": {
       "en": "Which Millennium Prize problem was solved?",
       "ja": "ミレニアム懸賞問題で解決済みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64284,7 +65034,8 @@
     "question_text": {
       "en": "Which sequence is used in cryptographic hashing?",
       "ja": "暗号ハッシュの基礎となる数列は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64324,7 +65075,8 @@
     "question_text": {
       "en": "Which game theory concept is a stable strategy?",
       "ja": "ゲーム理論で安定戦略を示す概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64364,7 +65116,8 @@
     "question_text": {
       "en": "Which curve is defined by y squared equals x cubed plus ax plus b?",
       "ja": "y² = x³+ax+b で定義される曲線は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64404,7 +65157,8 @@
     "question_text": {
       "en": "Which paradox involves a set of all sets?",
       "ja": "全集合の集合に関するパラドックスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64444,7 +65198,8 @@
     "question_text": {
       "en": "What does the four-character idiom 'isseki nichou' mean?",
       "ja": "四字熟語『一石二鳥』の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64484,7 +65239,8 @@
     "question_text": {
       "en": "Which constellation contains Betelgeuse?",
       "ja": "ベテルギウスを含む星座は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64524,7 +65280,8 @@
     "question_text": {
       "en": "What unit measures luminous intensity?",
       "ja": "光度の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64564,7 +65321,8 @@
     "question_text": {
       "en": "What does the idiom 'neko no te mo karitai' express?",
       "ja": "『猫の手も借りたい』が表す状況は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64604,7 +65362,8 @@
     "question_text": {
       "en": "Which family crest depicts three hollyhock leaves?",
       "ja": "三つ葉葵を描く家紋を使った家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64644,7 +65403,8 @@
     "question_text": {
       "en": "What is the SI unit of magnetic flux?",
       "ja": "磁束のSI単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64684,7 +65444,8 @@
     "question_text": {
       "en": "Which zodiac sign is represented by scales?",
       "ja": "天秤で表される星座は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64713,7 +65474,7 @@
         "en": "Naval Astronautics Society Association",
         "ja": "海軍宇宙協会",
         "ja_typings": [
-          "kaiguniuchuukyoukai"
+          "kaigunnuchuukyoukai"
         ]
       }
     ],
@@ -64724,7 +65485,8 @@
     "question_text": {
       "en": "What does NASA stand for?",
       "ja": "NASAは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64764,7 +65526,8 @@
     "question_text": {
       "en": "Which idiom means inseparable friends?",
       "ja": "切っても切れない友を意味するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64804,7 +65567,8 @@
     "question_text": {
       "en": "What unit measures sound intensity level?",
       "ja": "音の強さレベルの単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64844,7 +65608,8 @@
     "question_text": {
       "en": "What does ISBN identify?",
       "ja": "ISBNが識別するものは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64884,7 +65649,8 @@
     "question_text": {
       "en": "Which constellation contains the North Star?",
       "ja": "北極星を含む星座は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64924,7 +65690,8 @@
     "question_text": {
       "en": "What does 'gashin shoutan' mean?",
       "ja": "『臥薪嘗胆』の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64964,7 +65731,8 @@
     "question_text": {
       "en": "Which heraldic charge represents a lion standing?",
       "ja": "立ち上がるライオンを表す紋章用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65004,7 +65772,8 @@
     "question_text": {
       "en": "What unit measures radiation exposure?",
       "ja": "放射線被曝量の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65044,7 +65813,8 @@
     "question_text": {
       "en": "Which idiom describes a perfect match?",
       "ja": "完璧な組合せを表す四字熟語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65084,7 +65854,8 @@
     "question_text": {
       "en": "What does the word 'tsundoku' describe?",
       "ja": "『積ん読』が表すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65106,7 +65877,7 @@
         "en": "Arcturus",
         "ja": "アルクトゥルス",
         "ja_typings": [
-          "arukuturusu"
+          "arukutwurusu"
         ]
       },
       {
@@ -65124,7 +65895,8 @@
     "question_text": {
       "en": "Which star is the brightest in the night sky?",
       "ja": "夜空で最も明るい恒星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65164,7 +65936,8 @@
     "question_text": {
       "en": "What does 'wabi sabi' express in aesthetics?",
       "ja": "美学の『侘び寂び』が表すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65204,7 +65977,8 @@
     "question_text": {
       "en": "Which unit measures atmospheric pressure?",
       "ja": "気圧の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65233,7 +66007,7 @@
         "en": "good and evil",
         "ja": "善悪",
         "ja_typings": [
-          "zenaku"
+          "zennaku"
         ]
       }
     ],
@@ -65244,7 +66018,8 @@
     "question_text": {
       "en": "What does the Yin-Yang symbol represent?",
       "ja": "陰陽のシンボルが表すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65284,7 +66059,8 @@
     "question_text": {
       "en": "Which Japanese fan crest is associated with the Asai clan?",
       "ja": "浅井家の家紋は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65324,7 +66100,8 @@
     "question_text": {
       "en": "What does the idiom 'gyokuseki konkou' mean?",
       "ja": "『玉石混淆』の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65364,7 +66141,8 @@
     "question_text": {
       "en": "What unit measures the speed of computer operations?",
       "ja": "コンピュータ演算速度の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65404,7 +66182,8 @@
     "question_text": {
       "en": "Which constellation is shaped like a W?",
       "ja": "Wの形をした星座は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65444,7 +66223,8 @@
     "question_text": {
       "en": "What does WHO stand for?",
       "ja": "WHOの略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65452,7 +66232,7 @@
         "en": "nou aru taka wa tsume wo kakusu",
         "ja": "能ある鷹は爪を隠す",
         "ja_typings": [
-          "nouarutakawatsumewokakusu"
+          "nouarutakahatsumewokakusu"
         ]
       },
       {
@@ -65484,7 +66264,8 @@
     "question_text": {
       "en": "Which idiom describes hidden talents?",
       "ja": "隠れた才能を表す慣用句は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65524,7 +66305,8 @@
     "question_text": {
       "en": "Which mineral has hardness 10 on the Mohs scale?",
       "ja": "モース硬度10の鉱物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65564,7 +66346,8 @@
     "question_text": {
       "en": "What does the family crest 'agehacho' depict?",
       "ja": "家紋『揚羽蝶』が描くのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65604,7 +66387,8 @@
     "question_text": {
       "en": "Who is known as the first virtual YouTuber?",
       "ja": "初代バーチャルYouTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65644,7 +66428,8 @@
     "question_text": {
       "en": "Which VTuber agency is operated by Anycolor?",
       "ja": "Anycolor運営のVTuber事務所は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65684,7 +66469,8 @@
     "question_text": {
       "en": "What does 'kusa' mean in Japanese net slang?",
       "ja": "ネットスラング『草』の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65724,7 +66510,8 @@
     "question_text": {
       "en": "What is a 'Discord raid'?",
       "ja": "『Discord荒らし』とは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65764,7 +66551,8 @@
     "question_text": {
       "en": "Which term means 'lurker' in Twitch chat?",
       "ja": "Twitchチャットで『見るだけの人』を意味するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65804,7 +66592,8 @@
     "question_text": {
       "en": "What does 'AFK' stand for?",
       "ja": "『AFK』の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65844,7 +66633,8 @@
     "question_text": {
       "en": "Which Discord bot is famous for music streaming (before shutdown)?",
       "ja": "音楽配信で有名だったDiscordボット(閉鎖済)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65884,7 +66674,8 @@
     "question_text": {
       "en": "What does 'pepega' refer to in Twitch culture?",
       "ja": "Twitch文化での『pepega』は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65924,7 +66715,8 @@
     "question_text": {
       "en": "What is 'doxxing'?",
       "ja": "『ドキシング』とは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65964,7 +66756,8 @@
     "question_text": {
       "en": "Which slang phrase originated from 2channel for 'has been a while'?",
       "ja": "2ちゃん発祥の『久しぶり』系スラングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66004,7 +66797,8 @@
     "question_text": {
       "en": "What does the meme 'Big Brain' express?",
       "ja": "ミーム『Big Brain』の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66044,7 +66838,8 @@
     "question_text": {
       "en": "Which Hololive member is known as the shark girl?",
       "ja": "サメ少女として知られるホロメンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66052,7 +66847,7 @@
         "en": "amazed reaction",
         "ja": "驚嘆の反応",
         "ja_typings": [
-          "kyoutannohannou"
+          "kyoutannohannnou"
         ]
       },
       {
@@ -66084,7 +66879,8 @@
     "question_text": {
       "en": "What does 'POG' mean in stream chat?",
       "ja": "配信チャットの『POG』の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66124,7 +66920,8 @@
     "question_text": {
       "en": "Which term refers to a Twitch streamer's loyal viewers?",
       "ja": "Twitch配信者の常連視聴者を指す語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66164,7 +66961,8 @@
     "question_text": {
       "en": "What is a 'copypasta'?",
       "ja": "『コピペ』とは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66204,7 +67002,8 @@
     "question_text": {
       "en": "Which slang means 'crying with laughter' as kaomoji-like?",
       "ja": "笑い泣きを表す日本のネット表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66244,7 +67043,8 @@
     "question_text": {
       "en": "Which Vtuber created the song 'Hyperdontia'?",
       "ja": "『Hyperdontia』を歌ったVtuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66284,7 +67084,8 @@
     "question_text": {
       "en": "What is 'shadowbanning'?",
       "ja": "『シャドウバン』とは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66324,7 +67125,8 @@
     "question_text": {
       "en": "What does 'Kappa' represent in Twitch chat?",
       "ja": "Twitchの『Kappa』エモートは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66332,7 +67134,6 @@
         "en": "5channel",
         "ja": "5ちゃんねる",
         "ja_typings": [
-          "gochanneru",
           "5channneru"
         ]
       },
@@ -66365,7 +67166,8 @@
     "question_text": {
       "en": "Which platform did 2channel evolve into?",
       "ja": "2ちゃんねるが進化したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66405,7 +67207,8 @@
     "question_text": {
       "en": "What does the meme 'F in chat' express?",
       "ja": "ミーム『F in chat』の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66445,7 +67248,8 @@
     "question_text": {
       "en": "Which Nijisanji liver is known as the demon lord?",
       "ja": "にじさんじで魔王として知られるライバーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66485,7 +67289,8 @@
     "question_text": {
       "en": "What is 'stream sniping'?",
       "ja": "『ストリームスナイプ』とは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66493,7 +67298,7 @@
         "en": "one of my mutuals",
         "ja": "相互フォロワー",
         "ja_typings": [
-          "sougofororowa-"
+          "sougoforowa-"
         ]
       },
       {
@@ -66525,7 +67330,8 @@
     "question_text": {
       "en": "What does 'OOMfie' refer to on Twitter?",
       "ja": "X(Twitter)の『OOMfie』は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66565,7 +67371,8 @@
     "question_text": {
       "en": "Which Vtuber graduation event is called 'sotsugyou'?",
       "ja": "Vtuberが活動終了することを何という?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66605,7 +67412,8 @@
     "question_text": {
       "en": "Which meme features Drake approving/disapproving?",
       "ja": "Drakeが承認/否認するミームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66645,7 +67453,8 @@
     "question_text": {
       "en": "What does 'mukoukotsu' mean in net slang?",
       "ja": "ネット用語『無向骨』に近い意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66685,7 +67494,8 @@
     "question_text": {
       "en": "Which Discord feature allows server moderation?",
       "ja": "Discordでサーバー管理に使う機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66707,7 +67517,7 @@
         "en": "disgust",
         "ja": "嫌悪",
         "ja_typings": [
-          "keno"
+          "kennno"
         ]
       },
       {
@@ -66725,7 +67535,8 @@
     "question_text": {
       "en": "What does 'KEKW' express in Twitch chat?",
       "ja": "Twitchの『KEKW』が表すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66765,7 +67576,8 @@
     "question_text": {
       "en": "Which Hololive branch is JP-based original first gen?",
       "ja": "ホロライブJP初代1期生に属するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66805,7 +67617,8 @@
     "question_text": {
       "en": "Which protocol is the successor of HTTP/2 over QUIC?",
       "ja": "QUICベースのHTTP後継プロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66845,7 +67658,8 @@
     "question_text": {
       "en": "Which routing protocol uses link-state?",
       "ja": "リンクステート方式のルーティングプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66885,7 +67699,8 @@
     "question_text": {
       "en": "Which storage interface is replacing SATA SSDs?",
       "ja": "SATA SSDを置き換えつつある規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66925,7 +67740,8 @@
     "question_text": {
       "en": "Which port standard supports Thunderbolt 4?",
       "ja": "Thunderbolt 4が使う物理コネクタは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66965,7 +67781,8 @@
     "question_text": {
       "en": "Which display interface supports 8K at 60Hz?",
       "ja": "8K60Hz対応のディスプレイ規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67005,7 +67822,8 @@
     "question_text": {
       "en": "Which protocol resolves MAC from IP?",
       "ja": "IPからMACを解決するプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67045,7 +67863,8 @@
     "question_text": {
       "en": "Which protocol carries ping packets?",
       "ja": "pingが使うプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67085,7 +67904,8 @@
     "question_text": {
       "en": "Which CPU architecture is open source?",
       "ja": "オープンソースなCPUアーキテクチャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67125,7 +67945,8 @@
     "question_text": {
       "en": "Which GPU API is from Khronos for low-overhead access?",
       "ja": "Khronos策定の低オーバーヘッドGPU APIは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67133,7 +67954,7 @@
         "en": "802.11ax extended",
         "ja": "802.11ax拡張",
         "ja_typings": [
-          "8021axkakuchou"
+          "802.11axkakuchou"
         ]
       },
       {
@@ -67165,7 +67986,8 @@
     "question_text": {
       "en": "Which wireless standard is also called WiFi 6E?",
       "ja": "WiFi 6Eの正式名称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67205,7 +68027,8 @@
     "question_text": {
       "en": "Which Bluetooth profile is used for hands-free calls?",
       "ja": "ハンズフリー通話のBluetoothプロファイルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67245,7 +68068,8 @@
     "question_text": {
       "en": "Which encryption algorithm replaced DES?",
       "ja": "DESを置き換えた暗号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67285,7 +68109,8 @@
     "question_text": {
       "en": "Which key exchange uses elliptic curves?",
       "ja": "楕円曲線を使う鍵交換は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67325,7 +68150,8 @@
     "question_text": {
       "en": "Which protocol enables peer-to-peer browser communication?",
       "ja": "ブラウザ間P2P通信を可能にするのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67365,7 +68191,8 @@
     "question_text": {
       "en": "Which input device uses pressure-sensitive stylus?",
       "ja": "筆圧感知ペンを使う入力機器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67405,7 +68232,8 @@
     "question_text": {
       "en": "Which file system is default on modern macOS?",
       "ja": "現代のmacOSの標準ファイルシステムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67445,7 +68273,8 @@
     "question_text": {
       "en": "Which RAID level provides striping with parity?",
       "ja": "ストライピング+パリティのRAIDレベルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67485,7 +68314,8 @@
     "question_text": {
       "en": "Which BGP attribute determines best path?",
       "ja": "BGP最適経路を決める属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67525,7 +68355,8 @@
     "question_text": {
       "en": "Which display tech uses self-emitting pixels?",
       "ja": "自発光画素を使うディスプレイは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67565,7 +68396,8 @@
     "question_text": {
       "en": "Which BIOS replacement uses GPT partitions?",
       "ja": "GPTパーティションを使うBIOS後継は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67605,7 +68437,8 @@
     "question_text": {
       "en": "Which protocol is used for time synchronization?",
       "ja": "時刻同期に使うプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67645,7 +68478,8 @@
     "question_text": {
       "en": "Which network device operates at OSI layer 3?",
       "ja": "OSI第3層で動作する機器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67667,7 +68501,7 @@
         "en": "Coaxial",
         "ja": "同軸ケーブル",
         "ja_typings": [
-          "doujike-buru"
+          "doujikuke-buru"
         ]
       },
       {
@@ -67685,7 +68519,8 @@
     "question_text": {
       "en": "Which cable type uses fiber optics?",
       "ja": "光ファイバを使うケーブルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67725,7 +68560,8 @@
     "question_text": {
       "en": "Which CPU instruction set is used in Apple Silicon?",
       "ja": "Apple Siliconが採用する命令セットは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67765,7 +68601,8 @@
     "question_text": {
       "en": "Which hash function is part of SHA-3?",
       "ja": "SHA-3の基礎関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67805,7 +68642,8 @@
     "question_text": {
       "en": "Which port number does SSH use?",
       "ja": "SSHが使うポート番号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67845,7 +68683,8 @@
     "question_text": {
       "en": "Which container format is OCI standard?",
       "ja": "OCI標準のコンテナ形式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67885,7 +68724,8 @@
     "question_text": {
       "en": "Which GPU vendor created CUDA?",
       "ja": "CUDAを開発したGPUベンダは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67925,7 +68765,8 @@
     "question_text": {
       "en": "Which key concept allows VLANs over WAN?",
       "ja": "WAN越しにVLANを実現する技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67965,7 +68806,8 @@
     "question_text": {
       "en": "Which CPU feature accelerates virtualization?",
       "ja": "仮想化を加速するCPU機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68005,7 +68847,8 @@
     "question_text": {
       "en": "Which GitOps tool is part of CNCF?",
       "ja": "CNCFのGitOpsツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68045,7 +68888,8 @@
     "question_text": {
       "en": "Which service mesh is created by Buoyant?",
       "ja": "Buoyant社のサービスメッシュは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68085,7 +68929,8 @@
     "question_text": {
       "en": "Which standard unifies observability data?",
       "ja": "可観測性データを統一する標準は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68125,7 +68970,8 @@
     "question_text": {
       "en": "Which Linux feature allows safe kernel programmability?",
       "ja": "Linuxカーネルを安全に拡張する機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68133,7 +68979,7 @@
         "en": "Financial Operations",
         "ja": "クラウド財務運用",
         "ja_typings": [
-          "kuraudozaimuunyou"
+          "kuraudozaimuunnyou"
         ]
       },
       {
@@ -68165,7 +69011,8 @@
     "question_text": {
       "en": "What does FinOps stand for?",
       "ja": "FinOpsの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68205,7 +69052,8 @@
     "question_text": {
       "en": "Which agile framework uses sprints?",
       "ja": "スプリントを使うアジャイル手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68245,7 +69093,8 @@
     "question_text": {
       "en": "What does SLO stand for?",
       "ja": "SLOの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68285,7 +69134,8 @@
     "question_text": {
       "en": "Which testing technique tries unexpected inputs?",
       "ja": "予期しない入力を試すテスト技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68325,7 +69175,8 @@
     "question_text": {
       "en": "Which serverless runtime is by AWS?",
       "ja": "AWSのサーバーレス基盤は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68365,7 +69216,8 @@
     "question_text": {
       "en": "What does MTTR mean in SRE?",
       "ja": "SREの『MTTR』は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68405,7 +69257,8 @@
     "question_text": {
       "en": "Which methodology emphasizes blameless postmortems?",
       "ja": "ブレームレスを重視する手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68445,7 +69298,8 @@
     "question_text": {
       "en": "Which CI/CD service is built into GitHub?",
       "ja": "GitHub内蔵のCI/CDは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68485,7 +69339,8 @@
     "question_text": {
       "en": "What does TDD stand for?",
       "ja": "TDDの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68525,7 +69380,8 @@
     "question_text": {
       "en": "Which container orchestrator was open-sourced by Google?",
       "ja": "Google発のコンテナオーケストレータは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68565,7 +69421,8 @@
     "question_text": {
       "en": "Which DevOps pattern reduces deployment risk by gradual rollout?",
       "ja": "段階的展開でリスク低減するパターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68605,7 +69462,8 @@
     "question_text": {
       "en": "Which IaC tool uses HCL?",
       "ja": "HCLを使うIaCツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68645,7 +69503,8 @@
     "question_text": {
       "en": "What does the term 'shift left' mean?",
       "ja": "『シフトレフト』の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68660,7 +69519,7 @@
         "en": "Operations Key Reports",
         "ja": "運用報告",
         "ja_typings": [
-          "unyouhoukoku"
+          "unnyouhoukoku"
         ]
       },
       {
@@ -68685,7 +69544,8 @@
     "question_text": {
       "en": "Which framework defines OKRs?",
       "ja": "OKRsを定める枠組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68725,7 +69585,8 @@
     "question_text": {
       "en": "Which retrospective format uses ports?",
       "ja": "ポート(港)を使うレトロスペクティブは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68765,7 +69626,8 @@
     "question_text": {
       "en": "What is a feature flag?",
       "ja": "フィーチャーフラグとは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68805,7 +69667,8 @@
     "question_text": {
       "en": "Which methodology limits work in progress?",
       "ja": "進行中作業を制限する手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68845,7 +69708,8 @@
     "question_text": {
       "en": "Which test isolates a single function?",
       "ja": "単一機能を分離して試すテストは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68885,7 +69749,8 @@
     "question_text": {
       "en": "Which platform offers managed K8s by Google?",
       "ja": "Google提供のマネージドK8sは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68893,7 +69758,7 @@
         "en": "intentional failure injection",
         "ja": "意図的障害注入",
         "ja_typings": [
-          "itotekishougainyuunyuu"
+          "itotekishougaichuunyuu"
         ]
       },
       {
@@ -68925,7 +69790,8 @@
     "question_text": {
       "en": "What is 'chaos engineering' about?",
       "ja": "カオスエンジニアリングとは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68954,7 +69820,6 @@
         "en": "shadow deployment",
         "ja": "シャドウデプロイ",
         "ja_typings": [
-          "shadodepuroi",
           "shadoudepuroi"
         ]
       }
@@ -68966,7 +69831,8 @@
     "question_text": {
       "en": "Which deployment uses identical environment swap?",
       "ja": "同一環境を切り替える展開は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69006,7 +69872,8 @@
     "question_text": {
       "en": "Which architecture decomposes apps into small services?",
       "ja": "アプリを小サービスに分解する設計は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69046,7 +69913,8 @@
     "question_text": {
       "en": "What is a SLA?",
       "ja": "SLAとは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69086,7 +69954,8 @@
     "question_text": {
       "en": "Which testing examines security flaws?",
       "ja": "セキュリティ欠陥を調べるテストは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69126,7 +69995,8 @@
     "question_text": {
       "en": "Which manifest tool packages K8s apps?",
       "ja": "K8sアプリをパッケージ化するツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69166,7 +70036,8 @@
     "question_text": {
       "en": "What is a 'sidecar' pattern in K8s?",
       "ja": "K8sの『サイドカー』パターンとは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69174,7 +70045,7 @@
         "en": "ergative case",
         "ja": "能格",
         "ja_typings": [
-          "nougaku"
+          "noukaku"
         ]
       },
       {
@@ -69206,7 +70077,8 @@
     "question_text": {
       "en": "Which case marks the subject of a transitive verb in ergative languages?",
       "ja": "能格言語で他動詞の主語を表す格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69246,7 +70118,8 @@
     "question_text": {
       "en": "Which writing system uses consonant-vowel syllables?",
       "ja": "子音+母音の音節を表す文字体系は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69286,7 +70159,8 @@
     "question_text": {
       "en": "Which language family includes Finnish and Hungarian?",
       "ja": "フィンランド語とハンガリー語を含む語族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69326,7 +70200,8 @@
     "question_text": {
       "en": "Which writing system represents only consonants?",
       "ja": "子音のみを表す文字体系は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69366,7 +70241,8 @@
     "question_text": {
       "en": "What is the study of word structure?",
       "ja": "語形成を研究する分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69406,7 +70282,8 @@
     "question_text": {
       "en": "Which feature describes Mandarin tones?",
       "ja": "中国語のトーンを表す特徴は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69446,7 +70323,8 @@
     "question_text": {
       "en": "Which language uses Devanagari script?",
       "ja": "デーヴァナーガリーを使う言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69486,7 +70364,8 @@
     "question_text": {
       "en": "What is the IPA symbol for the glottal stop?",
       "ja": "声門閉鎖音のIPA記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69526,7 +70405,8 @@
     "question_text": {
       "en": "Which tense expresses past relative to past?",
       "ja": "過去より前を表す時制は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69566,7 +70446,8 @@
     "question_text": {
       "en": "Which language is the most spoken Bantu language?",
       "ja": "最も話されるバントゥー語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69606,7 +70487,8 @@
     "question_text": {
       "en": "Which type of word changes form by case in Russian?",
       "ja": "ロシア語で格によって変化する語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69646,7 +70528,8 @@
     "question_text": {
       "en": "Which script does Korean use natively?",
       "ja": "韓国語が固有に使う文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69686,7 +70569,8 @@
     "question_text": {
       "en": "Which area of phonetics studies sound production?",
       "ja": "音声生成を研究する分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69726,7 +70610,8 @@
     "question_text": {
       "en": "Which language is an isolate spoken in northern Spain?",
       "ja": "スペイン北部で話される孤立言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69748,7 +70633,7 @@
         "en": "genitive",
         "ja": "属格",
         "ja_typings": [
-          "zokukaku"
+          "zokkaku"
         ]
       },
       {
@@ -69766,7 +70651,8 @@
     "question_text": {
       "en": "Which case is used for direct objects in Latin?",
       "ja": "ラテン語の直接目的語に使う格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69806,7 +70692,8 @@
     "question_text": {
       "en": "Which feature distinguishes Korean honorifics?",
       "ja": "韓国語の敬語を特徴づけるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69846,7 +70733,8 @@
     "question_text": {
       "en": "Which Semitic language is the oldest still spoken?",
       "ja": "現在も話される最古のセム語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69861,7 +70749,7 @@
         "en": "nasal lengthening",
         "ja": "鼻音延長",
         "ja_typings": [
-          "bionnnenchou"
+          "bionnenchou"
         ]
       },
       {
@@ -69886,7 +70774,8 @@
     "question_text": {
       "en": "Which sound change is called palatalization?",
       "ja": "口蓋化と呼ばれる音変化は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69926,7 +70815,8 @@
     "question_text": {
       "en": "Which dialect of Chinese is spoken in Hong Kong?",
       "ja": "香港で話される中国語方言は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69966,7 +70856,8 @@
     "question_text": {
       "en": "Which writing direction is traditional Mongolian?",
       "ja": "伝統的モンゴル文字の書字方向は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70006,7 +70897,8 @@
     "question_text": {
       "en": "Which Indo-European subgroup includes Latin?",
       "ja": "ラテン語が属するインド・ヨーロッパ語派は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70035,7 +70927,7 @@
         "en": "vowel mutation",
         "ja": "母音変異",
         "ja_typings": [
-          "boinhennni"
+          "boinhenni"
         ]
       }
     ],
@@ -70046,7 +70938,8 @@
     "question_text": {
       "en": "Which feature distinguishes agglutinative languages?",
       "ja": "膠着語を特徴づけるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70086,7 +70979,8 @@
     "question_text": {
       "en": "Which ancient writing system is cuneiform?",
       "ja": "古代の楔形文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70126,7 +71020,8 @@
     "question_text": {
       "en": "Which mood expresses wish or possibility?",
       "ja": "願望や可能性を表すムードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70166,7 +71061,8 @@
     "question_text": {
       "en": "Which language uses click consonants?",
       "ja": "クリック子音を使う言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70206,7 +71102,8 @@
     "question_text": {
       "en": "Which feature does Vietnamese have?",
       "ja": "ベトナム語が持つ特徴は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70246,7 +71143,8 @@
     "question_text": {
       "en": "Which Austronesian language is spoken in New Zealand?",
       "ja": "ニュージーランドで話されるオーストロネシア語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70286,7 +71184,8 @@
     "question_text": {
       "en": "Which speech sound is a fricative?",
       "ja": "摩擦音はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70326,7 +71225,8 @@
     "question_text": {
       "en": "Which constructed language is most spoken?",
       "ja": "最も話される人工言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70334,7 +71234,7 @@
         "en": "triconsonantal root",
         "ja": "三子音語根",
         "ja_typings": [
-          "sanshiongokon"
+          "sanshiingokon"
         ]
       },
       {
@@ -70366,7 +71266,8 @@
     "question_text": {
       "en": "Which feature describes Arabic root system?",
       "ja": "アラビア語の語根体系の特徴は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70406,7 +71307,8 @@
     "question_text": {
       "en": "Which traditional Spanish dish is from Valencia, rice based with rabbit?",
       "ja": "ウサギ肉入りバレンシア発祥の伝統米料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70421,7 +71323,7 @@
         "en": "Vale Tudo",
         "ja": "バーリトゥード",
         "ja_typings": [
-          "ba-ritu-do"
+          "ba-ritwu-do"
         ]
       },
       {
@@ -70446,7 +71348,8 @@
     "question_text": {
       "en": "Which Brazilian martial art combines dance and acrobatics?",
       "ja": "ダンスとアクロバットを組合せたブラジル武術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70486,7 +71389,8 @@
     "question_text": {
       "en": "Which Spanish festival celebrates tomatoes?",
       "ja": "トマトの祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70526,7 +71430,8 @@
     "question_text": {
       "en": "Which Indian instrument has sympathetic strings?",
       "ja": "共鳴弦を持つインドの弦楽器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70566,7 +71471,8 @@
     "question_text": {
       "en": "Which Norse mythology figure is the trickster god?",
       "ja": "北欧神話のいたずら神は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70606,7 +71512,8 @@
     "question_text": {
       "en": "Which Mongolian traditional dwelling is round and portable?",
       "ja": "丸く可搬なモンゴル伝統住居は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70646,7 +71553,8 @@
     "question_text": {
       "en": "Which Spanish flamenco rhythm is sad and slow?",
       "ja": "悲しくゆっくりなフラメンコのリズムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70661,7 +71569,7 @@
         "en": "dunun",
         "ja": "ドゥヌン",
         "ja_typings": [
-          "dunun"
+          "dwunun"
         ]
       },
       {
@@ -70686,7 +71594,8 @@
     "question_text": {
       "en": "Which Senegalese drum is goblet-shaped?",
       "ja": "ゴブレット型のセネガル太鼓は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70726,7 +71635,8 @@
     "question_text": {
       "en": "Which Korean court dance uses fans?",
       "ja": "扇を使う韓国宮廷舞踊は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70766,7 +71676,8 @@
     "question_text": {
       "en": "Which Mexican holiday honors deceased relatives?",
       "ja": "故人を偲ぶメキシコの祭日は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70806,7 +71717,8 @@
     "question_text": {
       "en": "Which Indonesian shadow puppet theater is UNESCO listed?",
       "ja": "ユネスコ登録のインドネシア影絵芝居は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70846,7 +71758,8 @@
     "question_text": {
       "en": "Which Russian dish is layered with herring and beets?",
       "ja": "ニシンとビーツの層状ロシア料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70886,7 +71799,8 @@
     "question_text": {
       "en": "Which Greek instrument is a bouzouki ancestor?",
       "ja": "ブズーキの祖先となるギリシャ楽器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70926,7 +71840,8 @@
     "question_text": {
       "en": "Which Andean instrument is a panpipe?",
       "ja": "アンデスのパンパイプは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70966,7 +71881,8 @@
     "question_text": {
       "en": "Which Ethiopian bread is spongy and sour?",
       "ja": "スポンジ状で酸味のあるエチオピアのパンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71006,7 +71922,8 @@
     "question_text": {
       "en": "Which Egyptian mythological creature has lion body and human head?",
       "ja": "ライオン体に人頭のエジプト神話の生物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71046,7 +71963,8 @@
     "question_text": {
       "en": "Which Japanese festival is in Akita with paper lanterns balanced on poles?",
       "ja": "秋田で行われる竿燈の祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71061,7 +71979,7 @@
         "en": "Vodun",
         "ja": "ヴォドゥン",
         "ja_typings": [
-          "vodun"
+          "vodwun"
         ]
       },
       {
@@ -71086,7 +72004,8 @@
     "question_text": {
       "en": "Which African religion focuses on ancestors and Orishas?",
       "ja": "祖先とオリシャを崇拝するアフリカ宗教は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71126,7 +72045,8 @@
     "question_text": {
       "en": "Which Italian dance is fast paced from Naples?",
       "ja": "ナポリ発祥の速いイタリア舞踊は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71134,7 +72054,7 @@
         "en": "dungchen",
         "ja": "ドゥンチェン",
         "ja_typings": [
-          "dunchen"
+          "dwunchen"
         ]
       },
       {
@@ -71166,7 +72086,8 @@
     "question_text": {
       "en": "Which Tibetan instrument is a long horn?",
       "ja": "チベットの長い角笛は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71206,7 +72127,8 @@
     "question_text": {
       "en": "Which Polish dance is in triple meter and elegant?",
       "ja": "三拍子で優雅なポーランド舞踊は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71246,7 +72168,8 @@
     "question_text": {
       "en": "Which Persian poetic form has couplets?",
       "ja": "対句で構成されるペルシア詩形は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71286,7 +72209,8 @@
     "question_text": {
       "en": "Which Indian sweet is made from milk solids?",
       "ja": "ミルク固形分から作るインドの菓子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71308,7 +72232,6 @@
         "en": "bodhran",
         "ja": "ボウラン",
         "ja_typings": [
-          "boran",
           "bouran"
         ]
       },
@@ -71327,7 +72250,8 @@
     "question_text": {
       "en": "Which Scottish instrument has bag and drones?",
       "ja": "袋とドローンを持つスコットランド楽器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71342,7 +72266,7 @@
         "en": "Cantonese opera",
         "ja": "粤劇",
         "ja_typings": [
-          "echigeki"
+          "etsugeki"
         ]
       },
       {
@@ -71367,7 +72291,8 @@
     "question_text": {
       "en": "Which Chinese opera region is most famous?",
       "ja": "中国京劇の中心地は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71407,7 +72332,8 @@
     "question_text": {
       "en": "Which Native American structure is a conical tent?",
       "ja": "円錐形のネイティブアメリカン住居は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71447,7 +72373,8 @@
     "question_text": {
       "en": "Which Hawaiian dance tells stories with hands?",
       "ja": "手で物語を表すハワイの舞踊は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71487,7 +72414,8 @@
     "question_text": {
       "en": "Which Belgian dish is mussels with fries?",
       "ja": "ムール貝とフライドポテトのベルギー料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71527,7 +72455,8 @@
     "question_text": {
       "en": "Which Aztec god is the feathered serpent?",
       "ja": "羽毛の蛇のアステカ神は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71567,7 +72496,8 @@
     "question_text": {
       "en": "Which Vietnamese soup is broth-based with herbs?",
       "ja": "ハーブを使うベトナム麺スープは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71607,7 +72537,8 @@
     "question_text": {
       "en": "Which voice actress voices Rukia Kuchiki in Bleach?",
       "ja": "『BLEACH』で朽木ルキアを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71647,7 +72578,8 @@
     "question_text": {
       "en": "Which voice actor voices Izaya Orihara in Durarara!!?",
       "ja": "『デュラララ!!』で折原臨也を演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71687,7 +72619,8 @@
     "question_text": {
       "en": "Which voice actor voices Gintoki Sakata in Gintama?",
       "ja": "『銀魂』で坂田銀時を演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71727,7 +72660,8 @@
     "question_text": {
       "en": "Which voice actor voices Eren Yeager in Attack on Titan?",
       "ja": "『進撃の巨人』でエレン・イェーガーを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71767,7 +72701,8 @@
     "question_text": {
       "en": "Which voice actor voices Sebastian Michaelis in Black Butler?",
       "ja": "『黒執事』でセバスチャン・ミカエリスを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71807,7 +72742,8 @@
     "question_text": {
       "en": "Which voice actress is well known for tsundere roles like Shana and Louise?",
       "ja": "シャナやルイズなどツンデレ役で知られる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71847,7 +72783,8 @@
     "question_text": {
       "en": "Which voice actor voices Kirito in Sword Art Online?",
       "ja": "『ソードアート・オンライン』でキリトを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71887,7 +72824,8 @@
     "question_text": {
       "en": "Which voice actor voices Iida Tenya in My Hero Academia?",
       "ja": "『僕のヒーローアカデミア』で飯田天哉を演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71927,7 +72865,8 @@
     "question_text": {
       "en": "Which voice actor is widely known for roles like Cloud Strife and Suzaku Kururugi?",
       "ja": "クラウド・ストライフや枢木スザクなどで知られる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71967,7 +72906,8 @@
     "question_text": {
       "en": "Which voice actor voices Tetsuya Kuroko in Kuroko's Basketball?",
       "ja": "『黒子のバスケ』で黒子テツヤを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72007,7 +72947,8 @@
     "question_text": {
       "en": "Which actor voices L in the live-action Death Note films?",
       "ja": "実写映画『デスノート』でLを演じた俳優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72047,7 +72988,8 @@
     "question_text": {
       "en": "Which voice actress voices Hitagi Senjogahara in the Monogatari series?",
       "ja": "『〈物語〉シリーズ』で戦場ヶ原ひたぎを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72087,7 +73029,8 @@
     "question_text": {
       "en": "Which voice actress voices Usagi Tsukino in the original Sailor Moon anime?",
       "ja": "初代『美少女戦士セーラームーン』アニメで月野うさぎを演じた声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72127,7 +73070,8 @@
     "question_text": {
       "en": "Which voice actress voices Sailor Mercury / Ami Mizuno in the original Sailor Moon anime?",
       "ja": "初代『セーラームーン』アニメで水野亜美/セーラーマーキュリーを演じた声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72167,7 +73111,8 @@
     "question_text": {
       "en": "Which voice actor voices Char Aznable in Mobile Suit Gundam?",
       "ja": "『機動戦士ガンダム』でシャア・アズナブルを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72207,7 +73152,8 @@
     "question_text": {
       "en": "Which voice actor is famous for playing Kakashi Hatake in Naruto?",
       "ja": "『NARUTO』ではたけカカシを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72247,7 +73193,8 @@
     "question_text": {
       "en": "Which voice actress voices Yor Forger in Spy x Family?",
       "ja": "『SPY×FAMILY』でヨル・フォージャーを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72287,7 +73234,8 @@
     "question_text": {
       "en": "Which voice actress voices Haruhi Suzumiya in The Melancholy of Haruhi Suzumiya?",
       "ja": "『涼宮ハルヒの憂鬱』で涼宮ハルヒを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72327,7 +73275,8 @@
     "question_text": {
       "en": "Which studio produced Ghost in the Shell: Stand Alone Complex?",
       "ja": "『攻殻機動隊 STAND ALONE COMPLEX』を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72367,7 +73316,8 @@
     "question_text": {
       "en": "Which studio produced Death Note and One-Punch Man (Season 1)?",
       "ja": "『デスノート』『ワンパンマン』(1期) を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72407,7 +73357,8 @@
     "question_text": {
       "en": "Which studio produced Attack on Titan (Seasons 1-3)?",
       "ja": "『進撃の巨人』(1-3期) を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72447,7 +73398,8 @@
     "question_text": {
       "en": "Which studio produced Sword Art Online and Fairy Tail?",
       "ja": "『ソードアート・オンライン』『フェアリーテイル』を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72487,7 +73439,8 @@
     "question_text": {
       "en": "Which studio produced Naruto and Bleach?",
       "ja": "『NARUTO』『BLEACH』を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72527,7 +73480,8 @@
     "question_text": {
       "en": "Which anime follows Aladdin and Alibaba exploring mysterious dungeons?",
       "ja": "アラジンとアリババがダンジョンに挑む冒険アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72567,7 +73521,8 @@
     "question_text": {
       "en": "Which classic anime features Yusuke Urameshi as a Spirit Detective?",
       "ja": "浦飯幽助が霊界探偵を務める名作アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72607,7 +73562,8 @@
     "question_text": {
       "en": "Which space western anime features Gene Starwind and his ship the Outlaw?",
       "ja": "ジーン・スターウィンドが主人公の宇宙ウェスタンアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72647,7 +73603,8 @@
     "question_text": {
       "en": "Which Rumiko Takahashi work follows a boy who turns into a girl when splashed with cold water?",
       "ja": "高橋留美子作で水をかぶると女になる少年の物語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72687,7 +73644,8 @@
     "question_text": {
       "en": "Which Rumiko Takahashi work features the alien Lum and Ataru Moroboshi?",
       "ja": "高橋留美子作でラムちゃんと諸星あたるが登場する作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72727,7 +73685,8 @@
     "question_text": {
       "en": "Which anime, based on Mamare Touno's novels, traps players inside an MMORPG world?",
       "ja": "橙乃ままれ原作で MMO 世界に閉じ込められる作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72767,7 +73726,8 @@
     "question_text": {
       "en": "Which Shonen Jump anime follows Asta, a magicless boy in a magical kingdom?",
       "ja": "魔法が使えない少年アスタを描くジャンプアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72807,7 +73767,8 @@
     "question_text": {
       "en": "Which Hiro Mashima anime follows Natsu and his guild of mages?",
       "ja": "真島ヒロ原作、ナツが所属する魔導士ギルドの物語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72847,7 +73808,8 @@
     "question_text": {
       "en": "Which Katsura Hoshino anime follows exorcists fighting Akuma with Innocence?",
       "ja": "星野桂原作、イノセンスでアクマと戦うエクソシストたちの物語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72887,7 +73849,8 @@
     "question_text": {
       "en": "Which baseball anime follows the Seido High pitching ace Eijun Sawamura?",
       "ja": "沢村栄純が主人公の高校野球アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72927,7 +73890,8 @@
     "question_text": {
       "en": "Which Osamu Tezuka work features a boy reclaiming his body parts from demons?",
       "ja": "手塚治虫原作、体の部位を魔物から取り戻す少年の物語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72967,7 +73931,8 @@
     "question_text": {
       "en": "Which Rei Hiroe anime follows the mercenary crew of the Black Lagoon Company?",
       "ja": "広江礼威原作、傭兵チーム『ブラック・ラグーン商会』の物語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73007,7 +73972,8 @@
     "question_text": {
       "en": "Which Mamoru Hosoda film features a single mother raising two half-wolf children?",
       "ja": "細田守監督、狼男との間に生まれた姉弟を描く映画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73047,7 +74013,8 @@
     "question_text": {
       "en": "Which Mamoru Hosoda film centers on a virtual world called OZ?",
       "ja": "細田守監督、仮想空間 OZ を舞台にした映画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73087,7 +74054,8 @@
     "question_text": {
       "en": "Which Satoshi Kon film follows three homeless people who find an abandoned baby?",
       "ja": "今敏監督、ホームレス3人が捨て子を拾う物語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73127,7 +74095,8 @@
     "question_text": {
       "en": "Which Yutaka Yamamoto-directed anime follows an Edo-period executioner sent to a flower island?",
       "ja": "江戸時代の処刑人が花の島に派遣される死刑囚との物語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73167,7 +74136,8 @@
     "question_text": {
       "en": "Which Leiji Matsumoto work features a steam locomotive traveling through space?",
       "ja": "松本零士原作で宇宙を走る蒸気機関車を描く作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73207,7 +74177,8 @@
     "question_text": {
       "en": "Which World Masterpiece Theater anime is set in the Swiss Alps?",
       "ja": "世界名作劇場でスイスアルプスを舞台にした作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73247,7 +74218,8 @@
     "question_text": {
       "en": "Which 2021 original anime by CloverWorks features girls fighting in dream worlds to bring back the dead?",
       "ja": "2021年クローバーワークス制作、夢の世界で戦う少女たちのオリジナルアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73287,7 +74259,8 @@
     "question_text": {
       "en": "Which Hajime Komoto anime follows Mash Burnedead, a magicless boy attending magic school?",
       "ja": "甲本一原作、魔法が使えない少年マッシュが魔法学校に通う作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73327,7 +74300,8 @@
     "question_text": {
       "en": "Who created Akira and directed its 1988 film adaptation?",
       "ja": "『AKIRA』の原作者で1988年映画版の監督も務めたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73367,7 +74341,8 @@
     "question_text": {
       "en": "Who directed Tales from Earthsea and From Up on Poppy Hill at Studio Ghibli?",
       "ja": "ジブリで『ゲド戦記』『コクリコ坂から』を監督したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73407,7 +74382,8 @@
     "question_text": {
       "en": "Who is the character designer for Neon Genesis Evangelion?",
       "ja": "『新世紀エヴァンゲリオン』のキャラクターデザイナーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73422,7 +74398,6 @@
         "en": "Chimera Shadow Garden",
         "ja": "キメラ・シャドウガーデン",
         "ja_typings": [
-          "kimera/shadoga-den",
           "kimera/shadouga-den"
         ]
       },
@@ -73448,7 +74423,8 @@
     "question_text": {
       "en": "What is the name of Saitama's S-Class hero disciple in One-Punch Man?",
       "ja": "『ワンパンマン』でサイタマの弟子となる S級ヒーローの名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73488,7 +74464,8 @@
     "question_text": {
       "en": "Which Kodansha weekly serializes Fairy Tail and Hajime no Ippo?",
       "ja": "『フェアリーテイル』『はじめの一歩』を連載する講談社の週刊誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73528,7 +74505,8 @@
     "question_text": {
       "en": "Which Kodansha seinen magazine serializes Vagabond and Vinland Saga?",
       "ja": "『バガボンド』『ヴィンランド・サガ』を連載する講談社の青年誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73568,7 +74546,8 @@
     "question_text": {
       "en": "Which Kodansha monthly serialized Blame! and Mushishi?",
       "ja": "『BLAME!』『蟲師』を連載した講談社の月刊誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73608,7 +74587,8 @@
     "question_text": {
       "en": "Which Shogakukan biweekly serializes Golgo 13?",
       "ja": "『ゴルゴ13』を連載する小学館の隔週誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73648,7 +74628,8 @@
     "question_text": {
       "en": "Which Shogakukan biweekly serialized Sanctuary and 3-gatsu no Lion?",
       "ja": "『サンクチュアリ』『3月のライオン』を連載した小学館の隔週誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73688,7 +74669,8 @@
     "question_text": {
       "en": "Which Akita Shoten weekly serializes Baki and serialized Grappler Baki?",
       "ja": "『バキ』を連載する秋田書店の週刊誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73728,7 +74710,8 @@
     "question_text": {
       "en": "Which Shueisha magazine serializes One Piece and Jujutsu Kaisen?",
       "ja": "『ONE PIECE』『呪術廻戦』を連載する集英社の雑誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73768,7 +74751,8 @@
     "question_text": {
       "en": "Which manga features Akira Yuki training under his master in Edo-era Japan?",
       "ja": "アスタが魔法の国で修行する少年漫画は? (誤) — 正: アラジンとアリババがダンジョンに挑む小学館連載作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73808,7 +74792,8 @@
     "question_text": {
       "en": "Which Yuki Tabata manga follows Asta in the Clover Kingdom?",
       "ja": "田畠裕基の漫画で、アスタがクローバー王国で活躍する作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73848,7 +74833,8 @@
     "question_text": {
       "en": "Which Tsugumi Ohba & Takeshi Obata manga follows two boys aiming to become manga artists?",
       "ja": "大場つぐみ・小畑健で、漫画家を目指す二人の少年の物語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73888,7 +74874,8 @@
     "question_text": {
       "en": "Which Ohba & Obata manga features a boy chosen by an angel competing to become god?",
       "ja": "大場つぐみ・小畑健で、天使に選ばれた少年が神を目指す作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73928,7 +74915,8 @@
     "question_text": {
       "en": "Which Shinobu Kaitani manga revolves around a deception tournament with huge debts?",
       "ja": "甲斐谷忍の漫画で、巨額の借金を賭けた騙し合いトーナメントを描く作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73968,7 +74956,8 @@
     "question_text": {
       "en": "Which Daisuke Hashimoto cooking manga follows young chef Yoichi Ajiyoshi?",
       "ja": "味吉陽一を主人公とする料理漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74008,7 +74997,8 @@
     "question_text": {
       "en": "Which Mamare Touno light-novel-based manga is set in a dark fantasy of demon-human peace?",
       "ja": "魔王と勇者の和平を描く橙乃ままれ原作のダーク・ファンタジー漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74048,7 +75038,8 @@
     "question_text": {
       "en": "Who is the author of Video Girl Ai and I\"s?",
       "ja": "『電影少女』『I\"s』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74088,7 +75079,8 @@
     "question_text": {
       "en": "Who is the author of Rookies and Rokudenashi Blues?",
       "ja": "『ROOKIES』『ろくでなしBLUES』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74128,7 +75120,8 @@
     "question_text": {
       "en": "Who is the Year 24 Group member behind Kaze to Ki no Uta and Toward the Terra?",
       "ja": "『風と木の詩』『地球へ…』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74168,7 +75161,8 @@
     "question_text": {
       "en": "Who is the author of Basara and 7 Seeds?",
       "ja": "『BASARA』『7SEEDS』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74208,7 +75202,8 @@
     "question_text": {
       "en": "Who is the author of Saint Seiya?",
       "ja": "『聖闘士星矢』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74248,7 +75243,8 @@
     "question_text": {
       "en": "Who created Tensai Bakabon and Osomatsu-kun?",
       "ja": "『天才バカボン』『おそ松くん』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74288,7 +75284,8 @@
     "question_text": {
       "en": "Which all-female group created Cardcaptor Sakura and X/1999?",
       "ja": "『カードキャプターさくら』『X』を生み出した女性作家グループは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74328,7 +75325,8 @@
     "question_text": {
       "en": "Who wrote the original story for Fist of the North Star?",
       "ja": "『北斗の拳』の原作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74368,7 +75366,8 @@
     "question_text": {
       "en": "Who wrote the original story for Star of the Giants and Tomorrow's Joe?",
       "ja": "『巨人の星』『あしたのジョー』の原作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74408,7 +75407,8 @@
     "question_text": {
       "en": "Who is the duo behind Kinnikuman?",
       "ja": "『キン肉マン』の作者コンビは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74448,7 +75448,8 @@
     "question_text": {
       "en": "Who is the artist behind the One-Punch Man remake and Eyeshield 21?",
       "ja": "ワンパンマン作画版や『アイシールド21』作画の漫画家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74456,7 +75457,7 @@
         "en": "Yoko Kamio",
         "ja": "神尾葉子",
         "ja_typings": [
-          "kamiyouko"
+          "kamioyouko"
         ]
       },
       {
@@ -74488,7 +75489,8 @@
     "question_text": {
       "en": "Who is the author of Boys Over Flowers (Hana Yori Dango)?",
       "ja": "『花より男子』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74528,7 +75530,8 @@
     "question_text": {
       "en": "Who is the author of The Star of Cottonland?",
       "ja": "『綿の国星』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74568,7 +75571,8 @@
     "question_text": {
       "en": "Who created Doraemon as one half of the duo, and later worked solo on Laughing Salesman?",
       "ja": "藤子不二雄コンビの片割れで『笑ゥせぇるすまん』も手がけたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74608,7 +75612,8 @@
     "question_text": {
       "en": "Who is the author of Section Chief Kosaku Shima?",
       "ja": "『課長島耕作』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74648,7 +75653,8 @@
     "question_text": {
       "en": "Who is the horror manga master behind The Drifting Classroom?",
       "ja": "『漂流教室』の作者であるホラー漫画の巨匠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74688,7 +75694,8 @@
     "question_text": {
       "en": "Who is the author of Otoko Oidon and Salaryman Kintaro?",
       "ja": "『男一匹ガキ大将』『サラリーマン金太郎』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74728,7 +75735,8 @@
     "question_text": {
       "en": "Who created the dog adventure manga Silver Fang?",
       "ja": "犬の冒険漫画『銀牙 -流れ星 銀-』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74768,7 +75776,8 @@
     "question_text": {
       "en": "Who created Gallery Fake and Gaki Deka counterpart Yawara!? — namely the author of Gallery Fake?",
       "ja": "『ギャラリーフェイク』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74808,7 +75817,8 @@
     "question_text": {
       "en": "Who is the author of Captain and Play Ball?",
       "ja": "『キャプテン』『プレイボール』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74848,7 +75858,8 @@
     "question_text": {
       "en": "Who is the baseball manga master behind Dokaben?",
       "ja": "『ドカベン』の作者である野球漫画の巨匠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74888,7 +75899,8 @@
     "question_text": {
       "en": "Who is the author of Patlabor (manga)?",
       "ja": "漫画版『機動警察パトレイバー』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74928,7 +75940,8 @@
     "question_text": {
       "en": "Who is the author of The Five Star Stories?",
       "ja": "『ファイブスター物語』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74968,7 +75981,8 @@
     "question_text": {
       "en": "Who is the author of Ushio and Tora?",
       "ja": "『うしおととら』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75008,7 +76022,8 @@
     "question_text": {
       "en": "Who is the author of Asari-chan?",
       "ja": "『あさりちゃん』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75037,7 +76052,7 @@
         "en": "Yoko Kamio",
         "ja": "神尾葉子",
         "ja_typings": [
-          "kamiyouko"
+          "kamioyouko"
         ]
       }
     ],
@@ -75048,7 +76063,8 @@
     "question_text": {
       "en": "Who is the author of Tenshi nanka ja nai?",
       "ja": "『天使なんかじゃない』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75088,7 +76104,8 @@
     "question_text": {
       "en": "Who is the author of Banana Fish?",
       "ja": "『BANANA FISH』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75103,7 +76120,7 @@
         "en": "Yoko Kamio",
         "ja": "神尾葉子",
         "ja_typings": [
-          "kamiyouko"
+          "kamioyouko"
         ]
       },
       {
@@ -75128,7 +76145,8 @@
     "question_text": {
       "en": "Who is the author of Kimi ni Todoke?",
       "ja": "『君に届け』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75168,7 +76186,8 @@
     "question_text": {
       "en": "Who is the author of Sayonara, Zetsubou-Sensei?",
       "ja": "『さよなら絶望先生』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75208,7 +76227,8 @@
     "question_text": {
       "en": "Who is the historical-josei master behind Tenjo no Niji?",
       "ja": "『天上の虹』を描いた歴史少女漫画の巨匠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75248,7 +76268,8 @@
     "question_text": {
       "en": "Which Japanese publisher releases Kadokawa Bunko and many light novels?",
       "ja": "角川文庫やライトノベルを多数出す日本の出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75288,7 +76309,8 @@
     "question_text": {
       "en": "Which Japanese newspaper has the largest circulation and sponsors the Giants?",
       "ja": "発行部数最大、巨人を所有する日本の新聞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75328,7 +76350,8 @@
     "question_text": {
       "en": "Which Japanese newspaper sponsors the high school baseball Summer Koshien?",
       "ja": "夏の甲子園を主催する日本の新聞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75368,7 +76391,8 @@
     "question_text": {
       "en": "Which Japanese newspaper focuses on business and economics?",
       "ja": "経済を専門に扱う日本の新聞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75408,7 +76432,8 @@
     "question_text": {
       "en": "Who is the heir to Hanagumi at the Imperial Theatre in Sakura Wars?",
       "ja": "『サクラ大戦』で帝国華撃団・花組の隊員は神崎すみれと誰? (新人の少女の名)"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75448,7 +76473,8 @@
     "question_text": {
       "en": "Who is the rival actress in Glass Mask (Garasu no Kamen)?",
       "ja": "『ガラスの仮面』で北島マヤのライバルとなる天才女優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75488,7 +76514,8 @@
     "question_text": {
       "en": "Who is the legendary actress and mentor in Glass Mask?",
       "ja": "『ガラスの仮面』で月影先生として知られる伝説の女優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75528,7 +76555,8 @@
     "question_text": {
       "en": "Which Japanese game company developed the Metal Gear and Castlevania series?",
       "ja": "『メタルギア』『悪魔城ドラキュラ』を開発した日本のゲーム会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75568,7 +76596,8 @@
     "question_text": {
       "en": "Who is the creator of Virtua Fighter and Shenmue at Sega?",
       "ja": "セガで『バーチャファイター』『シェンムー』を生み出したクリエイターは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75608,7 +76637,8 @@
     "question_text": {
       "en": "Which Japanese developer is known for Star Ocean and Valkyrie Profile?",
       "ja": "『スターオーシャン』『ヴァルキリープロファイル』で知られるデベロッパーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75648,7 +76678,8 @@
     "question_text": {
       "en": "Which 1995 Square JRPG features Crono and time-traveling adventures?",
       "ja": "1995年スクウェアのRPGで、クロノが時を超える物語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75688,7 +76719,8 @@
     "question_text": {
       "en": "Which long-running Square Enix JRPG series began on the Famicom in 1987?",
       "ja": "1987年ファミコンで始まったスクウェアの長寿RPGシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75728,7 +76760,8 @@
     "question_text": {
       "en": "Which Sega 3D fighting series began in 1993 starring Akira Yuki?",
       "ja": "1993年に始まったセガの3D格闘ゲームシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75750,7 +76783,6 @@
         "en": "Dark Souls",
         "ja": "ダークソウル",
         "ja_typings": [
-          "da-kusoru",
           "da-kusouru"
         ]
       },
@@ -75769,7 +76801,8 @@
     "question_text": {
       "en": "Which BioWare RPG series features Grey Wardens fighting darkspawn?",
       "ja": "BioWare 製、灰色の守人がダークスポーンと戦うRPGシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75777,7 +76810,7 @@
         "en": "Nioh",
         "ja": "仁王",
         "ja_typings": [
-          "nioh"
+          "niou"
         ]
       },
       {
@@ -75798,7 +76831,6 @@
         "en": "Dark Souls",
         "ja": "ダークソウル",
         "ja_typings": [
-          "da-kusoru",
           "da-kusouru"
         ]
       }
@@ -75810,7 +76842,8 @@
     "question_text": {
       "en": "Which Team Ninja action RPG is set in Sengoku Japan starring William Adams?",
       "ja": "コーエーテクモ製、戦国時代を舞台にウィリアムが戦うアクションRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75825,7 +76858,7 @@
         "en": "Nioh",
         "ja": "仁王",
         "ja_typings": [
-          "nioh"
+          "niou"
         ]
       },
       {
@@ -75850,7 +76883,8 @@
     "question_text": {
       "en": "Which RGG Studio spin-off stars lawyer-turned-detective Takayuki Yagami?",
       "ja": "龍が如くスタジオのスピンオフで、八神隆之が主人公の作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75890,7 +76924,8 @@
     "question_text": {
       "en": "Which Sega 16-bit home console competed with the Super Famicom in the early 1990s?",
       "ja": "1990年代初頭にスーパーファミコンと競合したセガの16ビット家庭用機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75930,7 +76965,8 @@
     "question_text": {
       "en": "Which Sega handheld competed with the Game Boy?",
       "ja": "ゲームボーイと競合したセガの携帯ゲーム機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75959,7 +76995,6 @@
         "en": "Soul Blazer",
         "ja": "ソウルブレイダー",
         "ja_typings": [
-          "sorubureida-",
           "sourubureida-"
         ]
       }
@@ -75971,7 +77006,8 @@
     "question_text": {
       "en": "Which Square horror RPG is set in NYC starring Aya Brea?",
       "ja": "ニューヨークを舞台にアヤ・ブレアが活躍するスクウェアのホラーRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76011,7 +77047,8 @@
     "question_text": {
       "en": "Which Monolith Soft JRPG series features giant Titans and the Monado?",
       "ja": "モノリスソフトの巨神とモナドが登場するJRPGシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76033,7 +77070,7 @@
         "en": "Nioh",
         "ja": "仁王",
         "ja_typings": [
-          "nioh"
+          "niou"
         ]
       },
       {
@@ -76051,7 +77088,8 @@
     "question_text": {
       "en": "Which PlatinumGames action title stars a witch named Cereza?",
       "ja": "プラチナゲームズ製、魔女セレッサが主人公のアクションは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76080,7 +77118,6 @@
         "en": "Dark Souls",
         "ja": "ダークソウル",
         "ja_typings": [
-          "da-kusoru",
           "da-kusouru"
         ]
       }
@@ -76092,7 +77129,8 @@
     "question_text": {
       "en": "Which Capcom action series stars demon hunter Dante?",
       "ja": "カプコン製、悪魔狩人ダンテが主人公のアクションシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76132,7 +77170,8 @@
     "question_text": {
       "en": "Which Hi-Rez Studios free-to-play hero shooter features Champions?",
       "ja": "Hi-Rez Studios 製、チャンピオンが戦う基本無料ヒーローシューターは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76154,7 +77193,6 @@
         "en": "Dark Souls",
         "ja": "ダークソウル",
         "ja_typings": [
-          "da-kusoru",
           "da-kusouru"
         ]
       },
@@ -76173,7 +77211,8 @@
     "question_text": {
       "en": "Which BioWare sci-fi RPG series stars Commander Shepard?",
       "ja": "BioWare 製、シェパード司令官が主人公のSF RPGシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76181,7 +77220,6 @@
         "en": "Dark Souls",
         "ja": "ダークソウル",
         "ja_typings": [
-          "da-kusoru",
           "da-kusouru"
         ]
       },
@@ -76189,7 +77227,7 @@
         "en": "Nioh",
         "ja": "仁王",
         "ja_typings": [
-          "nioh"
+          "niou"
         ]
       },
       {
@@ -76214,7 +77252,8 @@
     "question_text": {
       "en": "Which FromSoftware action RPG series began with Lordran in 2011?",
       "ja": "2011年にロードランから始まったフロム・ソフトウェアのアクションRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76229,7 +77268,7 @@
         "en": "Nioh",
         "ja": "仁王",
         "ja_typings": [
-          "nioh"
+          "niou"
         ]
       },
       {
@@ -76254,7 +77293,8 @@
     "question_text": {
       "en": "Which Capcom action series is set in Sengoku-era Japan with samurai vs demons?",
       "ja": "カプコン製、戦国時代を舞台に侍が鬼と戦うアクションシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76276,7 +77316,7 @@
         "en": "Nioh",
         "ja": "仁王",
         "ja_typings": [
-          "nioh"
+          "niou"
         ]
       },
       {
@@ -76294,7 +77334,8 @@
     "question_text": {
       "en": "Which Acquire-developed series lets you live as a wandering samurai?",
       "ja": "アクワイア開発、流浪の侍として生きるシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76334,7 +77375,8 @@
     "question_text": {
       "en": "Which 1979 Atari arcade game lets you shoot rocks drifting in space?",
       "ja": "1979年アタリ製、宇宙の岩を撃つアーケードゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76374,7 +77416,8 @@
     "question_text": {
       "en": "Which Sega Yu Suzuki series stars Ryo Hazuki searching for his father's killer?",
       "ja": "鈴木裕監修、芭月涼が父の仇を追うセガの大作シリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76414,7 +77457,8 @@
     "question_text": {
       "en": "Which game genre is exemplified by StarCraft and Age of Empires?",
       "ja": "『スタークラフト』『エイジ・オブ・エンパイア』に代表されるジャンルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76454,7 +77498,8 @@
     "question_text": {
       "en": "Which 1988 Sega arcade racing game features tilting cockpit cabinets?",
       "ja": "1988年セガのアーケードレース、可動筐体が特徴の作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76494,7 +77539,8 @@
     "question_text": {
       "en": "Which Konami run-and-gun series began in 1987 with two commandos?",
       "ja": "1987年に始まったコナミの2人コマンドのラン&ガンシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76534,7 +77580,8 @@
     "question_text": {
       "en": "Which Konami cute-em-up features a bell-shooting flying ship?",
       "ja": "コナミ製、鈴を撃つ可愛い縦シューティングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76542,7 +77589,6 @@
         "en": "Soul Blazer",
         "ja": "ソウルブレイダー",
         "ja_typings": [
-          "sorubureida-",
           "sourubureida-"
         ]
       },
@@ -76575,7 +77621,8 @@
     "question_text": {
       "en": "Which Enix Super Famicom action RPG by Quintet has you reviving the world?",
       "ja": "クインテット製スーファミの、世界を蘇らせるエニックスのアクションRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76615,7 +77662,8 @@
     "question_text": {
       "en": "Which SNK weapon-based fighting game series spun off from Samurai Shodown?",
       "ja": "『サムライスピリッツ』から派生した武器対戦格闘ゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76655,7 +77703,8 @@
     "question_text": {
       "en": "Which NEC handheld is a portable PC Engine with a color LCD?",
       "ja": "PCエンジン互換のNEC製カラー液晶携帯機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76695,7 +77744,8 @@
     "question_text": {
       "en": "Which Nintendo series stars bounty hunter Samus Aran?",
       "ja": "サムス・アランが活躍する任天堂のシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76724,7 +77774,7 @@
         "en": "Yo-kai Watch",
         "ja": "妖怪ウォッチ",
         "ja_typings": [
-          "youkaiuocchi"
+          "youkaiwocchi"
         ]
       }
     ],
@@ -76735,7 +77785,8 @@
     "question_text": {
       "en": "Which HAL Laboratory Nintendo series stars a pink puffball hero?",
       "ja": "HAL研究所製、ピンクの丸い主人公が活躍する任天堂のシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76764,7 +77815,7 @@
         "en": "Yo-kai Watch",
         "ja": "妖怪ウォッチ",
         "ja_typings": [
-          "youkaiuocchi"
+          "youkaiwocchi"
         ]
       }
     ],
@@ -76775,7 +77826,8 @@
     "question_text": {
       "en": "Which Intelligent Systems tactical RPG series began on the Famicom?",
       "ja": "ファミコンで始まったインテリジェントシステムズのSRPGシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76790,7 +77842,7 @@
         "en": "Yo-kai Watch",
         "ja": "妖怪ウォッチ",
         "ja_typings": [
-          "youkaiuocchi"
+          "youkaiwocchi"
         ]
       },
       {
@@ -76815,7 +77867,8 @@
     "question_text": {
       "en": "Which Bandai franchise features creatures hatched from Digivices?",
       "ja": "デジヴァイスから生まれる生物のバンダイ製シリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76823,7 +77876,7 @@
         "en": "Yo-kai Watch",
         "ja": "妖怪ウォッチ",
         "ja_typings": [
-          "youkaiuocchi"
+          "youkaiwocchi"
         ]
       },
       {
@@ -76855,7 +77908,8 @@
     "question_text": {
       "en": "Which Level-5 RPG series features Keita Amano befriending youkai with a watch?",
       "ja": "レベルファイブ製、ケータくんが時計で妖怪と友達になるシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76895,7 +77949,8 @@
     "question_text": {
       "en": "Which 2001 PS2 JRPG features Tidus and the world of Spira?",
       "ja": "2001年のPS2 JRPGで、ティーダとスピラの世界を描く作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76935,7 +77990,8 @@
     "question_text": {
       "en": "Which Square action RPG series began in 1991 as a Final Fantasy spin-off?",
       "ja": "1991年にFFスピンオフとして始まったスクウェアのアクションRPGシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76975,7 +78031,8 @@
     "question_text": {
       "en": "Which Bandai Namco JRPG franchise includes Symphonia and Vesperia?",
       "ja": "『シンフォニア』『ヴェスペリア』を含むバンダイナムコのJRPGシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77015,7 +78072,8 @@
     "question_text": {
       "en": "Which 1997 PS1 Square RPG features seven scenarios across Regions?",
       "ja": "1997年PS1スクウェア製、7つのシナリオを行き来するRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77055,7 +78113,8 @@
     "question_text": {
       "en": "Which user-generated online platform lets kids create and play 3D worlds?",
       "ja": "ユーザー作成の3D世界を遊ぶオンラインプラットフォームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77070,7 +78129,7 @@
         "en": "Yo-kai Watch",
         "ja": "妖怪ウォッチ",
         "ja_typings": [
-          "youkaiuocchi"
+          "youkaiwocchi"
         ]
       },
       {
@@ -77084,7 +78143,6 @@
         "en": "Saints Row",
         "ja": "セインツロウ",
         "ja_typings": [
-          "seintsuro",
           "seintsurou"
         ]
       }
@@ -77096,7 +78154,8 @@
     "question_text": {
       "en": "Which Square Enix Minecraft-like spin-off stars a hero who builds with blocks?",
       "ja": "スクエニ製、ブロックを積んで世界を作るマイクラ風スピンオフは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77104,7 +78163,6 @@
         "en": "Saints Row",
         "ja": "セインツロウ",
         "ja_typings": [
-          "seintsuro",
           "seintsurou"
         ]
       },
@@ -77137,7 +78195,8 @@
     "question_text": {
       "en": "Which Volition open-world series follows the 3rd Street Saints gang?",
       "ja": "Volition 製、3rdストリートセインツのギャングを描くオープンワールドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77152,7 +78211,6 @@
         "en": "Saints Row",
         "ja": "セインツロウ",
         "ja_typings": [
-          "seintsuro",
           "seintsurou"
         ]
       },
@@ -77178,7 +78236,8 @@
     "question_text": {
       "en": "Which Ubisoft open-world hacker series began in 2014?",
       "ja": "2014年に始まったユービーアイのハッカー系オープンワールドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77200,7 +78259,6 @@
         "en": "Saints Row",
         "ja": "セインツロウ",
         "ja_typings": [
-          "seintsuro",
           "seintsurou"
         ]
       },
@@ -77219,7 +78277,8 @@
     "question_text": {
       "en": "Which 2K open-world series began with Tommy Angelo in 1930s Lost Heaven?",
       "ja": "1930年代ロスト・ヘブンのトミー・アンジェロが主人公の2Kオープンワールドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77259,7 +78318,8 @@
     "question_text": {
       "en": "Which 2017 Krafton battle royale popularized the genre on PC?",
       "ja": "2017年クラフトン製でバトロワを大流行させたPCゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77299,7 +78359,8 @@
     "question_text": {
       "en": "Which free-to-play battle royale is part of the Call of Duty franchise?",
       "ja": "CoD シリーズの基本無料バトロワは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77339,7 +78400,8 @@
     "question_text": {
       "en": "Which 1990 Nintendo 16-bit console succeeded the Famicom in Japan?",
       "ja": "ファミコンの後継として1990年に発売された任天堂の16ビット機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77379,7 +78441,8 @@
     "question_text": {
       "en": "Which 1989 Nintendo handheld popularized portable gaming with Tetris?",
       "ja": "1989年テトリスで携帯ゲームを普及させた任天堂の携帯機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77419,7 +78482,8 @@
     "question_text": {
       "en": "Which 1996 Nintendo 64-bit console launched with Super Mario 64?",
       "ja": "1996年スーパーマリオ64と共に発売された任天堂の64ビット機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77459,7 +78523,8 @@
     "question_text": {
       "en": "Which 1994 Sega 32-bit console competed with the PlayStation in Japan?",
       "ja": "1994年プレイステーションと競った32ビットのセガ家庭用機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77499,7 +78564,8 @@
     "question_text": {
       "en": "Which 2017 Nintendo hybrid console plays both docked and handheld?",
       "ja": "2017年発売、据置と携帯を両立する任天堂のハイブリッド機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77539,7 +78605,8 @@
     "question_text": {
       "en": "Which OOP concept allows a class to acquire properties from another class?",
       "ja": "あるクラスが別のクラスのプロパティを受け継ぐオブジェクト指向の概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77579,7 +78646,8 @@
     "question_text": {
       "en": "Which markup language uses customizable tags to describe structured data?",
       "ja": "ユーザー定義タグで構造化データを記述するマークアップ言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77621,7 +78689,8 @@
     "question_text": {
       "en": "Which self-balancing tree is widely used in databases and filesystems?",
       "ja": "データベースやファイルシステムで広く使われる自己平衡木は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77661,7 +78730,8 @@
     "question_text": {
       "en": "Which spreadsheet term refers to a single unit at the intersection of a row and column?",
       "ja": "表計算で行と列の交点にある一つの枠を指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77701,7 +78771,8 @@
     "question_text": {
       "en": "Which JVM language has functional features and is used at Twitter?",
       "ja": "JVM 上で動く関数型機能を持つ言語で Twitter でも使われていたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77741,7 +78812,8 @@
     "question_text": {
       "en": "In Perl, which keyword defines a subroutine?",
       "ja": "Perl でサブルーチンを定義するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77781,7 +78853,8 @@
     "question_text": {
       "en": "Who co-created Unix and the B programming language at Bell Labs?",
       "ja": "ベル研で Unix と B 言語を共同開発した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77821,7 +78894,8 @@
     "question_text": {
       "en": "Which company created the Swift programming language?",
       "ja": "プログラミング言語 Swift を開発した企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77861,7 +78935,8 @@
     "question_text": {
       "en": "Which design principle forwards a request from one object to another helper object?",
       "ja": "あるオブジェクトが処理を別のヘルパーオブジェクトに転送する設計原則は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77901,7 +78976,8 @@
     "question_text": {
       "en": "Which package manager is bundled with Node.js by default?",
       "ja": "Node.js に既定で同梱されるパッケージマネージャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77941,7 +79017,8 @@
     "question_text": {
       "en": "Which Groovy-based build automation tool is standard for Android?",
       "ja": "Android 開発で標準的に使われる Groovy ベースのビルドツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77981,7 +79058,8 @@
     "question_text": {
       "en": "Which classic Unix build tool reads a Makefile?",
       "ja": "Makefile を読み込む古典的な Unix のビルドツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78021,7 +79099,8 @@
     "question_text": {
       "en": "Which dynamic JVM language is often used with Gradle scripts?",
       "ja": "Gradle スクリプトで使われる動的な JVM 言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78061,7 +79140,8 @@
     "question_text": {
       "en": "Which classic synchronization primitive uses a counter to control resource access?",
       "ja": "カウンタで資源アクセスを制御する古典的な同期プリミティブは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78101,7 +79181,8 @@
     "question_text": {
       "en": "Which JavaScript keyword declares a regular function?",
       "ja": "JavaScript で通常の関数を宣言するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78141,7 +79222,8 @@
     "question_text": {
       "en": "Which company developed the original PC compatible architecture and OS/2?",
       "ja": "PC 互換機と OS/2 を生み出した企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78181,7 +79263,8 @@
     "question_text": {
       "en": "Which company created the Go programming language?",
       "ja": "プログラミング言語 Go を生み出した企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78210,7 +79293,7 @@
         "en": "Insertion sort",
         "ja": "挿入ソート",
         "ja_typings": [
-          "so-nyuusooto"
+          "sounyuuso-to"
         ]
       }
     ],
@@ -78221,7 +79304,8 @@
     "question_text": {
       "en": "Which divide-and-conquer sort uses a pivot to partition the array?",
       "ja": "ピボットを使って配列を分割する分割統治法のソートは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78261,7 +79345,8 @@
     "question_text": {
       "en": "Which comparison sort builds a binary heap to extract elements in order?",
       "ja": "二分ヒープを構築して要素を順に取り出す比較ソートは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78301,7 +79386,8 @@
     "question_text": {
       "en": "Which control-flow concept repeats a block of code using loops?",
       "ja": "ループを用いてコードブロックを繰り返す制御フローの概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78341,7 +79427,8 @@
     "question_text": {
       "en": "Which lightweight data interchange format is based on JavaScript object syntax?",
       "ja": "JavaScript のオブジェクト構文に基づく軽量データ交換形式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78381,7 +79468,8 @@
     "question_text": {
       "en": "Which JavaScript bundler is known for ES module-first design?",
       "ja": "ES モジュール優先の設計で知られる JavaScript バンドラは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78421,7 +79509,8 @@
     "question_text": {
       "en": "Which zero-configuration JavaScript bundler is famous for being beginner-friendly?",
       "ja": "ゼロ設定で初心者にも優しいことで知られる JavaScript バンドラは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78461,7 +79550,8 @@
     "question_text": {
       "en": "Which HTTP method requests data without modifying the server state?",
       "ja": "サーバの状態を変えずにデータを取得する HTTP メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78501,7 +79591,8 @@
     "question_text": {
       "en": "Which language runs on the JVM and was originally developed by Sun?",
       "ja": "サンが開発し JVM 上で動作する言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78541,7 +79632,8 @@
     "question_text": {
       "en": "In C++, which keyword hints the compiler to expand a function at call site?",
       "ja": "C++ で関数を呼び出し位置に展開するようコンパイラに示唆するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78581,7 +79673,8 @@
     "question_text": {
       "en": "Which JavaScript runtime built on V8 enables server-side scripting?",
       "ja": "V8 上に作られたサーバサイド JavaScript ランタイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78621,7 +79714,8 @@
     "question_text": {
       "en": "Which Pascal-like statically typed language compiles to C, JS, and more?",
       "ja": "Pascal 風の静的型付け言語で C や JS にコンパイル可能なのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78662,7 +79756,8 @@
     "question_text": {
       "en": "Which probabilistic data structure layers linked lists for fast search?",
       "ja": "リンクリストを多層化して高速検索を実現する確率的データ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78702,7 +79797,8 @@
     "question_text": {
       "en": "Which algorithm finds shortest paths and detects negative-weight cycles?",
       "ja": "負の重みの閉路も検出できる最短経路アルゴリズムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78742,7 +79838,8 @@
     "question_text": {
       "en": "Which programming paradigm focuses on explicit statements that change state?",
       "ja": "状態を変化させる明示的な命令文を中心とするプログラミングパラダイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78782,7 +79879,8 @@
     "question_text": {
       "en": "Which paradigm organizes code into reusable procedures or routines?",
       "ja": "コードを再利用可能な手続きにまとめるパラダイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78822,7 +79920,8 @@
     "question_text": {
       "en": "Who proposed the famous shortest path algorithm in 1956?",
       "ja": "1956 年に有名な最短経路アルゴリズムを提案した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78862,7 +79961,8 @@
     "question_text": {
       "en": "Which JavaScript keyword marks a function that returns a Promise?",
       "ja": "Promise を返す関数を示す JavaScript のキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78902,7 +80002,8 @@
     "question_text": {
       "en": "Which Python built-in pairs elements from multiple iterables?",
       "ja": "複数のイテラブルから要素をペアにする Python 組み込み関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78917,7 +80018,7 @@
         "en": "&&",
         "ja": "論理積演算子",
         "ja_typings": [
-          "ronritekienzanshi"
+          "ronrisekienzanshi"
         ]
       },
       {
@@ -78942,7 +80043,8 @@
     "question_text": {
       "en": "Which C operator selects between two expressions based on a condition?",
       "ja": "条件によって 2 つの式を選ぶ C 言語の演算子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78982,7 +80084,8 @@
     "question_text": {
       "en": "In C, which storage class limits a variable's visibility to its file?",
       "ja": "C 言語で変数の可視性をファイル内に限定する記憶クラスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79022,7 +80125,8 @@
     "question_text": {
       "en": "Which linear data structure stores elements with pointers to the next node?",
       "ja": "次ノードへのポインタで要素を繋ぐ線形データ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79062,7 +80166,8 @@
     "question_text": {
       "en": "Which contiguous-memory data structure offers O(1) index access?",
       "ja": "添字アクセスが O(1) で可能な連続メモリのデータ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79102,7 +80207,8 @@
     "question_text": {
       "en": "Which function maps keys to indices in a hash table?",
       "ja": "ハッシュテーブルで鍵を添字に変換する関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79144,7 +80250,8 @@
     "question_text": {
       "en": "Which tree variant has at most three children per node?",
       "ja": "各ノードが最大 3 つの子を持つ木は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79152,7 +80259,7 @@
         "en": "Complete Graph",
         "ja": "完全グラフ",
         "ja_typings": [
-          "kanzenngurafu"
+          "kanzengurafu"
         ]
       },
       {
@@ -79184,7 +80291,8 @@
     "question_text": {
       "en": "Which graph has an edge between every pair of distinct vertices?",
       "ja": "任意の 2 頂点間に辺がある無向グラフは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79224,7 +80332,8 @@
     "question_text": {
       "en": "Which OOP concept hides implementation details behind a simple interface?",
       "ja": "実装詳細を隠して簡潔なインタフェースを公開する OOP の概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79264,7 +80373,8 @@
     "question_text": {
       "en": "Which structural design pattern bridges incompatible interfaces?",
       "ja": "互換性のないインタフェースを橋渡しする構造的デザインパターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79304,7 +80414,8 @@
     "question_text": {
       "en": "Which behavioral pattern lets algorithms vary independently from clients?",
       "ja": "アルゴリズムをクライアントから独立に切り替えられる振る舞い系パターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79344,7 +80455,8 @@
     "question_text": {
       "en": "Which structural pattern wraps an object to add behavior dynamically?",
       "ja": "オブジェクトを包んで動的に振る舞いを追加する構造パターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79384,7 +80496,8 @@
     "question_text": {
       "en": "Which structural pattern provides a surrogate to control access to an object?",
       "ja": "オブジェクトへのアクセスを制御する代理を提供する構造パターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79424,7 +80537,8 @@
     "question_text": {
       "en": "Which pattern lets clients treat individual objects and compositions uniformly?",
       "ja": "個々の要素と複合要素を一様に扱える構造パターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79464,7 +80578,8 @@
     "question_text": {
       "en": "Which behavioral pattern adds operations without changing element classes?",
       "ja": "要素クラスを変えずに操作を追加できる振る舞いパターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79504,7 +80619,8 @@
     "question_text": {
       "en": "Which Rust standard collection is a growable, heap-allocated array?",
       "ja": "ヒープ確保で可変長配列を表す Rust の標準コレクションは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79544,7 +80660,8 @@
     "question_text": {
       "en": "Which HTTP header controls how much referrer information is sent with requests?",
       "ja": "リクエストに含めるリファラ情報の量を制御する HTTP ヘッダは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79584,7 +80701,8 @@
     "question_text": {
       "en": "Which Web Vitals metric measures the delay until the first user interaction is processed?",
       "ja": "最初のユーザー操作が処理されるまでの遅延を計る Web Vitals 指標は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79624,7 +80742,8 @@
     "question_text": {
       "en": "Which Web API observes performance-related events such as paint and longtask?",
       "ja": "ペイントやロングタスク等のパフォーマンス事象を観測する Web API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79646,7 +80765,7 @@
         "en": "Forbidden",
         "ja": "フォービドゥン",
         "ja_typings": [
-          "fo-bidun"
+          "fo-bidwun"
         ]
       },
       {
@@ -79664,7 +80783,8 @@
     "question_text": {
       "en": "Which HTTP status indicates the server cannot process due to client-side error?",
       "ja": "クライアント側の誤りで処理できないことを示す HTTP ステータスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79704,7 +80824,8 @@
     "question_text": {
       "en": "Which HTTP method submits data to be processed to a specified resource?",
       "ja": "指定リソースに処理用データを送信する HTTP メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79744,7 +80865,8 @@
     "question_text": {
       "en": "Which CSS framework is built with Sass and based on Flexbox?",
       "ja": "Sass で作られ Flexbox を基礎にした CSS フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79784,7 +80906,8 @@
     "question_text": {
       "en": "Which responsive front-end framework was originally created by ZURB?",
       "ja": "ZURB が生み出したレスポンシブなフロントエンドフレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79824,7 +80947,8 @@
     "question_text": {
       "en": "Which RxJS primitive represents a push-based stream of values over time?",
       "ja": "時間経過に伴う値のプッシュ型ストリームを表す RxJS のプリミティブは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79864,7 +80988,8 @@
     "question_text": {
       "en": "Which Unix-style command in shells locates files by name?",
       "ja": "シェルで名前からファイルを探す Unix 系コマンドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79904,7 +81029,8 @@
     "question_text": {
       "en": "Which Vue-based meta-framework supports SSR and static generation?",
       "ja": "SSR と静的生成に対応する Vue ベースのメタフレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79944,7 +81070,8 @@
     "question_text": {
       "en": "Which React-based static site generator pulls data via GraphQL?",
       "ja": "GraphQL でデータを取り込む React ベースの静的サイトジェネレータは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79984,7 +81111,8 @@
     "question_text": {
       "en": "Which GraphQL operation type pushes server updates to clients over time?",
       "ja": "サーバの更新を時系列でクライアントに送る GraphQL の操作型は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80024,7 +81152,8 @@
     "question_text": {
       "en": "Which XML-based open standard exchanges authentication and authorization data?",
       "ja": "認証認可情報を交換する XML ベースのオープン標準は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80064,7 +81193,8 @@
     "question_text": {
       "en": "Which Next.js rendering mode regenerates static pages on demand after deploy?",
       "ja": "デプロイ後にオンデマンドで静的ページを再生成する Next.js のレンダリング方式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80104,7 +81234,8 @@
     "question_text": {
       "en": "Which Web Vitals metric measures when the first content is painted on screen?",
       "ja": "画面に最初のコンテンツが描画されたタイミングを示す Web Vitals 指標は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80144,7 +81275,8 @@
     "question_text": {
       "en": "Which web technology pushes events from server to browser over a single HTTP connection?",
       "ja": "単一の HTTP 接続でサーバからブラウザへイベントを送る技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80184,7 +81316,8 @@
     "question_text": {
       "en": "Which browser storage persists key-value pairs without expiration on the same origin?",
       "ja": "同一オリジン上でキー値ペアを期限なく保持するブラウザストレージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80192,7 +81325,7 @@
         "en": "`<picture>`",
         "ja": "ピクチャ要素",
         "ja_typings": [
-          "pikutyayouso"
+          "pikuchayouso"
         ]
       },
       {
@@ -80224,7 +81357,8 @@
     "question_text": {
       "en": "Which HTML element lets you supply multiple image sources for different conditions?",
       "ja": "条件ごとに複数の画像ソースを与える HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80264,7 +81398,8 @@
     "question_text": {
       "en": "Which CSS at-rule applies styles only when the browser supports given features?",
       "ja": "ブラウザが指定機能を支持する場合だけスタイルを適用する CSS の at-rule は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80304,7 +81439,8 @@
     "question_text": {
       "en": "Which HTTP header controls access to browser features like camera and geolocation?",
       "ja": "カメラや位置情報など端末機能へのアクセスを制御する HTTP ヘッダは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80344,7 +81480,8 @@
     "question_text": {
       "en": "Which consortium maintains HTML, CSS, and other web standards led by Tim Berners-Lee?",
       "ja": "ティム・バーナーズ＝リーが率いる HTML や CSS の標準化団体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80384,7 +81521,8 @@
     "question_text": {
       "en": "Which organization standardizes Internet protocols such as HTTP and TLS?",
       "ja": "HTTP や TLS などインターネットプロトコルを標準化する組織は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80424,7 +81562,8 @@
     "question_text": {
       "en": "Which HTTP mechanism instructs the client to fetch a different URL?",
       "ja": "別の URL を取得するようクライアントに指示する HTTP の仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80464,7 +81603,8 @@
     "question_text": {
       "en": "Which HTTP status indicates a temporary redirect that should preserve the method?",
       "ja": "メソッドを保持したまま一時的にリダイレクトすることを示す HTTP ステータスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80504,7 +81644,8 @@
     "question_text": {
       "en": "Which HTTP status indicates the server is temporarily unable to handle the request?",
       "ja": "サーバが一時的にリクエストを処理できないことを示す HTTP ステータスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80544,7 +81685,8 @@
     "question_text": {
       "en": "Which HTTP method removes the specified resource?",
       "ja": "指定リソースを削除する HTTP メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80584,7 +81726,8 @@
     "question_text": {
       "en": "Which HTTP method returns only headers for a resource?",
       "ja": "リソースのヘッダだけを返す HTTP メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80624,7 +81767,8 @@
     "question_text": {
       "en": "Which HTTP method describes the communication options for the target resource?",
       "ja": "対象リソースに対する通信オプションを取得する HTTP メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80653,8 +81797,7 @@
         "en": "`<article>` tag",
         "ja": "アーティクルタグ",
         "ja_typings": [
-          "a-thikurutagu",
-          "a-thikulutagu"
+          "a-thikurutagu"
         ]
       }
     ],
@@ -80665,7 +81808,8 @@
     "question_text": {
       "en": "Which HTML element represents self-contained content like illustrations?",
       "ja": "挿絵など自己完結したコンテンツを表す HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80705,7 +81849,8 @@
     "question_text": {
       "en": "Which HTML element provides a drawable region for graphics via scripting?",
       "ja": "スクリプトで描画する領域を提供する HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80713,28 +81858,28 @@
         "en": "`title` attribute",
         "ja": "タイトル属性",
         "ja_typings": [
-          "taitorusokusei"
+          "taitoruzokusei"
         ]
       },
       {
         "en": "`alt` attribute",
         "ja": "オルト属性",
         "ja_typings": [
-          "orutosokusei"
+          "orutozokusei"
         ]
       },
       {
         "en": "`aria-label` attribute",
         "ja": "エリアラベル属性",
         "ja_typings": [
-          "ariaraberusokusei"
+          "eriaraberuzokusei"
         ]
       },
       {
         "en": "`label` attribute",
         "ja": "ラベル属性",
         "ja_typings": [
-          "raberusokusei"
+          "raberuzokusei"
         ]
       }
     ],
@@ -80745,7 +81890,8 @@
     "question_text": {
       "en": "Which HTML attribute provides advisory text shown as a tooltip on hover?",
       "ja": "ホバー時にツールチップとして表示される補助テキストの HTML 属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80753,28 +81899,28 @@
         "en": "`src` attribute",
         "ja": "ソース属性",
         "ja_typings": [
-          "so-susokusei"
+          "so-suzokusei"
         ]
       },
       {
         "en": "`href` attribute",
         "ja": "エイチレフ属性",
         "ja_typings": [
-          "eichirefusokusei"
+          "eichirefuzokusei"
         ]
       },
       {
         "en": "`data` attribute",
         "ja": "データ属性",
         "ja_typings": [
-          "de-tasokusei"
+          "de-tazokusei"
         ]
       },
       {
         "en": "`action` attribute",
         "ja": "アクション属性",
         "ja_typings": [
-          "akushonsokusei"
+          "akushonzokusei"
         ]
       }
     ],
@@ -80785,7 +81931,8 @@
     "question_text": {
       "en": "Which HTML attribute specifies the URL of an external resource like an image?",
       "ja": "画像など外部リソースの URL を指定する HTML 属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80793,28 +81940,28 @@
         "en": "`name` attribute",
         "ja": "ネーム属性",
         "ja_typings": [
-          "ne-musokusei"
+          "ne-muzokusei"
         ]
       },
       {
         "en": "`id` attribute",
         "ja": "アイディー属性",
         "ja_typings": [
-          "aidhi-sokusei"
+          "aidhi-zokusei"
         ]
       },
       {
         "en": "`for` attribute",
         "ja": "フォー属性",
         "ja_typings": [
-          "fo-sokusei"
+          "fo-zokusei"
         ]
       },
       {
         "en": "`value` attribute",
         "ja": "バリュー属性",
         "ja_typings": [
-          "baryu-sokusei"
+          "baryu-zokusei"
         ]
       }
     ],
@@ -80825,7 +81972,8 @@
     "question_text": {
       "en": "Which HTML attribute identifies a form control when submitted to the server?",
       "ja": "送信時にサーバへ送られるフォーム部品の識別子を表す HTML 属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80865,7 +82013,8 @@
     "question_text": {
       "en": "Which HTML element references external resources such as stylesheets?",
       "ja": "スタイルシートなど外部リソースを参照する HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80905,7 +82054,8 @@
     "question_text": {
       "en": "Which HTML element groups navigation links?",
       "ja": "ナビゲーション用のリンクをまとめる HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80945,7 +82095,8 @@
     "question_text": {
       "en": "Which of the following is NOT a real HTML element name?",
       "ja": "実在しない HTML 要素名はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80985,7 +82136,8 @@
     "question_text": {
       "en": "Which of the following is NOT a valid HTML tag?",
       "ja": "正しい HTML タグでないものはどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81000,7 +82152,7 @@
         "en": "`<picture>` tag",
         "ja": "ピクチャタグ",
         "ja_typings": [
-          "pikutyatagu"
+          "pikuchatagu"
         ]
       },
       {
@@ -81025,7 +82177,8 @@
     "question_text": {
       "en": "Which of these tag names does NOT exist in HTML?",
       "ja": "HTML に存在しないタグ名はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81054,7 +82207,6 @@
         "en": "`<applet>` tag",
         "ja": "アプレットタグ",
         "ja_typings": [
-          "aapurettotagu",
           "apurettotagu"
         ]
       }
@@ -81066,7 +82218,8 @@
     "question_text": {
       "en": "Which HTML element embeds external content such as plugins or media?",
       "ja": "プラグインやメディアなど外部コンテンツを埋め込む HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81106,7 +82259,8 @@
     "question_text": {
       "en": "Which CSS display value lays out children in a two-dimensional grid?",
       "ja": "子要素を 2 次元グリッドに配置する CSS の display 値は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81146,7 +82300,8 @@
     "question_text": {
       "en": "Which CSS display value makes the element start on a new line and take full width?",
       "ja": "要素を改行して横幅いっぱいに広げる CSS の display 値は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81175,7 +82330,6 @@
         "en": "`display: run-in`",
         "ja": "ランインディスプレイ",
         "ja_typings": [
-          "ranindhisupurei",
           "rannindhisupurei"
         ]
       }
@@ -81187,7 +82341,8 @@
     "question_text": {
       "en": "Which CSS display value flows the element within text without line breaks?",
       "ja": "要素を改行せずテキスト中に流す CSS の display 値は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81209,8 +82364,6 @@
         "en": "Table",
         "ja": "テーブルレイアウト",
         "ja_typings": [
-          "te-bururereiauto",
-          "te-bureiauto",
           "te-burureiauto"
         ]
       },
@@ -81229,7 +82382,8 @@
     "question_text": {
       "en": "Which CSS layout module arranges items in a single dimension with flexible sizing?",
       "ja": "アイテムを 1 次元に柔軟なサイズで並べる CSS レイアウトモジュールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81269,7 +82423,8 @@
     "question_text": {
       "en": "Which legacy CSS property removes an element from normal flow to the side?",
       "ja": "通常フローから要素を外して横に寄せる古典的な CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81309,7 +82464,8 @@
     "question_text": {
       "en": "Which CSS property sets how an element is positioned in the document?",
       "ja": "要素の配置方法を指定する CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81349,7 +82505,8 @@
     "question_text": {
       "en": "Which continent contains France, Germany, and Italy?",
       "ja": "フランス・ドイツ・イタリアを含む大陸は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81371,7 +82528,7 @@
         "en": "United States",
         "ja": "アメリカ合衆国",
         "ja_typings": [
-          "amerika/gasshuukoku"
+          "amerikagasshuukoku"
         ]
       },
       {
@@ -81389,7 +82546,8 @@
     "question_text": {
       "en": "Which country has the world's largest population by historical record in 2020?",
       "ja": "2020年時点で世界最大の人口を持っていた国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81397,28 +82555,28 @@
         "en": "Gobi Desert",
         "ja": "ゴビ砂漠",
         "ja_typings": [
-          "gobi/sabaku"
+          "gobisabaku"
         ]
       },
       {
         "en": "Taklamakan",
         "ja": "タクラマカン砂漠",
         "ja_typings": [
-          "takuramakan/sabaku"
+          "takuramakansabaku"
         ]
       },
       {
         "en": "Karakum",
         "ja": "カラクム砂漠",
         "ja_typings": [
-          "karakumu/sabaku"
+          "karakumusabaku"
         ]
       },
       {
         "en": "Thar",
         "ja": "タール砂漠",
         "ja_typings": [
-          "ta-ru/sabaku"
+          "ta-rusabaku"
         ]
       }
     ],
@@ -81429,7 +82587,8 @@
     "question_text": {
       "en": "Which desert stretches across southern Mongolia and northern China?",
       "ja": "モンゴル南部と中国北部に広がる砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81437,28 +82596,28 @@
         "en": "Lake Tanganyika",
         "ja": "タンガニーカ湖",
         "ja_typings": [
-          "tangani-ka/ko"
+          "tangani-kako"
         ]
       },
       {
         "en": "Lake Victoria",
         "ja": "ヴィクトリア湖",
         "ja_typings": [
-          "vikutoria/ko"
+          "vikutoriako"
         ]
       },
       {
         "en": "Lake Malawi",
         "ja": "マラウイ湖",
         "ja_typings": [
-          "maraui/ko"
+          "marauiko"
         ]
       },
       {
         "en": "Lake Chad",
         "ja": "チャド湖",
         "ja_typings": [
-          "chado/ko"
+          "chadoko"
         ]
       }
     ],
@@ -81469,7 +82628,8 @@
     "question_text": {
       "en": "Which African lake is the world's second-deepest freshwater lake?",
       "ja": "世界で2番目に深い淡水湖であるアフリカの湖は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81477,28 +82637,28 @@
         "en": "Lake Superior",
         "ja": "スペリオル湖",
         "ja_typings": [
-          "superioru/ko"
+          "superioruko"
         ]
       },
       {
         "en": "Lake Huron",
         "ja": "ヒューロン湖",
         "ja_typings": [
-          "hyu-ron/ko"
+          "hyu-ronko"
         ]
       },
       {
         "en": "Lake Michigan",
         "ja": "ミシガン湖",
         "ja_typings": [
-          "mishigan/ko"
+          "mishiganko"
         ]
       },
       {
         "en": "Lake Erie",
         "ja": "エリー湖",
         "ja_typings": [
-          "eri-/ko"
+          "eri-ko"
         ]
       }
     ],
@@ -81509,7 +82669,8 @@
     "question_text": {
       "en": "Which of the Great Lakes has the largest surface area?",
       "ja": "五大湖のうち最も面積が大きい湖は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81517,28 +82678,28 @@
         "en": "Alps",
         "ja": "アルプス山脈",
         "ja_typings": [
-          "arupusu/sanmyaku"
+          "arupususanmyaku"
         ]
       },
       {
         "en": "Pyrenees",
         "ja": "ピレネー山脈",
         "ja_typings": [
-          "pirene-/sanmyaku"
+          "pirene-sanmyaku"
         ]
       },
       {
         "en": "Carpathians",
         "ja": "カルパティア山脈",
         "ja_typings": [
-          "karupathia/sanmyaku"
+          "karupathiasanmyaku"
         ]
       },
       {
         "en": "Apennines",
         "ja": "アペニン山脈",
         "ja_typings": [
-          "apenin/sanmyaku"
+          "apeninsanmyaku"
         ]
       }
     ],
@@ -81549,7 +82710,8 @@
     "question_text": {
       "en": "Which mountain range runs through Switzerland, Austria, and northern Italy?",
       "ja": "スイス・オーストリア・北イタリアを貫く山脈は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81589,7 +82751,8 @@
     "question_text": {
       "en": "Which South American country has La Paz as one of its capitals?",
       "ja": "ラパスを首都の一つとする南米の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81629,7 +82792,8 @@
     "question_text": {
       "en": "Which African country has Khartoum as its capital?",
       "ja": "ハルツームを首都とするアフリカの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81637,7 +82801,7 @@
         "en": "United States",
         "ja": "アメリカ合衆国",
         "ja_typings": [
-          "amerika/gasshuukoku"
+          "amerikagasshuukoku"
         ]
       },
       {
@@ -81669,7 +82833,8 @@
     "question_text": {
       "en": "Which country has Washington D.C. as its capital?",
       "ja": "ワシントンD.C.を首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81677,28 +82842,28 @@
         "en": "Atacama Desert",
         "ja": "アタカマ砂漠",
         "ja_typings": [
-          "atakama/sabaku"
+          "atakamasabaku"
         ]
       },
       {
         "en": "Patagonian Desert",
         "ja": "パタゴニア砂漠",
         "ja_typings": [
-          "patagonia/sabaku"
+          "patagoniasabaku"
         ]
       },
       {
         "en": "Sechura Desert",
         "ja": "セチュラ砂漠",
         "ja_typings": [
-          "sechura/sabaku"
+          "sechurasabaku"
         ]
       },
       {
         "en": "Monte Desert",
         "ja": "モンテ砂漠",
         "ja_typings": [
-          "monte/sabaku"
+          "montesabaku"
         ]
       }
     ],
@@ -81709,7 +82874,8 @@
     "question_text": {
       "en": "Which desert is one of the driest places on Earth, located in Chile?",
       "ja": "チリにある、地球上で最も乾燥した場所の一つの砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81717,14 +82883,14 @@
         "en": "North America",
         "ja": "北アメリカ",
         "ja_typings": [
-          "kita/amerika"
+          "kitaamerika"
         ]
       },
       {
         "en": "South America",
         "ja": "南アメリカ",
         "ja_typings": [
-          "minami/amerika"
+          "minamiamerika"
         ]
       },
       {
@@ -81749,7 +82915,8 @@
     "question_text": {
       "en": "Which continent contains Canada and Mexico?",
       "ja": "カナダとメキシコを含む大陸は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81757,7 +82924,7 @@
         "en": "Antarctica",
         "ja": "南極大陸",
         "ja_typings": [
-          "nankyoku/tairiku"
+          "nankyokutairiku"
         ]
       },
       {
@@ -81771,7 +82938,7 @@
         "en": "South America",
         "ja": "南アメリカ",
         "ja_typings": [
-          "minami/amerika"
+          "minamiamerika"
         ]
       },
       {
@@ -81789,7 +82956,8 @@
     "question_text": {
       "en": "Which is the southernmost continent on Earth?",
       "ja": "地球上で最も南にある大陸は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81797,28 +82965,28 @@
         "en": "Mount Kenya",
         "ja": "ケニア山",
         "ja_typings": [
-          "kenia/san"
+          "keniasan"
         ]
       },
       {
         "en": "Mount Kilimanjaro",
         "ja": "キリマンジャロ山",
         "ja_typings": [
-          "kirimanjaro/san"
+          "kirimanjarosan"
         ]
       },
       {
         "en": "Mount Stanley",
         "ja": "スタンレー山",
         "ja_typings": [
-          "sutanre-/san"
+          "sutanre-san"
         ]
       },
       {
         "en": "Mount Meru",
         "ja": "メルー山",
         "ja_typings": [
-          "meru-/san"
+          "meru-san"
         ]
       }
     ],
@@ -81829,7 +82997,8 @@
     "question_text": {
       "en": "Which is the second-highest mountain in Africa, located in central Kenya?",
       "ja": "ケニア中央部にあるアフリカで2番目に高い山は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81869,7 +83038,8 @@
     "question_text": {
       "en": "Which is the largest city of Turkey, straddling Europe and Asia?",
       "ja": "ヨーロッパとアジアにまたがるトルコ最大の都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81877,28 +83047,28 @@
         "en": "Pyrenees",
         "ja": "ピレネー山脈",
         "ja_typings": [
-          "pirene-/sanmyaku"
+          "pirene-sanmyaku"
         ]
       },
       {
         "en": "Alps",
         "ja": "アルプス山脈",
         "ja_typings": [
-          "arupusu/sanmyaku"
+          "arupususanmyaku"
         ]
       },
       {
         "en": "Apennines",
         "ja": "アペニン山脈",
         "ja_typings": [
-          "apenin/sanmyaku"
+          "apeninsanmyaku"
         ]
       },
       {
         "en": "Cantabrian Mountains",
         "ja": "カンタブリア山脈",
         "ja_typings": [
-          "kantaburia/sanmyaku"
+          "kantaburiasanmyaku"
         ]
       }
     ],
@@ -81909,7 +83079,8 @@
     "question_text": {
       "en": "Which mountain range forms the border between France and Spain?",
       "ja": "フランスとスペインの国境を成す山脈は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81949,7 +83120,8 @@
     "question_text": {
       "en": "Which Scandinavian country has Copenhagen as its capital?",
       "ja": "コペンハーゲンを首都とする北欧の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81971,7 +83143,7 @@
         "en": "Faroe Islands",
         "ja": "フェロー諸島",
         "ja_typings": [
-          "fero-/shotou"
+          "fero-shotou"
         ]
       },
       {
@@ -81989,7 +83161,8 @@
     "question_text": {
       "en": "Which Nordic island country has Reykjavik as its capital?",
       "ja": "レイキャビクを首都とする北欧の島国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82029,7 +83202,8 @@
     "question_text": {
       "en": "Which country has Mexico City as its capital?",
       "ja": "メキシコシティを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82069,7 +83243,8 @@
     "question_text": {
       "en": "Which South American country has Caracas as its capital?",
       "ja": "カラカスを首都とする南米の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82109,7 +83284,8 @@
     "question_text": {
       "en": "Which Southeast Asian country has Vientiane as its capital?",
       "ja": "ヴィエンチャンを首都とする東南アジアの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82149,7 +83325,8 @@
     "question_text": {
       "en": "Which Southeast Asian country has Phnom Penh as its capital?",
       "ja": "プノンペンを首都とする東南アジアの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82189,7 +83366,8 @@
     "question_text": {
       "en": "Which Southeast Asian country has Naypyidaw as its capital?",
       "ja": "ネピドーを首都とする東南アジアの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82229,7 +83407,8 @@
     "question_text": {
       "en": "Which Balkan country has Sofia as its capital?",
       "ja": "ソフィアを首都とするバルカンの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82269,7 +83448,8 @@
     "question_text": {
       "en": "Which Eastern European country has Bucharest as its capital?",
       "ja": "ブカレストを首都とする東欧の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82309,7 +83489,8 @@
     "question_text": {
       "en": "Which Scandinavian country has Stockholm as its capital?",
       "ja": "ストックホルムを首都とする北欧の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82349,7 +83530,8 @@
     "question_text": {
       "en": "Which South American country has Montevideo as its capital?",
       "ja": "モンテビデオを首都とする南米の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82389,7 +83571,8 @@
     "question_text": {
       "en": "Which South American country has Asuncion as its capital?",
       "ja": "アスンシオンを首都とする南米の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82429,7 +83612,8 @@
     "question_text": {
       "en": "Which North African country has Tripoli as its capital?",
       "ja": "トリポリを首都とする北アフリカの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82469,7 +83653,8 @@
     "question_text": {
       "en": "Which Pacific island country has Suva as its capital?",
       "ja": "スバを首都とする太平洋の島国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82477,28 +83662,28 @@
         "en": "Rhine",
         "ja": "ライン川",
         "ja_typings": [
-          "rain/gawa"
+          "raingawa"
         ]
       },
       {
         "en": "Elbe",
         "ja": "エルベ川",
         "ja_typings": [
-          "erube/gawa"
+          "erubegawa"
         ]
       },
       {
         "en": "Danube",
         "ja": "ドナウ川",
         "ja_typings": [
-          "donau/gawa"
+          "donaugawa"
         ]
       },
       {
         "en": "Seine",
         "ja": "セーヌ川",
         "ja_typings": [
-          "se-nu/gawa"
+          "se-nugawa"
         ]
       }
     ],
@@ -82509,7 +83694,8 @@
     "question_text": {
       "en": "Which river flows through Germany and the Netherlands into the North Sea?",
       "ja": "ドイツとオランダを流れ北海に注ぐ川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82517,28 +83703,28 @@
         "en": "Danube",
         "ja": "ドナウ川",
         "ja_typings": [
-          "donau/gawa"
+          "donaugawa"
         ]
       },
       {
         "en": "Rhine",
         "ja": "ライン川",
         "ja_typings": [
-          "rain/gawa"
+          "raingawa"
         ]
       },
       {
         "en": "Volga",
         "ja": "ヴォルガ川",
         "ja_typings": [
-          "voruga/gawa"
+          "vorugagawa"
         ]
       },
       {
         "en": "Dnieper",
         "ja": "ドニエプル川",
         "ja_typings": [
-          "doniepuru/gawa"
+          "doniepurugawa"
         ]
       }
     ],
@@ -82549,7 +83735,8 @@
     "question_text": {
       "en": "Which river flows through Vienna, Budapest, and Belgrade into the Black Sea?",
       "ja": "ウィーン・ブダペスト・ベオグラードを流れ黒海に注ぐ川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82557,28 +83744,28 @@
         "en": "Loire",
         "ja": "ロワール川",
         "ja_typings": [
-          "rowa-ru/gawa"
+          "rowa-rugawa"
         ]
       },
       {
         "en": "Seine",
         "ja": "セーヌ川",
         "ja_typings": [
-          "se-nu/gawa"
+          "se-nugawa"
         ]
       },
       {
         "en": "Rhone",
         "ja": "ローヌ川",
         "ja_typings": [
-          "ro-nu/gawa"
+          "ro-nugawa"
         ]
       },
       {
         "en": "Garonne",
         "ja": "ガロンヌ川",
         "ja_typings": [
-          "garonnu/gawa"
+          "garonnugawa"
         ]
       }
     ],
@@ -82589,7 +83776,8 @@
     "question_text": {
       "en": "Which is the longest river in France?",
       "ja": "フランスで最も長い川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82618,7 +83806,7 @@
         "en": "Mekong",
         "ja": "メコン川",
         "ja_typings": [
-          "mekon/gawa"
+          "mekongawa"
         ]
       }
     ],
@@ -82629,7 +83817,8 @@
     "question_text": {
       "en": "Which Chinese river is also known as the Huang He?",
       "ja": "「黄河」とも呼ばれる中国の川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82637,7 +83826,7 @@
         "en": "Mekong",
         "ja": "メコン川",
         "ja_typings": [
-          "mekon/gawa"
+          "mekongawa"
         ]
       },
       {
@@ -82651,14 +83840,14 @@
         "en": "Salween",
         "ja": "サルウィン川",
         "ja_typings": [
-          "saruuin/gawa"
+          "saruuingawa"
         ]
       },
       {
         "en": "Irrawaddy",
         "ja": "イラワジ川",
         "ja_typings": [
-          "irawaji/gawa"
+          "irawajigawa"
         ]
       }
     ],
@@ -82669,7 +83858,8 @@
     "question_text": {
       "en": "Which river flows from Tibet through Laos and Vietnam into the South China Sea?",
       "ja": "チベットからラオス・ベトナムを流れ南シナ海に注ぐ川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82698,7 +83888,7 @@
         "en": "Mekong",
         "ja": "メコン川",
         "ja_typings": [
-          "mekon/gawa"
+          "mekongawa"
         ]
       }
     ],
@@ -82709,7 +83899,8 @@
     "question_text": {
       "en": "Which river flows through Guangzhou into the South China Sea?",
       "ja": "広州を流れ南シナ海に注ぐ中国の川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82724,14 +83915,14 @@
         "en": "Caspian Sea",
         "ja": "カスピ海",
         "ja_typings": [
-          "kasupi/kai"
+          "kasupikai"
         ]
       },
       {
         "en": "Aegean Sea",
         "ja": "エーゲ海",
         "ja_typings": [
-          "e-ge/kai"
+          "e-gekai"
         ]
       },
       {
@@ -82749,7 +83940,8 @@
     "question_text": {
       "en": "Which sea lies between Turkey and Ukraine?",
       "ja": "トルコとウクライナの間にある海は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82757,28 +83949,28 @@
         "en": "Taklamakan",
         "ja": "タクラマカン砂漠",
         "ja_typings": [
-          "takuramakan/sabaku"
+          "takuramakansabaku"
         ]
       },
       {
         "en": "Gobi Desert",
         "ja": "ゴビ砂漠",
         "ja_typings": [
-          "gobi/sabaku"
+          "gobisabaku"
         ]
       },
       {
         "en": "Karakum",
         "ja": "カラクム砂漠",
         "ja_typings": [
-          "karakumu/sabaku"
+          "karakumusabaku"
         ]
       },
       {
         "en": "Kyzylkum",
         "ja": "キジルクム砂漠",
         "ja_typings": [
-          "kijirukumu/sabaku"
+          "kijirukumusabaku"
         ]
       }
     ],
@@ -82789,7 +83981,8 @@
     "question_text": {
       "en": "Which desert lies in the Tarim Basin of northwest China?",
       "ja": "中国北西部タリム盆地にある砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82797,28 +83990,28 @@
         "en": "Karakum",
         "ja": "カラクム砂漠",
         "ja_typings": [
-          "karakumu/sabaku"
+          "karakumusabaku"
         ]
       },
       {
         "en": "Kyzylkum",
         "ja": "キジルクム砂漠",
         "ja_typings": [
-          "kijirukumu/sabaku"
+          "kijirukumusabaku"
         ]
       },
       {
         "en": "Taklamakan",
         "ja": "タクラマカン砂漠",
         "ja_typings": [
-          "takuramakan/sabaku"
+          "takuramakansabaku"
         ]
       },
       {
         "en": "Gobi Desert",
         "ja": "ゴビ砂漠",
         "ja_typings": [
-          "gobi/sabaku"
+          "gobisabaku"
         ]
       }
     ],
@@ -82829,7 +84022,8 @@
     "question_text": {
       "en": "Which desert covers most of Turkmenistan?",
       "ja": "トルクメニスタンの大部分を覆う砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82837,28 +84031,28 @@
         "en": "Thar",
         "ja": "タール砂漠",
         "ja_typings": [
-          "ta-ru/sabaku"
+          "ta-rusabaku"
         ]
       },
       {
         "en": "Karakum",
         "ja": "カラクム砂漠",
         "ja_typings": [
-          "karakumu/sabaku"
+          "karakumusabaku"
         ]
       },
       {
         "en": "Gobi Desert",
         "ja": "ゴビ砂漠",
         "ja_typings": [
-          "gobi/sabaku"
+          "gobisabaku"
         ]
       },
       {
         "en": "Negev",
         "ja": "ネゲヴ砂漠",
         "ja_typings": [
-          "negevu/sabaku"
+          "negevusabaku"
         ]
       }
     ],
@@ -82869,7 +84063,8 @@
     "question_text": {
       "en": "Which desert lies in northwestern India and southeastern Pakistan?",
       "ja": "インド北西部とパキスタン南東部にある砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82909,7 +84104,8 @@
     "question_text": {
       "en": "Which microstate on the French Riviera is famous for its casino?",
       "ja": "フレンチリヴィエラにある、カジノで有名な小国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82949,7 +84145,8 @@
     "question_text": {
       "en": "Which microstate lies between Switzerland and Austria?",
       "ja": "スイスとオーストリアの間にある小国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82957,28 +84154,28 @@
         "en": "Strait of Hormuz",
         "ja": "ホルムズ海峡",
         "ja_typings": [
-          "horumuzu/kaikyou"
+          "horumuzukaikyou"
         ]
       },
       {
         "en": "Strait of Malacca",
         "ja": "マラッカ海峡",
         "ja_typings": [
-          "marakka/kaikyou"
+          "marakkakaikyou"
         ]
       },
       {
         "en": "Bab-el-Mandeb",
         "ja": "バブ・エル・マンデブ海峡",
         "ja_typings": [
-          "babu/eru/mandebu/kaikyou"
+          "babu/eru/mandebukaikyou"
         ]
       },
       {
         "en": "Bosphorus",
         "ja": "ボスポラス海峡",
         "ja_typings": [
-          "bosuporasu/kaikyou"
+          "bosuporasukaikyou"
         ]
       }
     ],
@@ -82989,7 +84186,8 @@
     "question_text": {
       "en": "Which strait connects the Persian Gulf to the Gulf of Oman?",
       "ja": "ペルシア湾とオマーン湾を結ぶ海峡は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82997,28 +84195,28 @@
         "en": "Strait of Malacca",
         "ja": "マラッカ海峡",
         "ja_typings": [
-          "marakka/kaikyou"
+          "marakkakaikyou"
         ]
       },
       {
         "en": "Strait of Hormuz",
         "ja": "ホルムズ海峡",
         "ja_typings": [
-          "horumuzu/kaikyou"
+          "horumuzukaikyou"
         ]
       },
       {
         "en": "Sunda Strait",
         "ja": "スンダ海峡",
         "ja_typings": [
-          "sunda/kaikyou"
+          "sundakaikyou"
         ]
       },
       {
         "en": "Taiwan Strait",
         "ja": "台湾海峡",
         "ja_typings": [
-          "taiwan/kaikyou"
+          "taiwankaikyou"
         ]
       }
     ],
@@ -83029,7 +84227,8 @@
     "question_text": {
       "en": "Which strait connects the Indian Ocean and the South China Sea?",
       "ja": "インド洋と南シナ海を結ぶ海峡は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83069,7 +84268,8 @@
     "question_text": {
       "en": "Which island country in the eastern Mediterranean has Nicosia as its capital?",
       "ja": "東地中海にあるニコシアを首都とする島国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83109,7 +84309,8 @@
     "question_text": {
       "en": "Which Mediterranean island country has Valletta as its capital?",
       "ja": "ヴァレッタを首都とする地中海の島国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83138,7 +84339,7 @@
         "en": "East Timor",
         "ja": "東ティモール",
         "ja_typings": [
-          "higashi/thimo-ru"
+          "higashithimo-ru"
         ]
       }
     ],
@@ -83149,7 +84350,8 @@
     "question_text": {
       "en": "Which small Southeast Asian country on Borneo is ruled by a sultan?",
       "ja": "ボルネオ島にある、スルタンが統治する東南アジアの小国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83189,7 +84391,8 @@
     "question_text": {
       "en": "Which is the most populous city in Australia?",
       "ja": "オーストラリアで最も人口の多い都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83229,7 +84432,8 @@
     "question_text": {
       "en": "Which Australian city hosts the famous Melbourne Cup horse race?",
       "ja": "メルボルンカップ競馬が開催されるオーストラリアの都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83269,7 +84473,8 @@
     "question_text": {
       "en": "Which is the capital of Western Australia?",
       "ja": "西オーストラリア州の州都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83309,7 +84514,8 @@
     "question_text": {
       "en": "Which is the second-highest mountain in the world?",
       "ja": "世界で2番目に高い山は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83349,7 +84555,8 @@
     "question_text": {
       "en": "Which Mongol emperor founded the Yuan dynasty?",
       "ja": "元朝を建てたモンゴル皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83357,28 +84564,28 @@
         "en": "Henry IV",
         "ja": "アンリ4世",
         "ja_typings": [
-          "anri/4/sei"
+          "anri4sei"
         ]
       },
       {
         "en": "Louis XIII",
         "ja": "ルイ13世",
         "ja_typings": [
-          "rui/13/sei"
+          "rui13sei"
         ]
       },
       {
         "en": "Henry III",
         "ja": "アンリ3世",
         "ja_typings": [
-          "anri/3/sei"
+          "anri3sei"
         ]
       },
       {
         "en": "Charles IX",
         "ja": "シャルル9世",
         "ja_typings": [
-          "sharuru/9/sei"
+          "sharuru9sei"
         ]
       }
     ],
@@ -83389,7 +84596,8 @@
     "question_text": {
       "en": "Which French king issued the Edict of Nantes in 1598?",
       "ja": "1598年にナント勅令を発したフランス王は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83429,7 +84637,8 @@
     "question_text": {
       "en": "Which Indian revolutionary led the Indian National Army during WWII?",
       "ja": "第二次大戦中にインド国民軍を率いた独立運動家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83469,7 +84678,8 @@
     "question_text": {
       "en": "Which Soviet revolutionary founded the Red Army and was later exiled by Stalin?",
       "ja": "赤軍を創設し後にスターリンに追放されたソ連の革命家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83509,7 +84719,8 @@
     "question_text": {
       "en": "Which Chinese dynasty was founded by Kublai Khan in 1271?",
       "ja": "1271年にフビライ・ハンが建てた中国の王朝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83517,28 +84728,28 @@
         "en": "Crimean War",
         "ja": "クリミア戦争",
         "ja_typings": [
-          "kurimia/sensou"
+          "kurimiasensou"
         ]
       },
       {
         "en": "Russo-Turkish War",
         "ja": "露土戦争",
         "ja_typings": [
-          "roto/sensou"
+          "rotosensou"
         ]
       },
       {
         "en": "Franco-Prussian War",
         "ja": "普仏戦争",
         "ja_typings": [
-          "fufutsu/sensou"
+          "fufutsusensou"
         ]
       },
       {
         "en": "Austro-Prussian War",
         "ja": "普墺戦争",
         "ja_typings": [
-          "fuou/sensou"
+          "fuousensou"
         ]
       }
     ],
@@ -83549,7 +84760,8 @@
     "question_text": {
       "en": "Which 19th-century war was fought between Russia and an alliance of Britain, France, and the Ottoman Empire?",
       "ja": "ロシアと英仏オスマン連合の間で起こった19世紀の戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83589,7 +84801,8 @@
     "question_text": {
       "en": "Which Serbian-American inventor pioneered alternating-current electrical systems?",
       "ja": "交流電力システムを開拓したセルビア系米国人発明家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83597,7 +84810,6 @@
         "en": "Thermidorian Reaction",
         "ja": "テルミドールのクーデター",
         "ja_typings": [
-          "terumido-ru/no/ku-deta-",
           "terumido-runoku-deta-"
         ]
       },
@@ -83605,21 +84817,20 @@
         "en": "Storming of the Bastille",
         "ja": "バスティーユ襲撃",
         "ja_typings": [
-          "basuthi-yu/shuugeki"
+          "basuthi-yushuugeki"
         ]
       },
       {
         "en": "Night of August 4",
         "ja": "8月4日の夜",
         "ja_typings": [
-          "8gatsu/4nichi/no/yoru"
+          "8gatsu4nichinoyoru"
         ]
       },
       {
         "en": "Brumaire Coup",
         "ja": "ブリュメールのクーデター",
         "ja_typings": [
-          "buryume-ru/no/ku-deta-",
           "buryume-runoku-deta-"
         ]
       }
@@ -83631,7 +84842,8 @@
     "question_text": {
       "en": "Which 1794 event ended the Reign of Terror in revolutionary France?",
       "ja": "1794年に恐怖政治を終わらせたフランス革命期の事件は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83639,28 +84851,28 @@
         "en": "Battle of Valmy",
         "ja": "ヴァルミーの戦い",
         "ja_typings": [
-          "varumi-/no/tatakai"
+          "varumi-notatakai"
         ]
       },
       {
         "en": "Battle of Jemappes",
         "ja": "ジェマップの戦い",
         "ja_typings": [
-          "jemappu/no/tatakai"
+          "jemappunotatakai"
         ]
       },
       {
         "en": "Battle of Fleurus",
         "ja": "フルーリュスの戦い",
         "ja_typings": [
-          "furu-ryusu/no/tatakai"
+          "furu-ryusunotatakai"
         ]
       },
       {
         "en": "Battle of Marengo",
         "ja": "マレンゴの戦い",
         "ja_typings": [
-          "marengo/no/tatakai"
+          "marengonotatakai"
         ]
       }
     ],
@@ -83671,7 +84883,8 @@
     "question_text": {
       "en": "Which 1792 battle saw French revolutionary forces stop a Prussian invasion?",
       "ja": "1792年にフランス革命軍がプロイセン軍を阻止した戦いは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83711,7 +84924,8 @@
     "question_text": {
       "en": "Which Renaissance artist painted the Sistine Chapel ceiling?",
       "ja": "システィーナ礼拝堂の天井画を描いたルネサンスの芸術家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83751,7 +84965,8 @@
     "question_text": {
       "en": "Which Renaissance painter created 'The School of Athens'?",
       "ja": "「アテネの学堂」を描いたルネサンスの画家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83791,7 +85006,8 @@
     "question_text": {
       "en": "Which Renaissance painter created 'The Birth of Venus'?",
       "ja": "「ヴィーナスの誕生」を描いたルネサンスの画家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83820,7 +85036,6 @@
         "en": "Vallabhbhai Patel",
         "ja": "ヴァッラブバーイー・パテール",
         "ja_typings": [
-          "varrabu/ba-i-/pate-ru",
           "varrabuba-i-/pate-ru"
         ]
       }
@@ -83832,7 +85047,8 @@
     "question_text": {
       "en": "Who was the first Prime Minister of independent India?",
       "ja": "独立インドの初代首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83872,7 +85088,8 @@
     "question_text": {
       "en": "Which Mongol Great Khan succeeded Genghis Khan?",
       "ja": "チンギス・ハンの後を継いだモンゴル帝国の大ハーンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83880,14 +85097,14 @@
         "en": "Charles X",
         "ja": "シャルル10世",
         "ja_typings": [
-          "sharuru/10/sei"
+          "sharuru10sei"
         ]
       },
       {
         "en": "Louis XVIII",
         "ja": "ルイ18世",
         "ja_typings": [
-          "rui/18/sei"
+          "rui18sei"
         ]
       },
       {
@@ -83901,7 +85118,7 @@
         "en": "Napoleon III",
         "ja": "ナポレオン3世",
         "ja_typings": [
-          "naporeon/3/sei"
+          "naporeon3sei"
         ]
       }
     ],
@@ -83912,7 +85129,8 @@
     "question_text": {
       "en": "Which French king was overthrown in the July Revolution of 1830?",
       "ja": "1830年7月革命で退位したフランス王は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83941,7 +85159,7 @@
         "en": "Commodus",
         "ja": "コンモドゥス",
         "ja_typings": [
-          "konmodusu"
+          "konmodwusu"
         ]
       }
     ],
@@ -83952,7 +85170,8 @@
     "question_text": {
       "en": "Which Roman emperor was infamous for cruelty and was assassinated in 41 AD?",
       "ja": "残虐で知られ41年に暗殺されたローマ皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83960,28 +85179,28 @@
         "en": "Battle of Leipzig",
         "ja": "ライプツィヒの戦い",
         "ja_typings": [
-          "raiputsuhi/no/tatakai"
+          "raiputsihinotatakai"
         ]
       },
       {
         "en": "Battle of Waterloo",
         "ja": "ワーテルローの戦い",
         "ja_typings": [
-          "wa-teruroo/no/tatakai"
+          "wa-teruro-notatakai"
         ]
       },
       {
         "en": "Battle of Borodino",
         "ja": "ボロジノの戦い",
         "ja_typings": [
-          "borojino/no/tatakai"
+          "borojinonotatakai"
         ]
       },
       {
         "en": "Battle of Austerlitz",
         "ja": "アウステルリッツの戦い",
         "ja_typings": [
-          "ausuterurittsu/no/tatakai"
+          "ausuterurittsunotatakai"
         ]
       }
     ],
@@ -83992,7 +85211,8 @@
     "question_text": {
       "en": "Which 1813 battle saw Napoleon defeated by a coalition of European powers?",
       "ja": "1813年にナポレオンが欧州連合軍に敗れた戦いは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84032,7 +85252,8 @@
     "question_text": {
       "en": "Which British PM is associated with the Munich Agreement appeasing Hitler in 1938?",
       "ja": "1938年のミュンヘン協定でヒトラーに宥和したイギリス首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84072,7 +85293,8 @@
     "question_text": {
       "en": "Which British Labour PM led postwar reforms including the NHS?",
       "ja": "NHS創設など戦後改革を進めたイギリス労働党の首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84112,7 +85334,8 @@
     "question_text": {
       "en": "Which British PM led Britain during the 1956 Suez Crisis?",
       "ja": "1956年のスエズ危機時のイギリス首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84152,7 +85375,8 @@
     "question_text": {
       "en": "Which Nazi leader headed the SS and organized the Holocaust?",
       "ja": "親衛隊を率いホロコーストを組織したナチ指導者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84192,7 +85416,8 @@
     "question_text": {
       "en": "Which Nazi leader served as Minister of Propaganda?",
       "ja": "ナチス・ドイツの宣伝大臣を務めた人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84232,7 +85457,8 @@
     "question_text": {
       "en": "Which Nazi leader founded the Luftwaffe and the Gestapo?",
       "ja": "ルフトヴァッフェとゲシュタポを創設したナチ指導者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84272,7 +85498,8 @@
     "question_text": {
       "en": "Which Soviet leader denounced Stalin in 1956 and led during the Cuban Missile Crisis?",
       "ja": "1956年にスターリン批判を行いキューバ危機を経験したソ連指導者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84312,7 +85539,8 @@
     "question_text": {
       "en": "Which US president and WWII general served from 1953 to 1961?",
       "ja": "1953〜1961年に在任した第二次大戦の将軍出身の米大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84352,7 +85580,8 @@
     "question_text": {
       "en": "Which Mughal emperor known for religious tolerance ruled India in the 16th century?",
       "ja": "宗教的寛容で知られる16世紀インドのムガル皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84392,7 +85621,8 @@
     "question_text": {
       "en": "Which Mughal emperor was known for orthodox Islamic rule and expansion in the late 17th century?",
       "ja": "17世紀後半に厳格なイスラム統治と領土拡大を行ったムガル皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84400,28 +85630,28 @@
         "en": "Balkan War",
         "ja": "バルカン戦争",
         "ja_typings": [
-          "barukan/sensou"
+          "barukansensou"
         ]
       },
       {
         "en": "Crimean War",
         "ja": "クリミア戦争",
         "ja_typings": [
-          "kurimia/sensou"
+          "kurimiasensou"
         ]
       },
       {
         "en": "Russo-Turkish War",
         "ja": "露土戦争",
         "ja_typings": [
-          "roto/sensou"
+          "rotosensou"
         ]
       },
       {
         "en": "Greco-Turkish War",
         "ja": "希土戦争",
         "ja_typings": [
-          "kido/sensou"
+          "kidosensou"
         ]
       }
     ],
@@ -84432,7 +85662,8 @@
     "question_text": {
       "en": "Which 1912-1913 war was fought between Balkan states and the Ottoman Empire?",
       "ja": "1912〜13年にバルカン諸国とオスマン帝国の間で起きた戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84472,7 +85703,8 @@
     "question_text": {
       "en": "Which ancient Mesoamerican civilization is known for colossal stone heads?",
       "ja": "巨大な石頭像で知られる古代メソアメリカ文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84512,7 +85744,8 @@
     "question_text": {
       "en": "Which ancient civilization built the pyramids of Giza?",
       "ja": "ギザのピラミッドを築いた古代文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84552,7 +85785,8 @@
     "question_text": {
       "en": "Which ancient civilization invented paper and gunpowder?",
       "ja": "紙と火薬を発明した古代文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84567,21 +85801,21 @@
         "en": "Edward VII",
         "ja": "エドワード7世",
         "ja_typings": [
-          "edowa-do/7/sei"
+          "edowa-do7sei"
         ]
       },
       {
         "en": "George V",
         "ja": "ジョージ5世",
         "ja_typings": [
-          "jo-jii/5/sei"
+          "jo-ji5sei"
         ]
       },
       {
         "en": "William IV",
         "ja": "ウィリアム4世",
         "ja_typings": [
-          "wiriamu/4/sei"
+          "wiriamu4sei"
         ]
       }
     ],
@@ -84592,7 +85826,8 @@
     "question_text": {
       "en": "Which British monarch reigned during the height of the British Empire from 1837 to 1901?",
       "ja": "1837〜1901年に大英帝国の絶頂期に在位した君主は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84632,7 +85867,8 @@
     "question_text": {
       "en": "Which Japanese era ran from 1989 to 2019?",
       "ja": "1989年から2019年まで続いた日本の元号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84672,7 +85908,8 @@
     "question_text": {
       "en": "Which Japanese era began in 2019?",
       "ja": "2019年に始まった日本の元号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84680,28 +85917,28 @@
         "en": "Vietnam War",
         "ja": "ベトナム戦争",
         "ja_typings": [
-          "betonamu/sensou"
+          "betonamusensou"
         ]
       },
       {
         "en": "Korean War",
         "ja": "朝鮮戦争",
         "ja_typings": [
-          "chousen/sensou"
+          "chousensensou"
         ]
       },
       {
         "en": "Gulf War",
         "ja": "湾岸戦争",
         "ja_typings": [
-          "wangan/sensou"
+          "wangansensou"
         ]
       },
       {
         "en": "Cambodian Civil War",
         "ja": "カンボジア内戦",
         "ja_typings": [
-          "kanbojia/naisen"
+          "kanbojianaisen"
         ]
       }
     ],
@@ -84712,7 +85949,8 @@
     "question_text": {
       "en": "Which 20th-century war involved US military intervention in Southeast Asia from 1955 to 1975?",
       "ja": "1955〜1975年に米軍が東南アジアに介入した20世紀の戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84720,28 +85958,28 @@
         "en": "Holy Roman Empire",
         "ja": "神聖ローマ帝国",
         "ja_typings": [
-          "shinsei/ro-ma/teikoku"
+          "shinseiro-mateikoku"
         ]
       },
       {
         "en": "Byzantine Empire",
         "ja": "ビザンツ帝国",
         "ja_typings": [
-          "bizantsu/teikoku"
+          "bizantsuteikoku"
         ]
       },
       {
         "en": "Carolingian Empire",
         "ja": "カロリング帝国",
         "ja_typings": [
-          "karoringu/teikoku"
+          "karoringuteikoku"
         ]
       },
       {
         "en": "Frankish Kingdom",
         "ja": "フランク王国",
         "ja_typings": [
-          "furanku/oukoku"
+          "furankuoukoku"
         ]
       }
     ],
@@ -84752,7 +85990,8 @@
     "question_text": {
       "en": "Which European political entity existed from 962 to 1806 in central Europe?",
       "ja": "962年から1806年まで中欧に存在した政治体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84760,28 +85999,28 @@
         "en": "Abu Simbel Temple",
         "ja": "アブ・シンベル神殿",
         "ja_typings": [
-          "abu/shinberu/shinden"
+          "abushinberushinden"
         ]
       },
       {
         "en": "Luxor Temple",
         "ja": "ルクソール神殿",
         "ja_typings": [
-          "rukuso-ru/shinden"
+          "rukuso-rushinden"
         ]
       },
       {
         "en": "Karnak Temple",
         "ja": "カルナック神殿",
         "ja_typings": [
-          "karunakku/shinden"
+          "karunakkushinden"
         ]
       },
       {
         "en": "Temple of Hatshepsut",
         "ja": "ハトシェプスト葬祭殿",
         "ja_typings": [
-          "hatoshepusuto/sousaiden"
+          "hatoshepusutosousaiden"
         ]
       }
     ],
@@ -84792,7 +86031,8 @@
     "question_text": {
       "en": "Which Egyptian temple complex was relocated due to the Aswan High Dam?",
       "ja": "アスワンハイダム建設のため移築された古代エジプトの神殿は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84800,28 +86040,28 @@
         "en": "Luxor Temple",
         "ja": "ルクソール神殿",
         "ja_typings": [
-          "rukuso-ru/shinden"
+          "rukuso-rushinden"
         ]
       },
       {
         "en": "Karnak Temple",
         "ja": "カルナック神殿",
         "ja_typings": [
-          "karunakku/shinden"
+          "karunakkushinden"
         ]
       },
       {
         "en": "Abu Simbel Temple",
         "ja": "アブ・シンベル神殿",
         "ja_typings": [
-          "abu/shinberu/shinden"
+          "abushinberushinden"
         ]
       },
       {
         "en": "Edfu Temple",
         "ja": "エドフ神殿",
         "ja_typings": [
-          "edofu/shinden"
+          "edofushinden"
         ]
       }
     ],
@@ -84832,7 +86072,8 @@
     "question_text": {
       "en": "Which Egyptian temple in modern Luxor was the southern sanctuary of Amun?",
       "ja": "現在のルクソールにあるアモン神の南方聖域とされた神殿は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84840,28 +86081,28 @@
         "en": "Karnak Temple",
         "ja": "カルナック神殿",
         "ja_typings": [
-          "karunakku/shinden"
+          "karunakkushinden"
         ]
       },
       {
         "en": "Luxor Temple",
         "ja": "ルクソール神殿",
         "ja_typings": [
-          "rukuso-ru/shinden"
+          "rukuso-rushinden"
         ]
       },
       {
         "en": "Abu Simbel Temple",
         "ja": "アブ・シンベル神殿",
         "ja_typings": [
-          "abu/shinberu/shinden"
+          "abushinberushinden"
         ]
       },
       {
         "en": "Philae Temple",
         "ja": "フィラエ神殿",
         "ja_typings": [
-          "firae/shinden"
+          "firaeshinden"
         ]
       }
     ],
@@ -84872,7 +86113,8 @@
     "question_text": {
       "en": "Which vast Egyptian temple complex was dedicated mainly to Amun-Ra?",
       "ja": "主にアモン・ラー神に捧げられたエジプト最大の神殿群は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84880,7 +86122,6 @@
         "en": "Julius Caesar",
         "ja": "ユリウス・カエサル",
         "ja_typings": [
-          "uriusu/kaesaru",
           "yuriusu/kaesaru"
         ]
       },
@@ -84913,7 +86154,8 @@
     "question_text": {
       "en": "Which Roman general crossed the Rubicon in 49 BC?",
       "ja": "紀元前49年にルビコン川を渡ったローマの将軍は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84921,28 +86163,28 @@
         "en": "Tokugawa Iemochi",
         "ja": "徳川家茂",
         "ja_typings": [
-          "tokugawa/iemochi"
+          "tokugawaiemochi"
         ]
       },
       {
         "en": "Tokugawa Iesada",
         "ja": "徳川家定",
         "ja_typings": [
-          "tokugawa/iesada"
+          "tokugawaiesada"
         ]
       },
       {
         "en": "Tokugawa Nariaki",
         "ja": "徳川斉昭",
         "ja_typings": [
-          "tokugawa/nariaki"
+          "tokugawanariaki"
         ]
       },
       {
         "en": "Tokugawa Yoshinobu",
         "ja": "徳川慶喜",
         "ja_typings": [
-          "tokugawa/yoshinobu"
+          "tokugawayoshinobu"
         ]
       }
     ],
@@ -84953,7 +86195,8 @@
     "question_text": {
       "en": "Which 14th Tokugawa shogun reigned during the late Bakumatsu period?",
       "ja": "幕末期に在職した第14代徳川将軍は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84961,28 +86204,28 @@
         "en": "Tokugawa Iesada",
         "ja": "徳川家定",
         "ja_typings": [
-          "tokugawa/iesada"
+          "tokugawaiesada"
         ]
       },
       {
         "en": "Tokugawa Iemochi",
         "ja": "徳川家茂",
         "ja_typings": [
-          "tokugawa/iemochi"
+          "tokugawaiemochi"
         ]
       },
       {
         "en": "Tokugawa Ieyoshi",
         "ja": "徳川家慶",
         "ja_typings": [
-          "tokugawa/ieyoshi"
+          "tokugawaieyoshi"
         ]
       },
       {
         "en": "Tokugawa Yoshinobu",
         "ja": "徳川慶喜",
         "ja_typings": [
-          "tokugawa/yoshinobu"
+          "tokugawayoshinobu"
         ]
       }
     ],
@@ -84993,7 +86236,8 @@
     "question_text": {
       "en": "Which 13th Tokugawa shogun ruled from 1853 to 1858?",
       "ja": "1853〜1858年に在職した第13代徳川将軍は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85001,28 +86245,28 @@
         "en": "Tokugawa Nariaki",
         "ja": "徳川斉昭",
         "ja_typings": [
-          "tokugawa/nariaki"
+          "tokugawanariaki"
         ]
       },
       {
         "en": "Tokugawa Iemochi",
         "ja": "徳川家茂",
         "ja_typings": [
-          "tokugawa/iemochi"
+          "tokugawaiemochi"
         ]
       },
       {
         "en": "Tokugawa Iesada",
         "ja": "徳川家定",
         "ja_typings": [
-          "tokugawa/iesada"
+          "tokugawaiesada"
         ]
       },
       {
         "en": "Ii Naosuke",
         "ja": "井伊直弼",
         "ja_typings": [
-          "ii/naosuke"
+          "iinaosuke"
         ]
       }
     ],
@@ -85033,7 +86277,8 @@
     "question_text": {
       "en": "Which lord of Mito Domain was a major reformist figure in the late Edo period?",
       "ja": "幕末に活躍した水戸藩主の改革派の人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85041,28 +86286,28 @@
         "en": "Emperor Wu of Han",
         "ja": "漢の武帝",
         "ja_typings": [
-          "kan/no/butei"
+          "kannnobutei"
         ]
       },
       {
         "en": "Emperor Gaozu of Han",
         "ja": "漢の高祖",
         "ja_typings": [
-          "kan/no/kouso"
+          "kannnokouso"
         ]
       },
       {
         "en": "Emperor Wen of Han",
         "ja": "漢の文帝",
         "ja_typings": [
-          "kan/no/buntei"
+          "kannnobuntei"
         ]
       },
       {
         "en": "Emperor Jing of Han",
         "ja": "漢の景帝",
         "ja_typings": [
-          "kan/no/keitei"
+          "kannnokeitei"
         ]
       }
     ],
@@ -85073,7 +86318,8 @@
     "question_text": {
       "en": "Which Han emperor greatly expanded the empire and reigned 141-87 BC?",
       "ja": "紀元前141〜87年に在位し領土を大きく拡げた前漢の皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85081,28 +86327,28 @@
         "en": "Emperor Taizong of Tang",
         "ja": "唐の太宗",
         "ja_typings": [
-          "tou/no/taisou"
+          "tounotaisou"
         ]
       },
       {
         "en": "Emperor Gaozu of Tang",
         "ja": "唐の高祖",
         "ja_typings": [
-          "tou/no/kouso"
+          "tounokouso"
         ]
       },
       {
         "en": "Emperor Xuanzong of Tang",
         "ja": "唐の玄宗",
         "ja_typings": [
-          "tou/no/genso"
+          "tounogensou"
         ]
       },
       {
         "en": "Emperor Gaozong of Tang",
         "ja": "唐の高宗",
         "ja_typings": [
-          "tou/no/kousou"
+          "tounokousou"
         ]
       }
     ],
@@ -85113,7 +86359,8 @@
     "question_text": {
       "en": "Which Tang emperor presided over the early Tang golden age?",
       "ja": "唐初の黄金期を築いた皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85121,28 +86368,28 @@
         "en": "Emperor Yang of Sui",
         "ja": "隋の煬帝",
         "ja_typings": [
-          "zui/no/youdai"
+          "zuinoyoudai"
         ]
       },
       {
         "en": "Emperor Wen of Sui",
         "ja": "隋の文帝",
         "ja_typings": [
-          "zui/no/buntei"
+          "zuinobuntei"
         ]
       },
       {
         "en": "Emperor Gong of Sui",
         "ja": "隋の恭帝",
         "ja_typings": [
-          "zui/no/kyoutei"
+          "zuinokyoutei"
         ]
       },
       {
         "en": "Emperor Taizong of Tang",
         "ja": "唐の太宗",
         "ja_typings": [
-          "tou/no/taisou"
+          "tounotaisou"
         ]
       }
     ],
@@ -85153,7 +86400,8 @@
     "question_text": {
       "en": "Which Sui emperor built the Grand Canal but lost the throne to rebellion?",
       "ja": "大運河を建設したが反乱で帝位を失った隋の皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85161,14 +86409,14 @@
         "en": "Bill of Rights",
         "ja": "権利章典",
         "ja_typings": [
-          "kenri/shouten"
+          "kenrishouten"
         ]
       },
       {
         "en": "Petition of Right",
         "ja": "権利の請願",
         "ja_typings": [
-          "kenri/no/seigan"
+          "kenrinoseigan"
         ]
       },
       {
@@ -85182,7 +86430,7 @@
         "en": "Habeas Corpus Act",
         "ja": "人身保護法",
         "ja_typings": [
-          "jinshin/hogo/hou"
+          "jinshinhogohou"
         ]
       }
     ],
@@ -85193,7 +86441,8 @@
     "question_text": {
       "en": "Which 1689 English document limited royal power and established parliamentary rights?",
       "ja": "1689年に王権を制限し議会の権利を定めたイギリスの文書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85201,14 +86450,14 @@
         "en": "Petition of Right",
         "ja": "権利の請願",
         "ja_typings": [
-          "kenri/no/seigan"
+          "kenrinoseigan"
         ]
       },
       {
         "en": "Bill of Rights",
         "ja": "権利章典",
         "ja_typings": [
-          "kenri/shouten"
+          "kenrishouten"
         ]
       },
       {
@@ -85222,7 +86471,7 @@
         "en": "Act of Settlement",
         "ja": "王位継承法",
         "ja_typings": [
-          "oui/keishou/hou"
+          "ouikeishouhou"
         ]
       }
     ],
@@ -85233,7 +86482,8 @@
     "question_text": {
       "en": "Which 1628 English document was drafted by Parliament against Charles I?",
       "ja": "1628年に議会がチャールズ1世に対し起草した文書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85241,28 +86491,28 @@
         "en": "Edict of Nantes",
         "ja": "ナント勅令",
         "ja_typings": [
-          "nanto/chokurei"
+          "nantochokurei"
         ]
       },
       {
         "en": "Edict of Fontainebleau",
         "ja": "フォンテーヌブロー勅令",
         "ja_typings": [
-          "fonte-nuburo-/chokurei"
+          "fonte-nuburo-chokurei"
         ]
       },
       {
         "en": "Bill of Rights",
         "ja": "権利章典",
         "ja_typings": [
-          "kenri/shouten"
+          "kenrishouten"
         ]
       },
       {
         "en": "Concordat of Bologna",
         "ja": "ボローニャ政教条約",
         "ja_typings": [
-          "boro-nya/seikyou/jouyaku"
+          "boro-nyaseikyoujouyaku"
         ]
       }
     ],
@@ -85273,7 +86523,8 @@
     "question_text": {
       "en": "Which 1598 French royal edict granted religious tolerance to Huguenots?",
       "ja": "1598年にユグノーに信仰の自由を与えたフランス王令は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85281,28 +86532,28 @@
         "en": "Elba",
         "ja": "エルバ島",
         "ja_typings": [
-          "eruba/tou"
+          "erubatou"
         ]
       },
       {
         "en": "Saint Helena",
         "ja": "セントヘレナ島",
         "ja_typings": [
-          "sentohelena/tou"
+          "sentoherenatou"
         ]
       },
       {
         "en": "Corsica",
         "ja": "コルシカ島",
         "ja_typings": [
-          "korushika/tou"
+          "korushikatou"
         ]
       },
       {
         "en": "Sardinia",
         "ja": "サルデーニャ島",
         "ja_typings": [
-          "sarude-nya/tou"
+          "sarude-nyatou"
         ]
       }
     ],
@@ -85313,7 +86564,8 @@
     "question_text": {
       "en": "Which Mediterranean island was Napoleon exiled to in 1814?",
       "ja": "1814年にナポレオンが流された地中海の島は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85353,7 +86605,8 @@
     "question_text": {
       "en": "Which Danish physicist proposed a model of the hydrogen atom with quantized orbits in 1913?",
       "ja": "1913年に量子化された軌道を持つ水素原子モデルを提唱したデンマークの物理学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85361,7 +86614,7 @@
         "en": "Uranus",
         "ja": "天王星",
         "ja_typings": [
-          "tennousei"
+          "tennnousei"
         ]
       },
       {
@@ -85393,7 +86646,8 @@
     "question_text": {
       "en": "Which planet is the seventh from the Sun and tilted on its side?",
       "ja": "太陽から7番目の、横倒しに自転する惑星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85433,7 +86687,8 @@
     "question_text": {
       "en": "Which noble gas is the third most abundant gas in Earth's atmosphere?",
       "ja": "地球大気で3番目に多い希ガスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85473,7 +86728,8 @@
     "question_text": {
       "en": "Which planet is the second from the Sun and the hottest in the solar system?",
       "ja": "太陽から2番目で太陽系で最も高温の惑星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85513,7 +86769,8 @@
     "question_text": {
       "en": "Which human organ filters blood and produces urine?",
       "ja": "血液を濾過し尿を生成する人体の臓器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85553,7 +86810,8 @@
     "question_text": {
       "en": "Which organ stores white blood cells and recycles old red blood cells?",
       "ja": "白血球を蓄え古い赤血球を分解する臓器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85593,7 +86851,8 @@
     "question_text": {
       "en": "Which French naturalist proposed an early theory of inheritance of acquired characteristics?",
       "ja": "獲得形質の遺伝説を提唱したフランスの博物学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85633,7 +86892,8 @@
     "question_text": {
       "en": "Which Polish-French scientist discovered polonium and radium?",
       "ja": "ポロニウムとラジウムを発見したポーランド系フランス人科学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85673,7 +86933,8 @@
     "question_text": {
       "en": "Which optical phenomenon describes light bouncing off a surface?",
       "ja": "光が表面で跳ね返る光学現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85713,7 +86974,8 @@
     "question_text": {
       "en": "Which wave phenomenon describes bending around obstacles or through narrow slits?",
       "ja": "障害物や狭い隙間で波が回り込む現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85753,7 +87015,8 @@
     "question_text": {
       "en": "Which Danish astronomer made precise pre-telescope observations used by Kepler?",
       "ja": "ケプラーが利用した精密な肉眼観測を残したデンマークの天文学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85793,7 +87056,8 @@
     "question_text": {
       "en": "Which unit of pressure equals 100,000 pascals?",
       "ja": "10万パスカルに相当する圧力の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85833,7 +87097,8 @@
     "question_text": {
       "en": "Which gas, CH4, is the main component of natural gas?",
       "ja": "化学式CH4で天然ガスの主成分である気体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85873,7 +87138,8 @@
     "question_text": {
       "en": "Which atmospheric gas, O3, forms a protective layer in the stratosphere?",
       "ja": "化学式O3で成層圏に保護層を形成する気体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85881,28 +87147,28 @@
         "en": "Hooke's law",
         "ja": "フックの法則",
         "ja_typings": [
-          "fukku/no/housoku"
+          "fukkunohousoku"
         ]
       },
       {
         "en": "Newton's law",
         "ja": "ニュートンの法則",
         "ja_typings": [
-          "nyu-ton/no/housoku"
+          "nyu-tonnnohousoku"
         ]
       },
       {
         "en": "Boyle's law",
         "ja": "ボイルの法則",
         "ja_typings": [
-          "boiru/no/housoku"
+          "boirunohousoku"
         ]
       },
       {
         "en": "Ohm's law",
         "ja": "オームの法則",
         "ja_typings": [
-          "o-mu/no/housoku"
+          "o-munohousoku"
         ]
       }
     ],
@@ -85913,7 +87179,8 @@
     "question_text": {
       "en": "Which physical law states that the force exerted by a spring is proportional to its extension?",
       "ja": "ばねの力が伸びに比例するという物理法則は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85921,7 +87188,7 @@
         "en": "Beaufort scale",
         "ja": "ビューフォート風力階級",
         "ja_typings": [
-          "byu-fo-to/fuuryoku/kaikyuu"
+          "byu-fo-tofuuryokukaikyuu"
         ]
       },
       {
@@ -85935,14 +87202,14 @@
         "en": "Fujita scale",
         "ja": "藤田スケール",
         "ja_typings": [
-          "fujita/suke-ru"
+          "fujitasuke-ru"
         ]
       },
       {
         "en": "Mercalli scale",
         "ja": "メルカリ震度階級",
         "ja_typings": [
-          "merukari/shindo/kaikyuu"
+          "merukarishindokaikyuu"
         ]
       }
     ],
@@ -85953,7 +87220,8 @@
     "question_text": {
       "en": "Which empirical scale measures wind force from 0 to 12?",
       "ja": "0から12までで風力を表す経験的尺度は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85993,7 +87261,8 @@
     "question_text": {
       "en": "Which dwarf planet was reclassified from full planet status in 2006?",
       "ja": "2006年に惑星から準惑星に再分類された天体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86001,14 +87270,14 @@
         "en": "CO2",
         "ja": "二酸化炭素",
         "ja_typings": [
-          "nisanka/tanso"
+          "nisankatanso"
         ]
       },
       {
         "en": "SO2",
         "ja": "二酸化硫黄",
         "ja_typings": [
-          "nisanka/iou"
+          "nisankaiou"
         ]
       },
       {
@@ -86033,7 +87302,8 @@
     "question_text": {
       "en": "Which gas with formula CO2 is a major greenhouse gas exhaled by humans?",
       "ja": "化学式CO2で人間が呼吸で排出する主要な温室効果ガスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86055,7 +87325,7 @@
         "en": "CO2",
         "ja": "二酸化炭素",
         "ja_typings": [
-          "nisanka/tanso"
+          "nisankatanso"
         ]
       },
       {
@@ -86073,7 +87343,8 @@
     "question_text": {
       "en": "Which molecule with formula O2 is essential for human respiration?",
       "ja": "化学式O2で人間の呼吸に不可欠な分子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86088,14 +87359,14 @@
         "en": "CO2",
         "ja": "二酸化炭素",
         "ja_typings": [
-          "nisanka/tanso"
+          "nisankatanso"
         ]
       },
       {
         "en": "SO2",
         "ja": "二酸化硫黄",
         "ja_typings": [
-          "nisanka/iou"
+          "nisankaiou"
         ]
       },
       {
@@ -86113,7 +87384,8 @@
     "question_text": {
       "en": "Which pungent gas with formula NH3 is widely used in fertilizers?",
       "ja": "化学式NH3で肥料に広く用いられる刺激臭の気体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86153,7 +87425,8 @@
     "question_text": {
       "en": "Which element has the chemical symbol Cu?",
       "ja": "化学記号Cuで表される元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86193,7 +87466,8 @@
     "question_text": {
       "en": "Which element has the chemical symbol Pb?",
       "ja": "化学記号Pbで表される元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86233,7 +87507,8 @@
     "question_text": {
       "en": "Approximately what is the circumference of the Earth at the equator?",
       "ja": "地球の赤道周長は約何kmか?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86273,7 +87548,8 @@
     "question_text": {
       "en": "Approximately what is the distance from the Earth to the Moon?",
       "ja": "地球から月までの距離は約何kmか?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86313,7 +87589,8 @@
     "question_text": {
       "en": "Approximately what is the diameter of the Moon?",
       "ja": "月の直径は約何kmか?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86353,7 +87630,8 @@
     "question_text": {
       "en": "Which British physicist proposed that black holes emit radiation?",
       "ja": "ブラックホールが放射を発するという理論を提唱したイギリスの物理学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86393,7 +87671,8 @@
     "question_text": {
       "en": "Which is the third planet from the Sun?",
       "ja": "太陽から3番目の惑星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86433,7 +87712,8 @@
     "question_text": {
       "en": "Which element has the chemical symbol N?",
       "ja": "化学記号Nで表される元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86473,7 +87753,8 @@
     "question_text": {
       "en": "Which element has the chemical symbol C and is the basis of organic chemistry?",
       "ja": "化学記号Cで有機化学の基礎をなす元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86513,7 +87794,8 @@
     "question_text": {
       "en": "Which element has the chemical symbol H and is the lightest element?",
       "ja": "化学記号Hで最も軽い元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86521,7 +87803,6 @@
         "en": "Mendel and Darwin",
         "ja": "メンデルとダーウィン",
         "ja_typings": [
-          "menderu/to/da-win",
           "menderutoda-win"
         ]
       },
@@ -86529,7 +87810,6 @@
         "en": "Pasteur and Koch",
         "ja": "パスツールとコッホ",
         "ja_typings": [
-          "pasutsu-ru/to/kohho",
           "pasutsu-rutokohho"
         ]
       },
@@ -86537,7 +87817,6 @@
         "en": "Lamarck and Linnaeus",
         "ja": "ラマルクとリンネ",
         "ja_typings": [
-          "ramaruku/to/rinne",
           "ramarukutorinnne"
         ]
       },
@@ -86545,7 +87824,6 @@
         "en": "Watson and Crick",
         "ja": "ワトソンとクリック",
         "ja_typings": [
-          "watoson/to/kurikku",
           "watosontokurikku"
         ]
       }
@@ -86557,7 +87835,8 @@
     "question_text": {
       "en": "Who are the two 19th-century scientists most often cited as founders of evolution and modern genetics?",
       "ja": "進化論と近代遺伝学の創始者としてよく挙げられる19世紀の2人の科学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86565,7 +87844,6 @@
         "en": "Pasteur and Koch",
         "ja": "パスツールとコッホ",
         "ja_typings": [
-          "pasutsu-ru/to/kohho",
           "pasutsu-rutokohho"
         ]
       },
@@ -86573,7 +87851,6 @@
         "en": "Mendel and Darwin",
         "ja": "メンデルとダーウィン",
         "ja_typings": [
-          "menderu/to/da-win",
           "menderutoda-win"
         ]
       },
@@ -86581,7 +87858,6 @@
         "en": "Lamarck and Linnaeus",
         "ja": "ラマルクとリンネ",
         "ja_typings": [
-          "ramaruku/to/rinne",
           "ramarukutorinnne"
         ]
       },
@@ -86589,7 +87865,6 @@
         "en": "Watson and Crick",
         "ja": "ワトソンとクリック",
         "ja_typings": [
-          "watoson/to/kurikku",
           "watosontokurikku"
         ]
       }
@@ -86601,7 +87876,8 @@
     "question_text": {
       "en": "Who are the two 19th-century scientists most associated with the founding of microbiology?",
       "ja": "微生物学の創始に深く関わった19世紀の2人の科学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86609,7 +87885,6 @@
         "en": "Lamarck and Linnaeus",
         "ja": "ラマルクとリンネ",
         "ja_typings": [
-          "ramaruku/to/rinne",
           "ramarukutorinnne"
         ]
       },
@@ -86617,7 +87892,6 @@
         "en": "Mendel and Darwin",
         "ja": "メンデルとダーウィン",
         "ja_typings": [
-          "menderu/to/da-win",
           "menderutoda-win"
         ]
       },
@@ -86625,7 +87899,6 @@
         "en": "Pasteur and Koch",
         "ja": "パスツールとコッホ",
         "ja_typings": [
-          "pasutsu-ru/to/kohho",
           "pasutsu-rutokohho"
         ]
       },
@@ -86633,7 +87906,6 @@
         "en": "Watson and Crick",
         "ja": "ワトソンとクリック",
         "ja_typings": [
-          "watoson/to/kurikku",
           "watosontokurikku"
         ]
       }
@@ -86645,7 +87917,8 @@
     "question_text": {
       "en": "Who are the two pre-Darwinian naturalists associated with early classification and inheritance theory?",
       "ja": "ダーウィン以前の分類学・進化思想に関わった2人の博物学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86685,7 +87958,8 @@
     "question_text": {
       "en": "Which 18th-century Swedish naturalist established the modern binomial nomenclature?",
       "ja": "二名法を確立した18世紀スウェーデンの博物学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86725,7 +87999,8 @@
     "question_text": {
       "en": "What is the sum of the interior angles of a triangle in Euclidean geometry?",
       "ja": "ユークリッド幾何で三角形の内角の和は何度か?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86765,7 +88040,8 @@
     "question_text": {
       "en": "If an isoceles triangle has a vertex angle of 20 degrees, each base angle measures how many degrees?",
       "ja": "頂角20度の二等辺三角形の底角はそれぞれ何度か?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86805,7 +88081,8 @@
     "question_text": {
       "en": "Each interior angle of a regular hexagon measures how many degrees?",
       "ja": "正六角形の1つの内角は何度か?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86845,7 +88122,8 @@
     "question_text": {
       "en": "Approximately how long is a standard Olympic sprint track in meters for the 100m dash?",
       "ja": "オリンピックの100m走の距離は何mか?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86885,7 +88163,8 @@
     "question_text": {
       "en": "How long is a standard track distance for the 1km run in meters?",
       "ja": "1km走の距離はメートル換算で何mか?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86925,7 +88204,8 @@
     "question_text": {
       "en": "How many meters is a 3km running event?",
       "ja": "3km走は何mか?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86933,28 +88213,28 @@
         "en": "23",
         "ja": "23対",
         "ja_typings": [
-          "23/tsui"
+          "23tsui"
         ]
       },
       {
         "en": "48",
         "ja": "48対",
         "ja_typings": [
-          "48/tsui"
+          "48tsui"
         ]
       },
       {
         "en": "24",
         "ja": "24対",
         "ja_typings": [
-          "24/tsui"
+          "24tsui"
         ]
       },
       {
         "en": "46",
         "ja": "46対",
         "ja_typings": [
-          "46/tsui"
+          "46tsui"
         ]
       }
     ],
@@ -86965,7 +88245,8 @@
     "question_text": {
       "en": "How many pairs of chromosomes do humans normally have?",
       "ja": "ヒトの染色体は通常何対あるか?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86973,28 +88254,28 @@
         "en": "48",
         "ja": "48本",
         "ja_typings": [
-          "48/hon"
+          "48hon"
         ]
       },
       {
         "en": "23",
         "ja": "23本",
         "ja_typings": [
-          "23/hon"
+          "23hon"
         ]
       },
       {
         "en": "24",
         "ja": "24本",
         "ja_typings": [
-          "24/hon"
+          "24hon"
         ]
       },
       {
         "en": "46",
         "ja": "46本",
         "ja_typings": [
-          "46/hon"
+          "46hon"
         ]
       }
     ],
@@ -87005,7 +88286,8 @@
     "question_text": {
       "en": "How many chromosomes do chimpanzees have in total?",
       "ja": "チンパンジーの染色体は全部で何本あるか?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87013,28 +88295,28 @@
         "en": "24",
         "ja": "24時間",
         "ja_typings": [
-          "24/jikan"
+          "24jikan"
         ]
       },
       {
         "en": "23",
         "ja": "23時間",
         "ja_typings": [
-          "23/jikan"
+          "23jikan"
         ]
       },
       {
         "en": "48",
         "ja": "48時間",
         "ja_typings": [
-          "48/jikan"
+          "48jikan"
         ]
       },
       {
         "en": "12",
         "ja": "12時間",
         "ja_typings": [
-          "12/jikan"
+          "12jikan"
         ]
       }
     ],
@@ -87045,7 +88327,8 @@
     "question_text": {
       "en": "How many hours are in one day?",
       "ja": "1日は何時間か?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87085,7 +88368,8 @@
     "question_text": {
       "en": "Which organ enables breathing by exchanging oxygen and carbon dioxide?",
       "ja": "酸素と二酸化炭素を交換し呼吸を担う臓器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87125,7 +88409,8 @@
     "question_text": {
       "en": "Which organ is the control center of the human nervous system?",
       "ja": "人間の神経系の中枢を担う臓器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87165,7 +88450,8 @@
     "question_text": {
       "en": "Which star, near the celestial north pole, is used for navigation?",
       "ja": "天の北極付近にあり航法に使われる恒星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87205,7 +88491,8 @@
     "question_text": {
       "en": "Which red supergiant star marks the shoulder of Orion?",
       "ja": "オリオン座の肩を成す赤色超巨星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87213,28 +88500,28 @@
         "en": "KCl",
         "ja": "塩化カリウム",
         "ja_typings": [
-          "enka/kariumu"
+          "enkakariumu"
         ]
       },
       {
         "en": "NaCl",
         "ja": "塩化ナトリウム",
         "ja_typings": [
-          "enka/natoriumu"
+          "enkanatoriumu"
         ]
       },
       {
         "en": "CaCl2",
         "ja": "塩化カルシウム",
         "ja_typings": [
-          "enka/karushiumu"
+          "enkakarushiumu"
         ]
       },
       {
         "en": "MgCl2",
         "ja": "塩化マグネシウム",
         "ja_typings": [
-          "enka/maguneshiumu"
+          "enkamaguneshiumu"
         ]
       }
     ],
@@ -87245,7 +88532,8 @@
     "question_text": {
       "en": "Which chemical compound with formula KCl is commonly used as a salt substitute?",
       "ja": "化学式KClで塩の代替として使われる化合物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87253,28 +88541,28 @@
         "en": "CaCO3",
         "ja": "炭酸カルシウム",
         "ja_typings": [
-          "tansan/karushiumu"
+          "tansankarushiumu"
         ]
       },
       {
         "en": "CaO",
         "ja": "酸化カルシウム",
         "ja_typings": [
-          "sanka/karushiumu"
+          "sankakarushiumu"
         ]
       },
       {
         "en": "Ca(OH)2",
         "ja": "水酸化カルシウム",
         "ja_typings": [
-          "suisanka/karushiumu"
+          "suisankakarushiumu"
         ]
       },
       {
         "en": "CaSO4",
         "ja": "硫酸カルシウム",
         "ja_typings": [
-          "ryuusan/karushiumu"
+          "ryuusankarushiumu"
         ]
       }
     ],
@@ -87285,7 +88573,8 @@
     "question_text": {
       "en": "Which compound with formula CaCO3 is the main component of limestone?",
       "ja": "化学式CaCO3で石灰岩の主成分である化合物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87325,7 +88614,8 @@
     "question_text": {
       "en": "Which theorem states that large samples' means tend toward a normal distribution?",
       "ja": "大規模標本の平均が正規分布に近づくとする定理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87365,7 +88655,8 @@
     "question_text": {
       "en": "Who proposed 23 famous unsolved problems in 1900?",
       "ja": "1900年に23の未解決問題を提示した数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87405,7 +88696,8 @@
     "question_text": {
       "en": "Whose name is associated with the integral formula for analytic functions on a closed contour?",
       "ja": "閉曲線上の解析関数の積分公式に名を残す数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87445,7 +88737,8 @@
     "question_text": {
       "en": "Whose hypothesis about the zeros of the zeta function is a Millennium Prize problem?",
       "ja": "ゼータ関数の零点に関する仮説で知られミレニアム懸賞問題となっている数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87485,7 +88778,8 @@
     "question_text": {
       "en": "Which Norwegian mathematician proved the impossibility of solving the general quintic by radicals?",
       "ja": "一般5次方程式が代数的に解けないことを示したノルウェーの数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87525,7 +88819,8 @@
     "question_text": {
       "en": "What do you call a number that can be expressed as a ratio of two integers?",
       "ja": "2つの整数の比で表せる数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87565,7 +88860,8 @@
     "question_text": {
       "en": "If you rotate three-quarters of a full turn, how many degrees is that?",
       "ja": "1回転の4分の3を角度で表すと?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87605,7 +88901,8 @@
     "question_text": {
       "en": "What is the value of 2 divided by 6 as a fraction in lowest terms?",
       "ja": "2÷6を既約分数にすると?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87645,7 +88942,8 @@
     "question_text": {
       "en": "What is 10 squared?",
       "ja": "10の2乗は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87685,7 +88983,8 @@
     "question_text": {
       "en": "What is 3 multiplied by 7?",
       "ja": "3×7はいくつ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87725,7 +89024,8 @@
     "question_text": {
       "en": "What is 2 to the third power?",
       "ja": "2の3乗は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87766,7 +89066,8 @@
     "question_text": {
       "en": "What is the name of a perfectly round 3D figure where all surface points are equidistant from the center?",
       "ja": "中心から表面までの距離がすべて等しい立体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87806,7 +89107,8 @@
     "question_text": {
       "en": "What is the only even prime number?",
       "ja": "唯一の偶数の素数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87846,7 +89148,8 @@
     "question_text": {
       "en": "What is 2 squared?",
       "ja": "2の2乗は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87886,7 +89189,8 @@
     "question_text": {
       "en": "Whose conjecture says every even integer greater than 2 is the sum of two primes?",
       "ja": "2より大きい偶数はすべて2つの素数の和で表せるという予想を提唱したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87926,7 +89230,8 @@
     "question_text": {
       "en": "Which theorem proven by Andrew Wiles in 1995 says x^n + y^n = z^n has no positive integer solutions for n > 2?",
       "ja": "1995年にワイルズが証明した、n>2でx^n+y^n=z^nが正整数解を持たないとする定理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87966,7 +89271,8 @@
     "question_text": {
       "en": "Which theorem expands (a+b)^n using combinations?",
       "ja": "(a+b)^nを組合せを使って展開する定理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88006,7 +89312,8 @@
     "question_text": {
       "en": "Which Greek letter is often used to denote the golden ratio?",
       "ja": "黄金比を表すのによく使われるギリシャ文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88046,7 +89353,8 @@
     "question_text": {
       "en": "Which Greek letter is commonly used to denote an angle?",
       "ja": "角度を表すのによく使われるギリシャ文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88086,7 +89394,8 @@
     "question_text": {
       "en": "Whose family produced multiple Swiss mathematicians known for probability and fluid dynamics?",
       "ja": "確率や流体力学で知られるスイスの数学者一族の名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88126,7 +89435,8 @@
     "question_text": {
       "en": "Who is known for the construction of real numbers via cuts of rationals?",
       "ja": "有理数の切断で実数を構成したことで知られる数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88166,7 +89476,8 @@
     "question_text": {
       "en": "Which French mathematician's conjecture on 3-manifolds was solved by Perelman?",
       "ja": "3次元多様体に関する予想がペレルマンに解かれたフランスの数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88206,7 +89517,8 @@
     "question_text": {
       "en": "Who developed the calculus of variations and a theorem on subgroup order in group theory?",
       "ja": "変分法を発展させ群論で部分群の位数の定理にも名を残す数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88246,7 +89558,8 @@
     "question_text": {
       "en": "What do you call a positive integer with more than two divisors?",
       "ja": "約数を3つ以上もつ正の整数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88286,7 +89599,8 @@
     "question_text": {
       "en": "What do you call a positive integer equal to the sum of its proper divisors, like 6 or 28?",
       "ja": "自分自身を除く約数の和が自分自身に等しい数(6や28)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88326,7 +89640,8 @@
     "question_text": {
       "en": "What do you call the counting numbers 1, 2, 3, ...?",
       "ja": "1, 2, 3, ... のような数え上げの数を何という?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88366,7 +89681,8 @@
     "question_text": {
       "en": "What do you call the set including negative whole numbers, zero, and positive whole numbers?",
       "ja": "負・0・正の整数すべてをまとめた数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88406,7 +89722,8 @@
     "question_text": {
       "en": "Which constant approximately 2.71828 is the base of the natural logarithm?",
       "ja": "自然対数の底となる約2.71828の定数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88446,7 +89763,8 @@
     "question_text": {
       "en": "Which constant approximately 1.618 is often denoted by the Greek letter phi?",
       "ja": "ギリシャ文字ファイで表される約1.618の定数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88486,7 +89804,8 @@
     "question_text": {
       "en": "Which constant approximately equals 3.14159?",
       "ja": "約3.14159となる定数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88526,7 +89845,8 @@
     "question_text": {
       "en": "Which constant approximately 0.5772 appears as the limit difference between harmonic sums and the natural log?",
       "ja": "調和数と自然対数の差の極限として現れる約0.5772の定数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88566,7 +89886,8 @@
     "question_text": {
       "en": "Which ratio approximately 1:1.414 appears in A4 paper sizes?",
       "ja": "A4などのコピー用紙に現れる約1:1.414の比は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88606,7 +89927,8 @@
     "question_text": {
       "en": "Which metallic ratio is the third in the series after golden and silver?",
       "ja": "黄金比、白銀比に続く第3の金属比は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88646,7 +89968,8 @@
     "question_text": {
       "en": "What do you call a ratio related to harmonic means used in music and projective geometry?",
       "ja": "音楽や射影幾何で現れる調和平均に関わる比を何という?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88686,7 +90009,8 @@
     "question_text": {
       "en": "What do you call a sequence where each term differs from the previous by a constant?",
       "ja": "隣り合う項の差が一定の数列は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88726,7 +90050,8 @@
     "question_text": {
       "en": "What do you call a sequence where each term is a constant multiple of the previous one?",
       "ja": "隣り合う項の比が一定の数列は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88766,7 +90091,8 @@
     "question_text": {
       "en": "What do you call a sequence whose reciprocals form an arithmetic progression?",
       "ja": "逆数を取ると等差数列になる数列は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88806,7 +90132,8 @@
     "question_text": {
       "en": "How many degrees is a right angle?",
       "ja": "直角は何度?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88846,7 +90173,8 @@
     "question_text": {
       "en": "What is 4 divided by 6 as a fraction in lowest terms?",
       "ja": "4÷6を既約分数で表すと?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88886,7 +90214,8 @@
     "question_text": {
       "en": "Which set operation symbol represents the union of two sets?",
       "ja": "2つの集合の和集合を表す記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88926,7 +90255,8 @@
     "question_text": {
       "en": "What do you call set A when every element of A is also in set B?",
       "ja": "Aの要素すべてがBに含まれているとき、AはBの何?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88966,7 +90296,8 @@
     "question_text": {
       "en": "Which symbol means 'is an element of'?",
       "ja": "「要素として属する」を表す記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89006,7 +90337,8 @@
     "question_text": {
       "en": "What do you call a single number quantity without direction?",
       "ja": "向きを持たず大きさのみの量は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89046,7 +90378,8 @@
     "question_text": {
       "en": "What do you call a multi-dimensional generalization of vectors and matrices?",
       "ja": "ベクトルや行列を多次元に一般化した量は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89086,7 +90419,8 @@
     "question_text": {
       "en": "What do you call an ordered list of numbers indexed by natural numbers?",
       "ja": "自然数で順序付けられた数の並びは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89126,7 +90460,8 @@
     "question_text": {
       "en": "What do you call an unordered collection of distinct objects?",
       "ja": "順序を考えない異なるものの集まりを何という?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89166,7 +90501,8 @@
     "question_text": {
       "en": "Which French mathematician's triangle gives binomial coefficients?",
       "ja": "二項係数を並べた三角形に名を残すフランスの数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89206,7 +90542,8 @@
     "question_text": {
       "en": "Which ancient Greek mathematician's theorem relates the sides of a right triangle?",
       "ja": "直角三角形の辺の関係に名を残す古代ギリシャの数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89246,7 +90583,8 @@
     "question_text": {
       "en": "Which ancient Greek philosopher is credited with one of the first geometric theorems about angles in a semicircle?",
       "ja": "半円に内接する角に関する定理で知られる古代ギリシャの哲学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89286,7 +90624,8 @@
     "question_text": {
       "en": "Which Greek philosopher is associated with five regular polyhedra called the 'solids'?",
       "ja": "5種類の正多面体に名を残すギリシャの哲学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89326,7 +90665,8 @@
     "question_text": {
       "en": "Which country is the Eiffel Tower located in?",
       "ja": "エッフェル塔がある国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89366,7 +90706,8 @@
     "question_text": {
       "en": "Who is the Italian inventor credited with the first long-distance radio transmission?",
       "ja": "長距離無線通信を初めて成功させたイタリアの発明家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89406,7 +90747,8 @@
     "question_text": {
       "en": "Which country has London as its capital?",
       "ja": "ロンドンを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89446,7 +90788,8 @@
     "question_text": {
       "en": "Which animal group includes salmon, tuna, and trout?",
       "ja": "サケ・マグロ・マスを含む生き物のグループは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89486,7 +90829,8 @@
     "question_text": {
       "en": "Which country is shaped like a boot and known for pasta and pizza?",
       "ja": "長靴の形をしておりパスタやピザで有名な国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89526,7 +90870,8 @@
     "question_text": {
       "en": "Which language is spoken as the official language of Germany?",
       "ja": "ドイツの公用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89566,7 +90911,8 @@
     "question_text": {
       "en": "Which SI unit measures frequency, in cycles per second?",
       "ja": "周波数のSI単位(毎秒の振動回数)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89606,7 +90952,8 @@
     "question_text": {
       "en": "In baseball, what is the name of the base that batters aim to return to score?",
       "ja": "野球で打者が戻ってきて得点となるベースは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89646,7 +90993,8 @@
     "question_text": {
       "en": "In baseball, what term means a successful safe hit on the ball into fair territory?",
       "ja": "野球で打球がフェア地域に飛び出塁できた打撃を何という?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89686,7 +91034,8 @@
     "question_text": {
       "en": "In baseball, what term means the ball was hit outside the fair territory lines?",
       "ja": "野球で打球がフェア地域の外に飛ぶことを何という?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89726,7 +91075,8 @@
     "question_text": {
       "en": "How long is one half in a standard soccer match?",
       "ja": "サッカーの前半・後半は1つあたり何分?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89766,7 +91116,8 @@
     "question_text": {
       "en": "How long is one quarter in standard NBA basketball?",
       "ja": "NBAの1クォーターは何分?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89806,7 +91157,8 @@
     "question_text": {
       "en": "How long is one period in standard ice hockey?",
       "ja": "アイスホッケーの1ピリオドは何分?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89846,7 +91198,8 @@
     "question_text": {
       "en": "Who was the 7th president of the International Olympic Committee, serving 1980-2001?",
       "ja": "1980年から2001年までIOC会長を務めたスペイン人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89886,7 +91239,8 @@
     "question_text": {
       "en": "Who was the 8th president of the IOC, serving 2001-2013?",
       "ja": "2001年から2013年までIOC会長を務めたベルギー人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89926,7 +91280,8 @@
     "question_text": {
       "en": "Who became the 9th president of the IOC in 2013?",
       "ja": "2013年にIOC会長となったドイツ人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89966,7 +91321,8 @@
     "question_text": {
       "en": "Which Serbian-American inventor is known for AC electrical systems?",
       "ja": "交流送電で知られるセルビア系アメリカ人の発明家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90006,7 +91362,8 @@
     "question_text": {
       "en": "Who was the Polish-French physicist who won Nobel Prizes in both physics and chemistry for work on radioactivity?",
       "ja": "放射線の研究で物理学賞と化学賞の両方を受賞したポーランド系フランス人の物理学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90046,7 +91403,8 @@
     "question_text": {
       "en": "In which year did Melbourne host the Summer Olympics?",
       "ja": "メルボルン夏季オリンピックが開催された年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90086,7 +91444,8 @@
     "question_text": {
       "en": "In which year did Mexico City host the Summer Olympics?",
       "ja": "メキシコシティ夏季オリンピックが開催された年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90126,7 +91485,8 @@
     "question_text": {
       "en": "In which year did Munich host the Summer Olympics?",
       "ja": "ミュンヘン夏季オリンピックが開催された年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90166,7 +91526,8 @@
     "question_text": {
       "en": "Which trench off the Pacific coast of Tohoku is famous for deep-focus earthquakes?",
       "ja": "東北沖の太平洋にある深発地震で有名な海溝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90206,7 +91567,8 @@
     "question_text": {
       "en": "Which is the deepest trench in the Atlantic Ocean?",
       "ja": "大西洋で最も深い海溝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90246,7 +91608,8 @@
     "question_text": {
       "en": "Which trench in the South Pacific is the second deepest in the world?",
       "ja": "世界で2番目に深い南太平洋の海溝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90286,7 +91649,8 @@
     "question_text": {
       "en": "Who wrote 'The Grapes of Wrath' and won the Nobel Prize in Literature in 1962?",
       "ja": "「怒りの葡萄」を書き1962年にノーベル文学賞を受賞した米国人作家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90326,7 +91690,8 @@
     "question_text": {
       "en": "Who wrote 'The Sound and the Fury' and won the Nobel Prize in Literature in 1949?",
       "ja": "「響きと怒り」を書き1949年にノーベル文学賞を受賞した米国人作家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90366,7 +91731,8 @@
     "question_text": {
       "en": "Who wrote 'The Great Gatsby'?",
       "ja": "「グレート ギャツビー」の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90406,7 +91772,8 @@
     "question_text": {
       "en": "Who directed 'Jaws', 'E.T.', and 'Jurassic Park'?",
       "ja": "「ジョーズ」「E.T.」「ジュラシック パーク」を監督した米国人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90446,7 +91813,8 @@
     "question_text": {
       "en": "Who directed 'Taxi Driver' and 'Goodfellas'?",
       "ja": "「タクシードライバー」「グッドフェローズ」を監督した米国人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90486,7 +91854,8 @@
     "question_text": {
       "en": "Who directed 'Alien', 'Blade Runner', and 'Gladiator'?",
       "ja": "「エイリアン」「ブレードランナー」「グラディエーター」を監督した英国人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90526,7 +91895,8 @@
     "question_text": {
       "en": "Botanically classified as a fruit but commonly used as a vegetable, what red ingredient is essential to ketchup?",
       "ja": "植物学的には果実だが料理では野菜扱いされケチャップの主原料となる赤い食材は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90541,7 +91911,6 @@
         "en": "leopard",
         "ja": "ヒョウ",
         "ja_typings": [
-          "hyo",
           "hyou"
         ]
       },
@@ -90567,7 +91936,8 @@
     "question_text": {
       "en": "Which large cat is known as the 'king of the savannah' and lives in prides?",
       "ja": "サバンナの王者と呼ばれ群れを作る大型のネコ科動物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90607,7 +91977,8 @@
     "question_text": {
       "en": "Which slender African antelope is famous for its leaping bounds?",
       "ja": "跳躍で有名なアフリカの細身の動物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90615,7 +91986,6 @@
         "en": "leopard",
         "ja": "ヒョウ",
         "ja_typings": [
-          "hyo",
           "hyou"
         ]
       },
@@ -90648,7 +92018,8 @@
     "question_text": {
       "en": "Which spotted big cat is known for dragging prey up into trees?",
       "ja": "獲物を木の上に運ぶことで知られる斑点模様の大型ネコ科動物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90663,14 +92034,14 @@
         "en": "French Open",
         "ja": "全仏オープン",
         "ja_typings": [
-          "zenbutsuo-pun"
+          "zenfutsuo-pun"
         ]
       },
       {
         "en": "Australian Open",
         "ja": "全豪オープン",
         "ja_typings": [
-          "zengo-oopun"
+          "zengouo-pun"
         ]
       },
       {
@@ -90688,7 +92059,8 @@
     "question_text": {
       "en": "Which Grand Slam tennis tournament is played on grass in London?",
       "ja": "ロンドンの芝コートで開催されるテニスのグランドスラム大会は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90696,7 +92068,7 @@
         "en": "French Open",
         "ja": "全仏オープン",
         "ja_typings": [
-          "zenbutsuo-pun"
+          "zenfutsuo-pun"
         ]
       },
       {
@@ -90710,7 +92082,7 @@
         "en": "Australian Open",
         "ja": "全豪オープン",
         "ja_typings": [
-          "zengo-oopun"
+          "zengouo-pun"
         ]
       },
       {
@@ -90728,7 +92100,8 @@
     "question_text": {
       "en": "Which Grand Slam tennis tournament is played on clay courts in Paris?",
       "ja": "パリのクレーコートで開催されるテニスのグランドスラム大会は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90736,14 +92109,14 @@
         "en": "Australian Open",
         "ja": "全豪オープン",
         "ja_typings": [
-          "zengo-oopun"
+          "zengouo-pun"
         ]
       },
       {
         "en": "French Open",
         "ja": "全仏オープン",
         "ja_typings": [
-          "zenbutsuo-pun"
+          "zenfutsuo-pun"
         ]
       },
       {
@@ -90768,7 +92141,8 @@
     "question_text": {
       "en": "Which Grand Slam tennis tournament is held in Melbourne in January?",
       "ja": "1月にメルボルンで開催されるテニスのグランドスラム大会は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90808,7 +92182,8 @@
     "question_text": {
       "en": "Who is the English inventor of the early atmospheric steam engine in 1712?",
       "ja": "1712年に大気圧蒸気機関を実用化した英国の発明家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90848,7 +92223,8 @@
     "question_text": {
       "en": "Who built the early steam locomotive 'Rocket' in England?",
       "ja": "英国で蒸気機関車「ロケット号」を製作した技術者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90888,7 +92264,8 @@
     "question_text": {
       "en": "Who is the American engineer who developed the first commercially successful steamboat?",
       "ja": "商業的に成功した最初の蒸気船を開発した米国人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90928,7 +92305,8 @@
     "question_text": {
       "en": "Which large stinging insect builds papery nests and is more aggressive than honeybees?",
       "ja": "ミツバチより攻撃的で紙状の巣を作る大型の刺す昆虫は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90968,7 +92346,8 @@
     "question_text": {
       "en": "Which slender wasp builds open umbrella-shaped nests?",
       "ja": "細身で傘状の巣を作るハチは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91008,7 +92387,8 @@
     "question_text": {
       "en": "Which large solitary black bee bores into wood to make nests?",
       "ja": "木に穴を開けて巣を作る大きな黒い単独行動の蜂は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91048,7 +92428,8 @@
     "question_text": {
       "en": "Which early Japanese VTuber was known as the cheerful 'school idol' alongside the original four?",
       "ja": "初期4大VTuberの一人で「未来の学園アイドル」として人気を博したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91088,7 +92469,8 @@
     "question_text": {
       "en": "Which early Japanese VTuber is famous for an energetic Princess Kaguya themed persona?",
       "ja": "かぐや姫をモチーフにした奔放なキャラで知られる初期VTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91128,7 +92510,8 @@
     "question_text": {
       "en": "Which Hololive VTuber is a pirate captain known for the catchphrase 'ahoy'?",
       "ja": "「あほーい」で知られるホロライブの海賊船長は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91168,7 +92551,8 @@
     "question_text": {
       "en": "Which Plutchik emotion is conveyed by the red angry-face emoji?",
       "ja": "赤い怒り顔の絵文字が表すプルチック基本感情は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91183,7 +92567,6 @@
         "en": "VShojo",
         "ja": "ブイショウジョ",
         "ja_typings": [
-          "buishojo",
           "buishoujo"
         ]
       },
@@ -91209,7 +92592,8 @@
     "question_text": {
       "en": "Which VTuber agency manages stylish 'Noripro' talents in Japan?",
       "ja": "ののかみらいなど「のりプロ」の所属タレントを抱える事務所は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91217,7 +92601,6 @@
         "en": "VShojo",
         "ja": "ブイショウジョ",
         "ja_typings": [
-          "buishojo",
           "buishoujo"
         ]
       },
@@ -91250,7 +92633,8 @@
     "question_text": {
       "en": "Which English-language VTuber agency includes Ironmouse and Projekt Melody?",
       "ja": "アイアンマウスやプロジェクトメロディなどが所属する英語圏VTuber事務所は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91290,7 +92674,8 @@
     "question_text": {
       "en": "Which early VTuber's full name is 'Dennou Shoujo Siro'?",
       "ja": "「電脳少女シロ」のフルネームで知られる初期VTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91330,7 +92715,8 @@
     "question_text": {
       "en": "Which Japanese internet company is the parent of Nijisanji's operator Anycolor's predecessor relationships and also runs AbemaTV?",
       "ja": "AbemaTVを運営する日本のインターネット企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91370,7 +92756,8 @@
     "question_text": {
       "en": "What live streaming community term refers to the meme cat 'chato' that became iconic in early Japanese VTuber chats?",
       "ja": "初期VTuber配信のコメント文化で象徴的になった猫「ちゃと」を指す言葉は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91410,7 +92797,8 @@
     "question_text": {
       "en": "Which Hololive English Myth member is the detective with the catchphrase 'Watson'?",
       "ja": "ホロライブEN Mythの「探偵」キャラのメンバーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91450,7 +92838,8 @@
     "question_text": {
       "en": "Which Plutchik emotion is conveyed by the crying-face emoji?",
       "ja": "泣き顔の絵文字が表すプルチック基本感情は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91465,7 +92854,6 @@
         "en": "VShojo",
         "ja": "ブイショウジョ",
         "ja_typings": [
-          "buishojo",
           "buishoujo"
         ]
       },
@@ -91491,7 +92879,8 @@
     "question_text": {
       "en": "Which VTuber group focuses on competitive FPS and esports under Brave Group?",
       "ja": "ブレイブグループ傘下でFPS・eスポーツを中心とするVTuberグループは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91520,7 +92909,6 @@
         "en": "VShojo",
         "ja": "ブイショウジョ",
         "ja_typings": [
-          "buishojo",
           "buishoujo"
         ]
       }
@@ -91532,7 +92920,8 @@
     "question_text": {
       "en": "Which early Japanese VTuber group included Dennou Shoujo Siro and Mononobe no Alice?",
       "ja": "電脳少女シロや物述有栖が所属していた初期VTuberグループは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91572,7 +92961,8 @@
     "question_text": {
       "en": "Which Japanese company is famous for Weiss Schwarz card games and pro wrestling promotion?",
       "ja": "ヴァイスシュヴァルツやプロレス興行で知られる日本企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91612,7 +93002,8 @@
     "question_text": {
       "en": "Which Japanese electronics company makes the PlayStation?",
       "ja": "プレイステーションを製造する日本企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91634,8 +93025,7 @@
         "en": "kusa haeru",
         "ja": "ありがとう",
         "ja_typings": [
-          "arigatou",
-          "arigato"
+          "arigatou"
         ]
       },
       {
@@ -91653,7 +93043,8 @@
     "question_text": {
       "en": "Which Japanese chat slang of multiple 'w' characters means laughing hard?",
       "ja": "wを連ねた「wwwww」というネットスラングの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91693,7 +93084,8 @@
     "question_text": {
       "en": "Which Western internet slang means laughing, written as an emoticon with squinted eyes?",
       "ja": "目をつぶった顔文字で笑いを表す英語圏のネットスラングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91733,7 +93125,8 @@
     "question_text": {
       "en": "Which Japanese internet phrase literally meaning 'grass grows' is used to indicate laughter?",
       "ja": "「草が生える」という言葉でネット上の笑いを表す表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91773,7 +93166,8 @@
     "question_text": {
       "en": "Which YouTube monetization feature provides paid subscribers with badges and exclusive perks?",
       "ja": "YouTubeで有料会員にバッジや限定特典を付与する仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91813,7 +93207,8 @@
     "question_text": {
       "en": "What is the general term for sending money to a streamer?",
       "ja": "配信者にお金を送る一般用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91853,7 +93248,8 @@
     "question_text": {
       "en": "Which Japanese slang word for 'Super Chat' on YouTube is used in VTuber chats?",
       "ja": "YouTubeのスーパーチャットをVTuber視聴者が略して呼ぶ言葉は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91893,7 +93289,8 @@
     "question_text": {
       "en": "Which Japanese chat slang abbreviates 'donation/tip'?",
       "ja": "「投げ銭」を意味するチャットスラングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91933,7 +93330,8 @@
     "question_text": {
       "en": "Which Japanese fan slang abbreviates 'members-only stream'?",
       "ja": "「メンバー限定配信」をファンが略す言い方は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91973,7 +93371,8 @@
     "question_text": {
       "en": "Which Japanese word meaning 'limited' is used for members-only or time-limited content?",
       "ja": "メン限や期間限定で使われる「限定」の日本語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92013,7 +93412,8 @@
     "question_text": {
       "en": "Which English abbreviation refers to a recurring paid subscription service?",
       "ja": "月額課金サービスの英語略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92053,7 +93453,8 @@
     "question_text": {
       "en": "What is the in-app currency name commonly used in mobile games and streaming apps?",
       "ja": "モバイルゲームや配信アプリの基本的なアプリ内通貨の呼び名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92093,7 +93494,8 @@
     "question_text": {
       "en": "Which premium in-app currency is often represented as a shining stone?",
       "ja": "光る宝石として描かれる高価なアプリ内通貨は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92133,7 +93535,8 @@
     "question_text": {
       "en": "Which niconico feature lets viewers shoot a barrage of comments at once?",
       "ja": "ニコニコ動画でコメントを一斉に大量に流す機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92173,7 +93576,8 @@
     "question_text": {
       "en": "Which niconico video commenting style scrolls comments from right to left?",
       "ja": "ニコニコ動画でコメントが右から左へ流れる方式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92213,7 +93617,8 @@
     "question_text": {
       "en": "Which general English term refers to live text conversation in a stream?",
       "ja": "ライブ配信で文字会話を行う一般的な英語の名称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92253,7 +93658,8 @@
     "question_text": {
       "en": "Which VTuber title refers to the head of a student council, used by Shirogane Noel?",
       "ja": "白銀ノエルが使う「会長」を意味するVTuber呼称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92293,7 +93699,8 @@
     "question_text": {
       "en": "Which Japanese title meaning 'group leader' is used as a nickname for Shirogane Noel?",
       "ja": "白銀ノエルの愛称として使われる「団長」を意味する呼称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92333,7 +93740,8 @@
     "question_text": {
       "en": "Which Japanese title meaning 'company president' is used as a nickname for Houshou Marine?",
       "ja": "宝鐘マリンの愛称として使われる「社長」を意味する呼称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92373,7 +93781,8 @@
     "question_text": {
       "en": "Which Japanese character ending sound is associated with cute cat-like speech?",
       "ja": "猫っぽい可愛い語尾としてキャラに使われるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92413,7 +93822,8 @@
     "question_text": {
       "en": "Which Japanese sentence-ending emphasis word means roughly 'you know'?",
       "ja": "強調や念押しで使う「ぞ」を含む語尾は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92453,7 +93863,8 @@
     "question_text": {
       "en": "Which Japanese assertive sentence-ending phrase often used by anime characters means roughly 'it is so'?",
       "ja": "アニメキャラがよく使う「断定」の語尾で「のだ」となるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92493,7 +93904,8 @@
     "question_text": {
       "en": "Which Hololive branch is based in Indonesia?",
       "ja": "ホロライブのインドネシア拠点支部は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92533,7 +93945,8 @@
     "question_text": {
       "en": "Which Hololive branch is the original Japanese division?",
       "ja": "ホロライブの本家日本支部は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92573,7 +93986,8 @@
     "question_text": {
       "en": "Which Hololive branch operated in mainland China before its 2020 closure?",
       "ja": "2020年に活動終了したホロライブの中国大陸支部は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92613,7 +94027,8 @@
     "question_text": {
       "en": "Which Hololive English Myth member is themed after a phoenix and known as KFP?",
       "ja": "不死鳥がモチーフでKFPのファン名でも知られるホロライブEN Mythのメンバーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92653,7 +94068,8 @@
     "question_text": {
       "en": "Which Nijisanji VTuber is famous as one of the original gen 1 members and was known as 'Mito-chan'?",
       "ja": "にじさんじ1期生で「ミトちゃん」として親しまれてきたメンバーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92693,7 +94109,8 @@
     "question_text": {
       "en": "Which Nijisanji female VTuber is known for collabs with Honma Himawari as a duo?",
       "ja": "本間ひまわりとのコンビでも知られるにじさんじの女性ライバーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92733,7 +94150,8 @@
     "question_text": {
       "en": "Which Nijisanji VTuber pairs with Sasaki Saku in the 'Saku and Hima' duo?",
       "ja": "「咲ひま」コンビで笹木咲とペアになるにじさんじのメンバーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92773,7 +94191,8 @@
     "question_text": {
       "en": "Which Nijisanji male duo consists of two top streamers known as 'ChroNoiR'?",
       "ja": "「ChroNoiR」として知られるにじさんじのトップ配信者2人組は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92813,7 +94232,8 @@
     "question_text": {
       "en": "Which Nijisanji male duo combines 'Kanae' with the lawyer-themed VTuber?",
       "ja": "叶と弁護士キャラのVTuberが組むにじさんじのコンビは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92853,7 +94273,8 @@
     "question_text": {
       "en": "Which Nijisanji collab pair brings together the vampire-themed Kuzuha and the gen 1 chairperson?",
       "ja": "吸血鬼キャラの葛葉と1期生委員長によるコラボペアは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92893,7 +94314,8 @@
     "question_text": {
       "en": "Which manga and anime by Hajime Isayama features humans fighting giant humanoids?",
       "ja": "諫山創による人類と巨人の戦いを描いた漫画・アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92933,7 +94355,8 @@
     "question_text": {
       "en": "Which long-running Shonen Jump manga features pirates searching for the ultimate treasure?",
       "ja": "海賊たちが究極の財宝を探す週刊少年ジャンプの長編漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92973,7 +94396,8 @@
     "question_text": {
       "en": "Which manga by Koyoharu Gotouge features a boy who joins a corps to slay demons after his family is attacked?",
       "ja": "家族を襲われた少年が鬼を狩る隊に入る、吾峠呼世晴の漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93013,7 +94437,8 @@
     "question_text": {
       "en": "Which English chat phrase means 'understood' or 'I see'?",
       "ja": "「了解」「わかった」を意味する英語チャットフレーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93053,7 +94478,8 @@
     "question_text": {
       "en": "Which Japanese script is used mainly for foreign loanwords?",
       "ja": "外来語を表すのに主に使われる日本語の文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93082,7 +94508,7 @@
         "en": "Dravidian",
         "ja": "ドラヴィダ諸語",
         "ja_typings": [
-          "dorabidashogo"
+          "doravidashogo"
         ]
       }
     ],
@@ -93093,7 +94519,8 @@
     "question_text": {
       "en": "Which controversial language family groups Turkic, Mongolic, and Tungusic?",
       "ja": "テュルク・モンゴル・ツングース諸語をまとめる仮説的な語族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93134,7 +94561,8 @@
     "question_text": {
       "en": "Which language has the most native speakers as a global lingua franca?",
       "ja": "世界共通語として最も広く使われている言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93175,7 +94603,8 @@
     "question_text": {
       "en": "Which part of speech connects words or clauses, like 'and' or 'but'?",
       "ja": "「そして」「しかし」のように語句や節をつなぐ品詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93191,8 +94620,7 @@
         "en": "Active voice",
         "ja": "能動態",
         "ja_typings": [
-          "nodoutai",
-          "nodotai"
+          "noudoutai"
         ]
       },
       {
@@ -93218,7 +94646,8 @@
     "question_text": {
       "en": "Which grammatical voice is neither active nor passive (e.g., Ancient Greek)?",
       "ja": "能動でも受動でもない、古典ギリシャ語などにある態は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93258,7 +94687,8 @@
     "question_text": {
       "en": "Which Romance language is the official language of Italy?",
       "ja": "イタリアの公用語であるロマンス諸語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93299,7 +94729,8 @@
     "question_text": {
       "en": "Which romanization system for Mandarin was widely used before Pinyin?",
       "ja": "ピンイン以前に広く使われた中国語ローマ字表記は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93315,7 +94746,7 @@
         "en": "Metaphor",
         "ja": "隠喩",
         "ja_typings": [
-          "inyu"
+          "innyu"
         ]
       },
       {
@@ -93341,7 +94772,8 @@
     "question_text": {
       "en": "Which rhetorical device juxtaposes contrasting ideas in parallel structure?",
       "ja": "対立する語句を並列に置く修辞技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93372,7 +94804,7 @@
         "en": "Kun-yomi",
         "ja": "訓読み",
         "ja_typings": [
-          "kunyomi"
+          "kunnyomi"
         ]
       }
     ],
@@ -93383,7 +94815,8 @@
     "question_text": {
       "en": "Which Sino-Japanese reading reflects the pronunciation of Tang-era China?",
       "ja": "唐代の中国音を伝える漢字の音読みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93423,7 +94856,8 @@
     "question_text": {
       "en": "Which ancient Semitic script is the ancestor of most modern alphabets?",
       "ja": "現代のアルファベットの祖となった古代セム系文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93463,7 +94897,8 @@
     "question_text": {
       "en": "Which Romance language is co-official in Andorra and parts of Spain?",
       "ja": "アンドラとスペインの一部で公用語となるロマンス語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93503,7 +94938,8 @@
     "question_text": {
       "en": "What name is used for Chinese characters when used in Korean?",
       "ja": "韓国語で使われる漢字の呼称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93511,7 +94947,7 @@
         "en": "Dravidian",
         "ja": "ドラヴィダ語族",
         "ja_typings": [
-          "doravu~idagozoku"
+          "doravidagozoku"
         ]
       },
       {
@@ -93543,7 +94979,8 @@
     "question_text": {
       "en": "Which language family includes Tamil, Telugu, and Malayalam?",
       "ja": "タミル語・テルグ語・マラヤーラム語を含む語族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93584,7 +95021,8 @@
     "question_text": {
       "en": "What is a standardized set of letters used to write a language?",
       "ja": "言語を表記するために標準化された文字の集合は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93600,7 +95038,7 @@
         "en": "consonant cluster",
         "ja": "子音連結",
         "ja_typings": [
-          "shi'inrenketsu"
+          "shiinrenketsu"
         ]
       },
       {
@@ -93625,7 +95063,8 @@
     "question_text": {
       "en": "Which phonological phenomenon (e.g., in Turkish) requires vowels in a word to share features?",
       "ja": "トルコ語などで語内の母音が同じ特徴を持つ現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93667,7 +95106,8 @@
     "question_text": {
       "en": "Which branch of linguistics studies word formation?",
       "ja": "語の形成を研究する言語学の分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93707,7 +95147,8 @@
     "question_text": {
       "en": "What is the smallest unit of sound that distinguishes meaning?",
       "ja": "意味を区別する音声の最小単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93747,7 +95188,8 @@
     "question_text": {
       "en": "What is a unit of pronunciation having one vowel sound?",
       "ja": "母音を1つ含む発音の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93789,7 +95231,8 @@
     "question_text": {
       "en": "Which field studies the physical sounds of human speech?",
       "ja": "人間の言語音の物理的性質を扱う分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93831,7 +95274,8 @@
     "question_text": {
       "en": "What is the study of writing systems and their units?",
       "ja": "文字体系とその単位を研究する分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93871,7 +95315,8 @@
     "question_text": {
       "en": "Which script is used to write modern Standard Arabic?",
       "ja": "現代標準アラビア語を書くための文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93911,7 +95356,8 @@
     "question_text": {
       "en": "Which alphabet is used to write modern Greek?",
       "ja": "現代ギリシャ語を書くアルファベットは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93951,7 +95397,8 @@
     "question_text": {
       "en": "Which script is used to write modern Hebrew?",
       "ja": "現代ヘブライ語を書く文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93991,7 +95438,8 @@
     "question_text": {
       "en": "In which direction is English written?",
       "ja": "英語の文字を書く方向は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94031,7 +95479,8 @@
     "question_text": {
       "en": "In which direction is traditional vertical Japanese text read?",
       "ja": "日本語の伝統的な縦書きの読む方向は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94071,7 +95520,8 @@
     "question_text": {
       "en": "Which writing direction is used by Mongolian traditional script?",
       "ja": "モンゴル伝統文字の書字方向は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94113,7 +95563,8 @@
     "question_text": {
       "en": "Which part of speech modifies a noun, like 'red' or 'tall'?",
       "ja": "「赤い」「高い」のように名詞を修飾する品詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94154,7 +95605,8 @@
     "question_text": {
       "en": "In Japanese grammar, what part of speech only modifies nouns (e.g., kono, sono)?",
       "ja": "「この」「その」のように名詞だけを修飾する日本語の品詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94195,7 +95647,8 @@
     "question_text": {
       "en": "Which part of speech expresses emotion (e.g., 'oh!', 'wow!')?",
       "ja": "「あっ」「おお」のように感動を表す品詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94236,7 +95689,8 @@
     "question_text": {
       "en": "Which part of speech replaces a noun (e.g., 'he', 'she', 'it')?",
       "ja": "名詞の代わりに使われる品詞 (例: 彼、それ) は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94277,7 +95731,8 @@
     "question_text": {
       "en": "What is Japanese honorific 'o-' / 'go-' prefix style called?",
       "ja": "日本語で「お」「ご」を付けて言葉を整える表現の名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94318,7 +95773,8 @@
     "question_text": {
       "en": "Which register of speech is used in informal conversation?",
       "ja": "日常会話で用いられる、くだけた言葉遣いは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94360,7 +95816,8 @@
     "question_text": {
       "en": "Which Japanese style is used in official documents and speeches?",
       "ja": "公的な文書や演説で用いられる日本語の文体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94402,7 +95859,8 @@
     "question_text": {
       "en": "What is the process of forming a new word by adding affixes?",
       "ja": "接辞を付けて新しい語を作る過程は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94444,7 +95902,8 @@
     "question_text": {
       "en": "What is the modification of a word to express grammatical features?",
       "ja": "語の文法的特徴を表すための変化は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94485,7 +95944,8 @@
     "question_text": {
       "en": "What is a diachronic change in pronunciation of a language called?",
       "ja": "時間とともに起こる言語の発音変化は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94526,7 +95986,8 @@
     "question_text": {
       "en": "What is the doubling of a consonant sound called (e.g., Japanese sokuon)?",
       "ja": "促音のように子音が重なる現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94569,7 +96030,8 @@
     "question_text": {
       "en": "What term refers to a vowel changing across related forms (e.g., sing/sang)?",
       "ja": "関連する語形で母音が変化する現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94610,7 +96072,8 @@
     "question_text": {
       "en": "What is the historical sound change in Japanese where word-internal sounds change for ease?",
       "ja": "日本語で発音が変化する音便現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94625,14 +96088,14 @@
         "en": "I-onbin",
         "ja": "イ音便",
         "ja_typings": [
-          "i-onbin"
+          "ionbin"
         ]
       },
       {
         "en": "U-onbin",
         "ja": "ウ音便",
         "ja_typings": [
-          "u-onbin"
+          "uonbin"
         ]
       },
       {
@@ -94650,7 +96113,8 @@
     "question_text": {
       "en": "Which Japanese sound change turns a consonant into a nasal (e.g., 'shinde')?",
       "ja": "日本語で子音が撥音に変化する音便は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94691,7 +96155,8 @@
     "question_text": {
       "en": "Which Japanese sandhi merges a final n with a following vowel (e.g., han'nou)?",
       "ja": "撥音が後続母音と結びついて生じる日本語の連音現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94735,7 +96200,8 @@
     "question_text": {
       "en": "Which grammatical aspect expresses completed action with present relevance?",
       "ja": "完了して現在に影響が残ることを示す相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94776,7 +96242,8 @@
     "question_text": {
       "en": "Which tense refers to actions that already happened?",
       "ja": "すでに起こった出来事を示す時制は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94817,7 +96284,8 @@
     "question_text": {
       "en": "Which tense refers to actions yet to happen?",
       "ja": "これから起こる出来事を示す時制は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94859,7 +96327,8 @@
     "question_text": {
       "en": "Which grammatical category describes the flow of time within an action?",
       "ja": "動作の時間的な流れ方を表す文法カテゴリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94901,7 +96370,8 @@
     "question_text": {
       "en": "Which grammatical category distinguishes active and passive?",
       "ja": "能動と受動を区別する文法カテゴリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94943,7 +96413,8 @@
     "question_text": {
       "en": "Which grammatical category expresses attitude (e.g., command, wish)?",
       "ja": "話者の心的態度 (命令・願望など) を表す文法カテゴリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94984,7 +96455,8 @@
     "question_text": {
       "en": "Which Japanese verb form expresses 'can do' (e.g., yomeru)?",
       "ja": "「読める」のように「〜できる」を表す日本語の動詞形は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95024,7 +96496,8 @@
     "question_text": {
       "en": "Which language is the official language of France?",
       "ja": "フランスの公用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95064,7 +96537,8 @@
     "question_text": {
       "en": "Which language is the official language of the Netherlands?",
       "ja": "オランダの公用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95104,7 +96578,8 @@
     "question_text": {
       "en": "Which Valencia festival burns giant satirical figures in March?",
       "ja": "3月にバレンシアで巨大な人形を焼くスペインの祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95144,7 +96619,8 @@
     "question_text": {
       "en": "Which Mexican Christmas tradition reenacts Mary and Joseph seeking lodging?",
       "ja": "メキシコでマリアとヨセフの宿探しを再現するクリスマス行事は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95184,7 +96660,8 @@
     "question_text": {
       "en": "Which nine-night Hindu festival worships the goddess Durga?",
       "ja": "ドゥルガー女神を祀る9夜にわたるヒンドゥー教の祭は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95224,7 +96701,8 @@
     "question_text": {
       "en": "Which Tamil harvest festival celebrates the sun in January?",
       "ja": "1月に太陽神を祝うタミル人の収穫祭は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95264,7 +96742,8 @@
     "question_text": {
       "en": "What is the traditional Indian male garment wrapped around the waist?",
       "ja": "腰に巻くインドの伝統的な男性用の衣装は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95304,7 +96783,8 @@
     "question_text": {
       "en": "Which Dominican music and dance style features romantic guitar?",
       "ja": "ロマンチックなギターが特徴のドミニカ共和国の音楽は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95344,7 +96824,8 @@
     "question_text": {
       "en": "Which Seville festival features flamenco and casetas after Holy Week?",
       "ja": "聖週間後にセビリアで開かれるフラメンコの祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95384,7 +96865,8 @@
     "question_text": {
       "en": "Which large communal dwelling housed several families in Native American cultures?",
       "ja": "複数の家族が暮らした北米先住民の細長い共同住居は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95426,7 +96908,8 @@
     "question_text": {
       "en": "Who is the most important playwright and theorist of Noh theatre?",
       "ja": "能の大成者として最も知られる劇作家・理論家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95467,7 +96950,8 @@
     "question_text": {
       "en": "Who is the master of haiku famous for 'Oku no Hosomichi'?",
       "ja": "『奥の細道』で知られる俳諧の巨匠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95511,7 +96995,8 @@
     "question_text": {
       "en": "Which Muromachi-era ink painter is known for landscapes like 'Long Landscape Scroll'?",
       "ja": "『山水長巻』で知られる室町時代の水墨画家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95551,7 +97036,8 @@
     "question_text": {
       "en": "Which is the largest city in Brazil?",
       "ja": "ブラジル最大の都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95591,7 +97077,8 @@
     "question_text": {
       "en": "Which Brazilian city was the country's first capital and is known for Afro-Brazilian culture?",
       "ja": "ブラジル最初の首都で、アフロ・ブラジル文化の中心地は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95606,7 +97093,7 @@
         "en": "Venice Film Festival",
         "ja": "ヴェネツィア国際映画祭",
         "ja_typings": [
-          "vu~enetsiakokusaieigasai"
+          "venetsiakokusaieigasai"
         ]
       },
       {
@@ -95631,7 +97118,8 @@
     "question_text": {
       "en": "Which French film festival awards the Palme d'Or?",
       "ja": "パルム・ドールを授与するフランスの映画祭は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95671,7 +97159,8 @@
     "question_text": {
       "en": "Which Italian carnival is famous for elaborate masks?",
       "ja": "華やかな仮面で知られるイタリアの謝肉祭は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95711,7 +97200,8 @@
     "question_text": {
       "en": "Which Brazilian music festival is one of the largest in the world?",
       "ja": "ブラジルで開かれる世界最大級の音楽フェスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95753,7 +97243,8 @@
     "question_text": {
       "en": "Which masked Japanese musical drama dates from the 14th century?",
       "ja": "14世紀から続く面を着けた日本の歌舞演劇は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95795,7 +97286,8 @@
     "question_text": {
       "en": "Which Japanese traditional puppet theatre uses three puppeteers per puppet?",
       "ja": "1体の人形を3人で操る日本の伝統人形劇は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95836,7 +97328,8 @@
     "question_text": {
       "en": "Which Japanese comic theatre is performed between Noh plays?",
       "ja": "能の演目の合間に上演される滑稽な日本の演劇は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95876,7 +97369,8 @@
     "question_text": {
       "en": "Which Islamic month commemorates the martyrdom of Husayn ibn Ali?",
       "ja": "フサイン・イブン・アリーの殉教を悼むイスラム暦の月は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95916,7 +97410,8 @@
     "question_text": {
       "en": "Which Islamic month follows Ramadan and starts with Eid al-Fitr?",
       "ja": "ラマダーン明けでイード・アル＝フィトルから始まるイスラム暦の月は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95956,7 +97451,8 @@
     "question_text": {
       "en": "Which is the seventh month of the Islamic calendar, considered sacred?",
       "ja": "イスラム暦の第7月で神聖月とされるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95996,7 +97492,8 @@
     "question_text": {
       "en": "Which Italian coffee drink tops espresso with foamed milk in equal layers?",
       "ja": "エスプレッソに泡立てミルクを等量に重ねるイタリアのコーヒーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96036,7 +97533,8 @@
     "question_text": {
       "en": "Which Italian coffee is espresso 'stained' with a small amount of milk?",
       "ja": "エスプレッソに少量のミルクを加えたイタリアのコーヒーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96076,7 +97574,8 @@
     "question_text": {
       "en": "Which coffee is espresso diluted with hot water?",
       "ja": "エスプレッソをお湯で薄めたコーヒーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96116,7 +97615,8 @@
     "question_text": {
       "en": "Which Spanish Holy Week celebration features hooded processions?",
       "ja": "とんがり頭巾の行列が特徴のスペイン聖週間の祝祭は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96158,7 +97658,8 @@
     "question_text": {
       "en": "Which Chinese festival celebrates the harvest with mooncakes?",
       "ja": "月餅を食べて収穫を祝う中国の祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96200,7 +97701,8 @@
     "question_text": {
       "en": "Which Chinese festival features dragon boat races and zongzi?",
       "ja": "ドラゴンボートレースと粽が伝統の中国の祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96242,7 +97744,8 @@
     "question_text": {
       "en": "Which Chinese festival is the tomb-sweeping day in early April?",
       "ja": "4月初旬に行われる墓参りの中国の祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96271,7 +97774,7 @@
         "en": "Ratatouille",
         "ja": "ラタトゥイユ",
         "ja_typings": [
-          "ratatuiyu"
+          "ratatwuiyu"
         ]
       }
     ],
@@ -96282,7 +97785,8 @@
     "question_text": {
       "en": "Which Provencal fish stew is from Marseille?",
       "ja": "マルセイユ発祥のプロヴァンス風魚介スープは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96322,7 +97826,8 @@
     "question_text": {
       "en": "Which French slow-cooked stew of beans and meat is from Languedoc?",
       "ja": "ラングドック地方の豆と肉の煮込み料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96351,7 +97856,7 @@
         "en": "Ratatouille",
         "ja": "ラタトゥイユ",
         "ja_typings": [
-          "ratatuiyu"
+          "ratatwuiyu"
         ]
       }
     ],
@@ -96362,7 +97867,8 @@
     "question_text": {
       "en": "Which classic French dish is a boiled beef and vegetable stew?",
       "ja": "牛肉と野菜を煮込んだフランスの伝統料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96402,7 +97908,8 @@
     "question_text": {
       "en": "Which long collarless shirt is worn across South Asia?",
       "ja": "南アジアで広く着用される襟なしの長いシャツは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96442,7 +97949,8 @@
     "question_text": {
       "en": "Which loose trousers are paired with a kameez in South Asia?",
       "ja": "南アジアでカミーズと合わせる、ゆったりしたズボンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96482,7 +97990,8 @@
     "question_text": {
       "en": "Which non-mandatory Islamic pilgrimage to Mecca can be performed any time of year?",
       "ja": "メッカへの随時可能な小巡礼は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96522,7 +98031,8 @@
     "question_text": {
       "en": "Which is the Islamic ritual prayer performed five times a day?",
       "ja": "1日5回行うイスラム教の礼拝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96562,7 +98072,8 @@
     "question_text": {
       "en": "Which Islamic pillar is the obligatory almsgiving?",
       "ja": "イスラム教における義務的な喜捨は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96602,7 +98113,8 @@
     "question_text": {
       "en": "Which Russian word names the traditional grandmother's headscarf or nesting doll?",
       "ja": "ロシアの伝統的なおばあさんの頭巾や入れ子人形を指す語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96642,7 +98154,8 @@
     "question_text": {
       "en": "Which Russian small baked or fried bun is filled with meat or potatoes?",
       "ja": "肉や芋を詰めて焼くロシアの小さなパンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96682,7 +98195,8 @@
     "question_text": {
       "en": "Which Russian folk painting uses red, black and gold on wooden tableware?",
       "ja": "赤・黒・金で木製食器を彩るロシアの民芸絵付けは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96726,7 +98240,8 @@
     "question_text": {
       "en": "Which Paris Gothic cathedral has flying buttresses and famous gargoyles?",
       "ja": "フライング・バットレスとガーゴイルで有名なパリのゴシック大聖堂は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96770,7 +98285,8 @@
     "question_text": {
       "en": "Which German Gothic cathedral is the largest in northern Europe?",
       "ja": "北ヨーロッパ最大のゴシック大聖堂であるドイツの教会は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96814,7 +98330,8 @@
     "question_text": {
       "en": "Which Italian Gothic cathedral has more than 3,000 statues on its facade?",
       "ja": "3000体以上の彫像が並ぶイタリアのゴシック大聖堂は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96858,7 +98375,8 @@
     "question_text": {
       "en": "Which avant-garde school of ikebana was founded in 1927 by Teshigahara?",
       "ja": "1927年に勅使河原蒼風が創始したいけばなの流派は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96902,7 +98420,8 @@
     "question_text": {
       "en": "Which ikebana school pioneered the moribana shallow-container style?",
       "ja": "盛花を考案したいけばなの流派は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96946,7 +98465,8 @@
     "question_text": {
       "en": "Which ikebana school traces its origin to Emperor Saga at Daikaku-ji?",
       "ja": "嵯峨天皇と大覚寺に由来するいけばなの流派は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96986,7 +98506,8 @@
     "question_text": {
       "en": "What is the national embroidered formal shirt of the Philippines for men?",
       "ja": "フィリピンの男性正装である刺繍シャツは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97026,7 +98547,8 @@
     "question_text": {
       "en": "Which is the holiest day of the Jewish year, the Day of Atonement?",
       "ja": "ユダヤ教で最も神聖な「贖罪の日」は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97066,7 +98588,8 @@
     "question_text": {
       "en": "Which Jewish festival of lights lasts eight nights?",
       "ja": "8日間ろうそくを灯すユダヤ教の光の祭は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97074,7 +98597,6 @@
         "en": "ECS",
         "ja": "ECS",
         "ja_typings": [
-          "i-shi-esu",
           "ecs"
         ]
       },
@@ -97082,7 +98604,6 @@
         "en": "EKS",
         "ja": "EKS",
         "ja_typings": [
-          "i-kei-esu",
           "eks"
         ]
       },
@@ -97108,7 +98629,8 @@
     "question_text": {
       "en": "Which AWS service runs Docker containers without Kubernetes?",
       "ja": "Kubernetes を使わず Docker コンテナを動かす AWS のサービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97116,7 +98638,6 @@
         "en": "EKS",
         "ja": "EKS",
         "ja_typings": [
-          "i-kei-esu",
           "eks"
         ]
       },
@@ -97124,7 +98645,6 @@
         "en": "ECS",
         "ja": "ECS",
         "ja_typings": [
-          "i-shi-esu",
           "ecs"
         ]
       },
@@ -97132,7 +98652,6 @@
         "en": "AKS",
         "ja": "AKS",
         "ja_typings": [
-          "e-kei-esu",
           "aks"
         ]
       },
@@ -97140,7 +98659,6 @@
         "en": "GKE",
         "ja": "GKE",
         "ja_typings": [
-          "ji-kei-i-",
           "gke"
         ]
       }
@@ -97152,7 +98670,8 @@
     "question_text": {
       "en": "Which is AWS's managed Kubernetes service?",
       "ja": "AWS が提供するマネージド Kubernetes は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97160,7 +98679,6 @@
         "en": "QA",
         "ja": "QA",
         "ja_typings": [
-          "kyu-e-",
           "qa"
         ]
       },
@@ -97168,7 +98686,6 @@
         "en": "UA",
         "ja": "UA",
         "ja_typings": [
-          "yu-e-",
           "ua"
         ]
       },
@@ -97176,7 +98693,6 @@
         "en": "DA",
         "ja": "DA",
         "ja_typings": [
-          "di-e-",
           "da"
         ]
       },
@@ -97184,7 +98700,6 @@
         "en": "PA",
         "ja": "PA",
         "ja_typings": [
-          "pi-e-",
           "pa"
         ]
       }
@@ -97196,7 +98711,8 @@
     "question_text": {
       "en": "Which abbreviation refers to quality assurance in software?",
       "ja": "ソフトウェアの品質保証を意味する略語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97204,7 +98720,6 @@
         "en": "OCI",
         "ja": "OCI",
         "ja_typings": [
-          "o-shi-ai",
           "oci"
         ]
       },
@@ -97212,7 +98727,6 @@
         "en": "CRI",
         "ja": "CRI",
         "ja_typings": [
-          "shi-a-ru-ai",
           "cri"
         ]
       },
@@ -97220,7 +98734,6 @@
         "en": "CNI",
         "ja": "CNI",
         "ja_typings": [
-          "shi-enu-ai",
           "cni"
         ]
       },
@@ -97228,7 +98741,6 @@
         "en": "OPA",
         "ja": "OPA",
         "ja_typings": [
-          "o-pi-e-",
           "opa"
         ]
       }
@@ -97240,7 +98752,8 @@
     "question_text": {
       "en": "Which open standard defines container runtimes and image format?",
       "ja": "コンテナランタイムとイメージ形式のオープン標準は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97282,7 +98795,8 @@
     "question_text": {
       "en": "Which non-functional requirement measures uptime of a system?",
       "ja": "システムの稼働率を示す非機能要件は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97290,7 +98804,6 @@
         "en": "AKS",
         "ja": "AKS",
         "ja_typings": [
-          "e-kei-esu",
           "aks"
         ]
       },
@@ -97298,7 +98811,6 @@
         "en": "EKS",
         "ja": "EKS",
         "ja_typings": [
-          "i-kei-esu",
           "eks"
         ]
       },
@@ -97306,7 +98818,6 @@
         "en": "GKE",
         "ja": "GKE",
         "ja_typings": [
-          "ji-kei-i-",
           "gke"
         ]
       },
@@ -97314,7 +98825,6 @@
         "en": "OKE",
         "ja": "OKE",
         "ja_typings": [
-          "o-kei-i-",
           "oke"
         ]
       }
@@ -97326,7 +98836,8 @@
     "question_text": {
       "en": "Which is Microsoft Azure's managed Kubernetes service?",
       "ja": "Microsoft Azure のマネージド Kubernetes は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97334,7 +98845,6 @@
         "en": "OKE",
         "ja": "OKE",
         "ja_typings": [
-          "o-kei-i-",
           "oke"
         ]
       },
@@ -97342,7 +98852,6 @@
         "en": "AKS",
         "ja": "AKS",
         "ja_typings": [
-          "e-kei-esu",
           "aks"
         ]
       },
@@ -97350,7 +98859,6 @@
         "en": "EKS",
         "ja": "EKS",
         "ja_typings": [
-          "i-kei-esu",
           "eks"
         ]
       },
@@ -97358,7 +98866,6 @@
         "en": "GKE",
         "ja": "GKE",
         "ja_typings": [
-          "ji-kei-i-",
           "gke"
         ]
       }
@@ -97370,7 +98877,8 @@
     "question_text": {
       "en": "Which is Oracle Cloud's managed Kubernetes service?",
       "ja": "Oracle Cloud のマネージド Kubernetes は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97378,7 +98886,6 @@
         "en": "ITIL",
         "ja": "ITIL",
         "ja_typings": [
-          "aitiru",
           "itil"
         ]
       },
@@ -97386,7 +98893,6 @@
         "en": "COBIT",
         "ja": "COBIT",
         "ja_typings": [
-          "kobitto",
           "cobit"
         ]
       },
@@ -97394,7 +98900,6 @@
         "en": "TOGAF",
         "ja": "TOGAF",
         "ja_typings": [
-          "to-gafu",
           "togaf"
         ]
       },
@@ -97402,7 +98907,6 @@
         "en": "PMBOK",
         "ja": "PMBOK",
         "ja_typings": [
-          "pinbokku",
           "pmbok"
         ]
       }
@@ -97414,7 +98918,8 @@
     "question_text": {
       "en": "Which framework standardizes IT service management practices?",
       "ja": "IT サービスマネジメントのベストプラクティス集は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97454,7 +98959,8 @@
     "question_text": {
       "en": "Which Scrum event begins a sprint by selecting backlog items?",
       "ja": "バックログを選んでスプリントを開始する Scrum のイベントは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97494,7 +99000,8 @@
     "question_text": {
       "en": "Which Ruby-based configuration management tool defines infrastructure as recipes?",
       "ja": "Ruby ベースでレシピを書く構成管理ツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97534,7 +99041,8 @@
     "question_text": {
       "en": "Which configuration management tool uses a declarative DSL and a pull model?",
       "ja": "宣言的 DSL とプル型を採用する構成管理ツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97556,7 +99064,6 @@
         "en": "QA",
         "ja": "QA",
         "ja_typings": [
-          "kyu-e-",
           "qa"
         ]
       },
@@ -97564,7 +99071,6 @@
         "en": "BA",
         "ja": "BA",
         "ja_typings": [
-          "bi-e-",
           "ba"
         ]
       }
@@ -97576,7 +99082,8 @@
     "question_text": {
       "en": "Which DevOps practice automatically delivers code to production?",
       "ja": "コードを自動で本番にデリバリする DevOps プラクティスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97616,7 +99123,8 @@
     "question_text": {
       "en": "Which HashiCorp tool manages reproducible developer VMs?",
       "ja": "再現可能な開発用 VM を管理する HashiCorp のツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97624,7 +99132,6 @@
         "en": "EBS",
         "ja": "EBS",
         "ja_typings": [
-          "i-bi-esu",
           "ebs"
         ]
       },
@@ -97632,7 +99139,6 @@
         "en": "EFS",
         "ja": "EFS",
         "ja_typings": [
-          "i-efu-esu",
           "efs"
         ]
       },
@@ -97640,7 +99146,6 @@
         "en": "S3",
         "ja": "S3",
         "ja_typings": [
-          "esu-su-ri-",
           "s3"
         ]
       },
@@ -97659,7 +99164,8 @@
     "question_text": {
       "en": "Which AWS service provides block storage volumes for EC2?",
       "ja": "EC2 にブロックストレージボリュームを提供する AWS のサービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97667,7 +99173,6 @@
         "en": "EFS",
         "ja": "EFS",
         "ja_typings": [
-          "i-efu-esu",
           "efs"
         ]
       },
@@ -97675,7 +99180,6 @@
         "en": "EBS",
         "ja": "EBS",
         "ja_typings": [
-          "i-bi-esu",
           "ebs"
         ]
       },
@@ -97683,7 +99187,6 @@
         "en": "S3",
         "ja": "S3",
         "ja_typings": [
-          "esu-su-ri-",
           "s3"
         ]
       },
@@ -97691,7 +99194,6 @@
         "en": "FSx",
         "ja": "FSx",
         "ja_typings": [
-          "efu-esu-ekkusu",
           "fsx"
         ]
       }
@@ -97703,7 +99205,8 @@
     "question_text": {
       "en": "Which AWS service provides scalable shared file storage (NFS)?",
       "ja": "AWS で NFS 互換の共有ファイルストレージを提供するサービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97743,7 +99246,8 @@
     "question_text": {
       "en": "Which AWS PaaS deploys apps and handles capacity, load balancing, scaling?",
       "ja": "AWS でアプリ展開と負荷分散・スケーリングを自動化する PaaS は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97773,7 +99277,6 @@
         "en": "F1 score",
         "ja": "F1スコア",
         "ja_typings": [
-          "efuwansukoa",
           "f1sukoa"
         ]
       }
@@ -97785,7 +99288,8 @@
     "question_text": {
       "en": "Which metric measures how often predictions are correct?",
       "ja": "予測の正答率を表す指標は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97826,7 +99330,8 @@
     "question_text": {
       "en": "Which security concept verifies the identity of a user?",
       "ja": "ユーザーの本人確認を行うセキュリティ概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97868,7 +99373,8 @@
     "question_text": {
       "en": "Which data property describes data surviving after the program ends?",
       "ja": "プログラム終了後もデータが保持される性質は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97910,7 +99416,8 @@
     "question_text": {
       "en": "Which non-functional requirement is about response time and throughput?",
       "ja": "応答時間やスループットを評価する非機能要件は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97951,7 +99458,8 @@
     "question_text": {
       "en": "Which non-functional requirement protects personal information?",
       "ja": "個人情報の保護に関する非機能要件は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97959,7 +99467,6 @@
         "en": "DaaS",
         "ja": "DaaS",
         "ja_typings": [
-          "da-su",
           "daas"
         ]
       },
@@ -97967,7 +99474,6 @@
         "en": "IaaS",
         "ja": "IaaS",
         "ja_typings": [
-          "aia-su",
           "iaas"
         ]
       },
@@ -97975,7 +99481,6 @@
         "en": "PaaS",
         "ja": "PaaS",
         "ja_typings": [
-          "pa-su",
           "paas"
         ]
       },
@@ -97983,7 +99488,6 @@
         "en": "SaaS",
         "ja": "SaaS",
         "ja_typings": [
-          "sa-su",
           "saas"
         ]
       }
@@ -97995,7 +99499,8 @@
     "question_text": {
       "en": "Which cloud delivery model provides virtual desktops?",
       "ja": "仮想デスクトップを提供するクラウドモデルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98035,7 +99540,8 @@
     "question_text": {
       "en": "Which Agile term refers to one timeboxed cycle of work?",
       "ja": "アジャイルで時間枠を区切った1サイクルの作業を指すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98075,7 +99581,8 @@
     "question_text": {
       "en": "Which project term marks a significant scheduled checkpoint?",
       "ja": "プロジェクトの重要な節目を示す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98115,7 +99622,8 @@
     "question_text": {
       "en": "Which event makes a new version of software available to users?",
       "ja": "ソフトウェアの新版を利用者へ提供することを指すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98123,7 +99631,6 @@
         "en": "Product Owner",
         "ja": "プロダクトオーナー",
         "ja_typings": [
-          "purodakuto-na-",
           "purodakutoo-na-"
         ]
       },
@@ -98156,7 +99663,8 @@
     "question_text": {
       "en": "Which Scrum role owns the product backlog and prioritization?",
       "ja": "プロダクトバックログと優先順位を所有する Scrum の役割は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98171,7 +99679,6 @@
         "en": "Product Owner",
         "ja": "プロダクトオーナー",
         "ja_typings": [
-          "purodakuto-na-",
           "purodakutoo-na-"
         ]
       },
@@ -98197,7 +99704,8 @@
     "question_text": {
       "en": "Which engineering role leads technical decisions in a team?",
       "ja": "チームの技術的意思決定を主導するエンジニアの役職は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98212,7 +99720,6 @@
         "en": "Product Owner",
         "ja": "プロダクトオーナー",
         "ja_typings": [
-          "purodakuto-na-",
           "purodakutoo-na-"
         ]
       },
@@ -98238,7 +99745,8 @@
     "question_text": {
       "en": "Which role manages scope, schedule, and budget of a project?",
       "ja": "プロジェクトの範囲・予定・予算を管理する役割は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98246,7 +99754,6 @@
         "en": "MIT",
         "ja": "MITライセンス",
         "ja_typings": [
-          "emuaiti-raisensu",
           "mitraisensu"
         ]
       },
@@ -98254,7 +99761,6 @@
         "en": "BSD",
         "ja": "BSDライセンス",
         "ja_typings": [
-          "bi-esudi-raisensu",
           "bsdraisensu"
         ]
       },
@@ -98262,7 +99768,6 @@
         "en": "Apache",
         "ja": "Apacheライセンス",
         "ja_typings": [
-          "apatchiraisensu",
           "apacheraisensu"
         ]
       },
@@ -98270,7 +99775,6 @@
         "en": "GPL",
         "ja": "GPL",
         "ja_typings": [
-          "ji-pi-eru",
           "gpl"
         ]
       }
@@ -98282,7 +99786,8 @@
     "question_text": {
       "en": "Which permissive open source license is associated with the X Window System?",
       "ja": "X Window System に由来する寛容なオープンソースライセンスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98290,7 +99795,6 @@
         "en": "BSD",
         "ja": "BSDライセンス",
         "ja_typings": [
-          "bi-esudi-raisensu",
           "bsdraisensu"
         ]
       },
@@ -98298,7 +99802,6 @@
         "en": "MIT",
         "ja": "MITライセンス",
         "ja_typings": [
-          "emuaiti-raisensu",
           "mitraisensu"
         ]
       },
@@ -98306,7 +99809,6 @@
         "en": "Apache",
         "ja": "Apacheライセンス",
         "ja_typings": [
-          "apatchiraisensu",
           "apacheraisensu"
         ]
       },
@@ -98314,7 +99816,6 @@
         "en": "MPL",
         "ja": "MPL",
         "ja_typings": [
-          "emupi-eru",
           "mpl"
         ]
       }
@@ -98326,7 +99827,8 @@
     "question_text": {
       "en": "Which open source license originated with the Berkeley Unix distribution?",
       "ja": "Berkeley Unix 由来のオープンソースライセンスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98334,7 +99836,6 @@
         "en": "Apache",
         "ja": "Apacheライセンス",
         "ja_typings": [
-          "apatchiraisensu",
           "apacheraisensu"
         ]
       },
@@ -98342,7 +99843,6 @@
         "en": "MIT",
         "ja": "MITライセンス",
         "ja_typings": [
-          "emuaiti-raisensu",
           "mitraisensu"
         ]
       },
@@ -98350,7 +99850,6 @@
         "en": "BSD",
         "ja": "BSDライセンス",
         "ja_typings": [
-          "bi-esudi-raisensu",
           "bsdraisensu"
         ]
       },
@@ -98358,7 +99857,6 @@
         "en": "GPL",
         "ja": "GPL",
         "ja_typings": [
-          "ji-pi-eru",
           "gpl"
         ]
       }
@@ -98370,7 +99868,8 @@
     "question_text": {
       "en": "Which open source license version 2.0 has an explicit patent grant?",
       "ja": "明示的な特許許諾条項を含むオープンソースライセンス2.0は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98378,7 +99877,6 @@
         "en": "AWS",
         "ja": "AWS",
         "ja_typings": [
-          "e-daburyu-esu",
           "aws"
         ]
       },
@@ -98386,7 +99884,6 @@
         "en": "GCP",
         "ja": "GCP",
         "ja_typings": [
-          "ji-shi-pi-",
           "gcp"
         ]
       },
@@ -98401,7 +99898,6 @@
         "en": "OCI",
         "ja": "OCI",
         "ja_typings": [
-          "o-shi-ai",
           "oci"
         ]
       }
@@ -98413,7 +99909,8 @@
     "question_text": {
       "en": "Which is the largest public cloud provider, run by Amazon?",
       "ja": "Amazon が運営する最大手のパブリッククラウドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98421,7 +99918,6 @@
         "en": "GCP",
         "ja": "GCP",
         "ja_typings": [
-          "ji-shi-pi-",
           "gcp"
         ]
       },
@@ -98429,7 +99925,6 @@
         "en": "AWS",
         "ja": "AWS",
         "ja_typings": [
-          "e-daburyu-esu",
           "aws"
         ]
       },
@@ -98444,7 +99939,6 @@
         "en": "OCI",
         "ja": "OCI",
         "ja_typings": [
-          "o-shi-ai",
           "oci"
         ]
       }
@@ -98456,7 +99950,8 @@
     "question_text": {
       "en": "Which Google public cloud platform competes with AWS and Azure?",
       "ja": "AWS や Azure と競合する Google のパブリッククラウドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98496,7 +99991,8 @@
     "question_text": {
       "en": "Which processing mode runs a job collectively at scheduled times?",
       "ja": "決まった時刻にまとめて処理する方式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98504,7 +100000,6 @@
         "en": "NDA",
         "ja": "NDA",
         "ja_typings": [
-          "enudi-e-",
           "nda"
         ]
       },
@@ -98512,7 +100007,6 @@
         "en": "MOU",
         "ja": "MOU",
         "ja_typings": [
-          "emuo-yu-",
           "mou"
         ]
       },
@@ -98520,7 +100014,6 @@
         "en": "EULA",
         "ja": "EULA",
         "ja_typings": [
-          "yu-ra",
           "eula"
         ]
       },
@@ -98528,7 +100021,6 @@
         "en": "SLA",
         "ja": "SLA",
         "ja_typings": [
-          "esuerue-",
           "sla"
         ]
       }
@@ -98540,7 +100032,8 @@
     "question_text": {
       "en": "Which legal agreement prevents disclosure of confidential info?",
       "ja": "機密情報の開示を禁じる契約は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98548,7 +100041,6 @@
         "en": "MOU",
         "ja": "MOU",
         "ja_typings": [
-          "emuo-yu-",
           "mou"
         ]
       },
@@ -98556,7 +100048,6 @@
         "en": "NDA",
         "ja": "NDA",
         "ja_typings": [
-          "enudi-e-",
           "nda"
         ]
       },
@@ -98564,7 +100055,6 @@
         "en": "EULA",
         "ja": "EULA",
         "ja_typings": [
-          "yu-ra",
           "eula"
         ]
       },
@@ -98572,7 +100062,6 @@
         "en": "SLA",
         "ja": "SLA",
         "ja_typings": [
-          "esuerue-",
           "sla"
         ]
       }
@@ -98584,7 +100073,8 @@
     "question_text": {
       "en": "Which non-binding agreement outlines mutual intent between parties?",
       "ja": "当事者間の意思を確認するための法的拘束力のない覚書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98592,7 +100082,6 @@
         "en": "EULA",
         "ja": "EULA",
         "ja_typings": [
-          "yu-ra",
           "eula"
         ]
       },
@@ -98600,7 +100089,6 @@
         "en": "MOU",
         "ja": "MOU",
         "ja_typings": [
-          "emuo-yu-",
           "mou"
         ]
       },
@@ -98608,7 +100096,6 @@
         "en": "NDA",
         "ja": "NDA",
         "ja_typings": [
-          "enudi-e-",
           "nda"
         ]
       },
@@ -98616,7 +100103,6 @@
         "en": "SLA",
         "ja": "SLA",
         "ja_typings": [
-          "esuerue-",
           "sla"
         ]
       }
@@ -98628,7 +100114,8 @@
     "question_text": {
       "en": "Which contract is presented to end users for software use?",
       "ja": "ソフトウェア使用にあたりエンドユーザーに提示される契約は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98668,7 +100155,8 @@
     "question_text": {
       "en": "Which culture unites development and operations teams?",
       "ja": "開発と運用を統合する文化・運動は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98676,7 +100164,6 @@
         "en": "CaC",
         "ja": "CaC",
         "ja_typings": [
-          "shi-e-shi-",
           "cac"
         ]
       },
@@ -98684,7 +100171,6 @@
         "en": "PaC",
         "ja": "PaC",
         "ja_typings": [
-          "pi-e-shi-",
           "pac"
         ]
       },
@@ -98692,7 +100178,6 @@
         "en": "DaC",
         "ja": "DaC",
         "ja_typings": [
-          "di-e-shi-",
           "dac"
         ]
       },
@@ -98700,7 +100185,6 @@
         "en": "IaC",
         "ja": "IaC",
         "ja_typings": [
-          "aia-shi-",
           "iac"
         ]
       }
@@ -98712,7 +100196,8 @@
     "question_text": {
       "en": "Which practice manages configurations declaratively as code?",
       "ja": "構成情報をコードとして宣言的に管理する手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98720,7 +100205,6 @@
         "en": "PaC",
         "ja": "PaC",
         "ja_typings": [
-          "pi-e-shi-",
           "pac"
         ]
       },
@@ -98728,7 +100212,6 @@
         "en": "CaC",
         "ja": "CaC",
         "ja_typings": [
-          "shi-e-shi-",
           "cac"
         ]
       },
@@ -98736,7 +100219,6 @@
         "en": "DaC",
         "ja": "DaC",
         "ja_typings": [
-          "di-e-shi-",
           "dac"
         ]
       },
@@ -98744,7 +100226,6 @@
         "en": "IaC",
         "ja": "IaC",
         "ja_typings": [
-          "aia-shi-",
           "iac"
         ]
       }
@@ -98756,7 +100237,8 @@
     "question_text": {
       "en": "Which practice expresses security policies as code (e.g., OPA)?",
       "ja": "OPA 等でポリシーをコードとして書く手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98764,7 +100246,6 @@
         "en": "DaC",
         "ja": "DaC",
         "ja_typings": [
-          "di-e-shi-",
           "dac"
         ]
       },
@@ -98772,7 +100253,6 @@
         "en": "CaC",
         "ja": "CaC",
         "ja_typings": [
-          "shi-e-shi-",
           "cac"
         ]
       },
@@ -98780,7 +100260,6 @@
         "en": "PaC",
         "ja": "PaC",
         "ja_typings": [
-          "pi-e-shi-",
           "pac"
         ]
       },
@@ -98788,7 +100267,6 @@
         "en": "IaC",
         "ja": "IaC",
         "ja_typings": [
-          "aia-shi-",
           "iac"
         ]
       }
@@ -98800,7 +100278,8 @@
     "question_text": {
       "en": "Which practice manages documentation as code in repositories?",
       "ja": "ドキュメントをコードのようにリポジトリ管理する手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98840,7 +100319,8 @@
     "question_text": {
       "en": "Which DB object executes a procedure when a table changes?",
       "ja": "テーブル変更時に処理を実行する DB オブジェクトは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98880,7 +100360,8 @@
     "question_text": {
       "en": "Which DB object is a virtual table from a stored query?",
       "ja": "クエリから生成される仮想表である DB オブジェクトは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98920,7 +100401,8 @@
     "question_text": {
       "en": "Which DB term names the overall structure of tables and relations?",
       "ja": "テーブルと関係の全体構造を示す DB 用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98928,7 +100410,6 @@
         "en": "NewSQL",
         "ja": "NewSQL",
         "ja_typings": [
-          "nyu-esukyu-eru",
           "newsql"
         ]
       },
@@ -98936,7 +100417,6 @@
         "en": "NoSQL",
         "ja": "NoSQL",
         "ja_typings": [
-          "no-esukyu-eru",
           "nosql"
         ]
       },
@@ -98944,7 +100424,6 @@
         "en": "OLAP",
         "ja": "OLAP",
         "ja_typings": [
-          "o-rappu",
           "olap"
         ]
       },
@@ -98952,7 +100431,6 @@
         "en": "OLTP",
         "ja": "OLTP",
         "ja_typings": [
-          "o-rutipi-",
           "oltp"
         ]
       }
@@ -98964,7 +100442,8 @@
     "question_text": {
       "en": "Which class of databases combines SQL with horizontal scalability?",
       "ja": "SQL と水平スケールを両立させる新世代 DB は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98972,7 +100451,6 @@
         "en": "OLAP",
         "ja": "OLAP",
         "ja_typings": [
-          "o-rappu",
           "olap"
         ]
       },
@@ -98980,7 +100458,6 @@
         "en": "OLTP",
         "ja": "OLTP",
         "ja_typings": [
-          "o-rutipi-",
           "oltp"
         ]
       },
@@ -98988,7 +100465,6 @@
         "en": "NewSQL",
         "ja": "NewSQL",
         "ja_typings": [
-          "nyu-esukyu-eru",
           "newsql"
         ]
       },
@@ -98996,7 +100472,6 @@
         "en": "NoSQL",
         "ja": "NoSQL",
         "ja_typings": [
-          "no-esukyu-eru",
           "nosql"
         ]
       }
@@ -99008,7 +100483,8 @@
     "question_text": {
       "en": "Which workload type emphasizes analytical multi-dimensional queries?",
       "ja": "多次元分析クエリ向けのワークロード種別は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99016,7 +100492,6 @@
         "en": "OLTP",
         "ja": "OLTP",
         "ja_typings": [
-          "o-rutipi-",
           "oltp"
         ]
       },
@@ -99024,7 +100499,6 @@
         "en": "OLAP",
         "ja": "OLAP",
         "ja_typings": [
-          "o-rappu",
           "olap"
         ]
       },
@@ -99032,7 +100506,6 @@
         "en": "NewSQL",
         "ja": "NewSQL",
         "ja_typings": [
-          "nyu-esukyu-eru",
           "newsql"
         ]
       },
@@ -99040,7 +100513,6 @@
         "en": "NoSQL",
         "ja": "NoSQL",
         "ja_typings": [
-          "no-esukyu-eru",
           "nosql"
         ]
       }
@@ -99052,7 +100524,8 @@
     "question_text": {
       "en": "Which workload type handles many short, transactional operations?",
       "ja": "短時間のトランザクション処理を多数こなすワークロードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99060,7 +100533,6 @@
         "en": "HIPAA",
         "ja": "HIPAA",
         "ja_typings": [
-          "hipa-",
           "hipaa"
         ]
       },
@@ -99068,7 +100540,6 @@
         "en": "CCPA",
         "ja": "CCPA",
         "ja_typings": [
-          "shi-shi-pi-e-",
           "ccpa"
         ]
       },
@@ -99076,7 +100547,6 @@
         "en": "SOX",
         "ja": "SOX",
         "ja_typings": [
-          "sokkusu",
           "sox"
         ]
       },
@@ -99084,7 +100554,6 @@
         "en": "GDPR",
         "ja": "GDPR",
         "ja_typings": [
-          "ji-di-pi-a-ru",
           "gdpr"
         ]
       }
@@ -99096,7 +100565,8 @@
     "question_text": {
       "en": "Which US law protects health information privacy?",
       "ja": "アメリカで医療情報のプライバシーを守る法律は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99104,7 +100574,6 @@
         "en": "CCPA",
         "ja": "CCPA",
         "ja_typings": [
-          "shi-shi-pi-e-",
           "ccpa"
         ]
       },
@@ -99112,7 +100581,6 @@
         "en": "HIPAA",
         "ja": "HIPAA",
         "ja_typings": [
-          "hipa-",
           "hipaa"
         ]
       },
@@ -99120,7 +100588,6 @@
         "en": "SOX",
         "ja": "SOX",
         "ja_typings": [
-          "sokkusu",
           "sox"
         ]
       },
@@ -99128,7 +100595,6 @@
         "en": "GDPR",
         "ja": "GDPR",
         "ja_typings": [
-          "ji-di-pi-a-ru",
           "gdpr"
         ]
       }
@@ -99140,7 +100606,8 @@
     "question_text": {
       "en": "Which California law protects consumer data rights?",
       "ja": "カリフォルニア州の消費者データ保護法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99148,7 +100615,6 @@
         "en": "SOX",
         "ja": "SOX",
         "ja_typings": [
-          "sokkusu",
           "sox"
         ]
       },
@@ -99156,7 +100622,6 @@
         "en": "HIPAA",
         "ja": "HIPAA",
         "ja_typings": [
-          "hipa-",
           "hipaa"
         ]
       },
@@ -99164,7 +100629,6 @@
         "en": "CCPA",
         "ja": "CCPA",
         "ja_typings": [
-          "shi-shi-pi-e-",
           "ccpa"
         ]
       },
@@ -99172,7 +100636,6 @@
         "en": "GDPR",
         "ja": "GDPR",
         "ja_typings": [
-          "ji-di-pi-a-ru",
           "gdpr"
         ]
       }
@@ -99184,7 +100647,8 @@
     "question_text": {
       "en": "Which US law tightens corporate financial reporting after Enron?",
       "ja": "エンロン事件後に施行されたアメリカの企業会計改革法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99192,7 +100656,6 @@
         "en": "FTP",
         "ja": "FTP",
         "ja_typings": [
-          "efuti-pi-",
           "ftp"
         ]
       },
@@ -99200,7 +100663,6 @@
         "en": "SFTP",
         "ja": "SFTP",
         "ja_typings": [
-          "esuefuti-pi-",
           "sftp"
         ]
       },
@@ -99208,7 +100670,6 @@
         "en": "FTPS",
         "ja": "FTPS",
         "ja_typings": [
-          "efuti-pi-esu",
           "ftps"
         ]
       },
@@ -99216,7 +100677,6 @@
         "en": "TFTP",
         "ja": "TFTP",
         "ja_typings": [
-          "thi-efuthi-pi-",
           "tftp"
         ]
       }
@@ -99228,7 +100688,8 @@
     "question_text": {
       "en": "Which file transfer protocol uses plain text and ports 20/21?",
       "ja": "ポート20/21を使う平文ファイル転送プロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99236,7 +100697,6 @@
         "en": "16 bits",
         "ja": "16ビット",
         "ja_typings": [
-          "ju-rokubitto",
           "16bitto"
         ]
       },
@@ -99244,7 +100704,6 @@
         "en": "8 bits",
         "ja": "8ビット",
         "ja_typings": [
-          "hachibitto",
           "8bitto"
         ]
       },
@@ -99252,7 +100711,6 @@
         "en": "32 bits",
         "ja": "32ビット",
         "ja_typings": [
-          "sanju-nibitto",
           "32bitto"
         ]
       },
@@ -99260,7 +100718,6 @@
         "en": "64 bits",
         "ja": "64ビット",
         "ja_typings": [
-          "rokuju-yonbitto",
           "64bitto"
         ]
       }
@@ -99272,7 +100729,8 @@
     "question_text": {
       "en": "Which CPU register width was standard for Intel 8086?",
       "ja": "Intel 8086 の標準的なレジスタ幅は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99280,7 +100738,6 @@
         "en": "64 bits",
         "ja": "64ビット",
         "ja_typings": [
-          "rokuju-yonbitto",
           "64bitto"
         ]
       },
@@ -99288,7 +100745,6 @@
         "en": "32 bits",
         "ja": "32ビット",
         "ja_typings": [
-          "sanju-nibitto",
           "32bitto"
         ]
       },
@@ -99296,7 +100752,6 @@
         "en": "16 bits",
         "ja": "16ビット",
         "ja_typings": [
-          "ju-rokubitto",
           "16bitto"
         ]
       },
@@ -99304,7 +100759,6 @@
         "en": "128 bits",
         "ja": "128ビット",
         "ja_typings": [
-          "hyakunijuhachibitto",
           "128bitto"
         ]
       }
@@ -99316,7 +100770,8 @@
     "question_text": {
       "en": "Which CPU register width is standard for modern x86_64 / ARM64?",
       "ja": "現代の x86_64 や ARM64 で標準のレジスタ幅は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99324,7 +100779,6 @@
         "en": "MD5",
         "ja": "MD5",
         "ja_typings": [
-          "emudi-go",
           "md5"
         ]
       },
@@ -99332,7 +100786,6 @@
         "en": "SHA-1",
         "ja": "SHA-1",
         "ja_typings": [
-          "esuetchie-ichi",
           "sha-1"
         ]
       },
@@ -99340,7 +100793,6 @@
         "en": "SHA-256",
         "ja": "SHA-256",
         "ja_typings": [
-          "esuetchie-nigorokuju-roku",
           "sha-256"
         ]
       },
@@ -99348,7 +100800,6 @@
         "en": "CRC32",
         "ja": "CRC32",
         "ja_typings": [
-          "shi-a-ru-shi-sanjuni",
           "crc32"
         ]
       }
@@ -99360,7 +100811,8 @@
     "question_text": {
       "en": "Which 128-bit hash function is now considered broken?",
       "ja": "現在では衝突攻撃に弱い128ビットのハッシュ関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99368,7 +100820,6 @@
         "en": "POP3",
         "ja": "POP3",
         "ja_typings": [
-          "popputsuri-",
           "pop3"
         ]
       },
@@ -99376,7 +100827,6 @@
         "en": "IMAP",
         "ja": "IMAP",
         "ja_typings": [
-          "aimappu",
           "imap"
         ]
       },
@@ -99384,7 +100834,6 @@
         "en": "SMTP",
         "ja": "SMTP",
         "ja_typings": [
-          "esuemuti-pi-",
           "smtp"
         ]
       },
@@ -99403,7 +100852,8 @@
     "question_text": {
       "en": "Which protocol retrieves email by downloading from server (legacy)?",
       "ja": "メールをダウンロードして取得する旧来の受信プロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99418,7 +100868,6 @@
         "en": "SCSI",
         "ja": "SCSI",
         "ja_typings": [
-          "sukajii",
           "scsi"
         ]
       },
@@ -99433,7 +100882,6 @@
         "en": "eSATA",
         "ja": "eSATA",
         "ja_typings": [
-          "i-sata",
           "esata"
         ]
       }
@@ -99445,7 +100893,8 @@
     "question_text": {
       "en": "Which serial interface connects hard drives in PCs?",
       "ja": "PC で HDD を接続する内蔵シリアルインタフェースは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99453,7 +100902,6 @@
         "en": "22",
         "ja": "ポート22",
         "ja_typings": [
-          "po-toniju-ni",
           "po-to22"
         ]
       },
@@ -99461,7 +100909,6 @@
         "en": "21",
         "ja": "ポート21",
         "ja_typings": [
-          "po-tonijuichi",
           "po-to21"
         ]
       },
@@ -99469,7 +100916,6 @@
         "en": "23",
         "ja": "ポート23",
         "ja_typings": [
-          "po-toniju-san",
           "po-to23"
         ]
       },
@@ -99477,7 +100923,6 @@
         "en": "25",
         "ja": "ポート25",
         "ja_typings": [
-          "po-tonijugo",
           "po-to25"
         ]
       }
@@ -99489,7 +100934,8 @@
     "question_text": {
       "en": "Which TCP port does SSH use by default?",
       "ja": "SSH が既定で使う TCP ポートは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99497,7 +100943,6 @@
         "en": "ROM",
         "ja": "ROM",
         "ja_typings": [
-          "romu",
           "rom"
         ]
       },
@@ -99505,7 +100950,6 @@
         "en": "RAM",
         "ja": "RAM",
         "ja_typings": [
-          "ramu",
           "ram"
         ]
       },
@@ -99531,7 +100975,8 @@
     "question_text": {
       "en": "Which memory type can only be read, not modified at runtime?",
       "ja": "実行時に書き換えできず読み出し専用のメモリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99571,7 +101016,8 @@
     "question_text": {
       "en": "Which OS component provides a command-line interface?",
       "ja": "コマンドライン操作を提供する OS の構成要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99579,7 +101025,6 @@
         "en": "VPN",
         "ja": "VPN",
         "ja_typings": [
-          "bui-pi-enu",
           "vpn"
         ]
       },
@@ -99587,7 +101032,6 @@
         "en": "DNS",
         "ja": "DNS",
         "ja_typings": [
-          "di-enu-esu",
           "dns"
         ]
       },
@@ -99595,7 +101039,6 @@
         "en": "VLAN",
         "ja": "VLAN",
         "ja_typings": [
-          "buiran",
           "vlan"
         ]
       },
@@ -99603,7 +101046,6 @@
         "en": "NAT",
         "ja": "NAT",
         "ja_typings": [
-          "natto",
           "nat"
         ]
       }
@@ -99615,7 +101057,8 @@
     "question_text": {
       "en": "Which technology creates an encrypted tunnel over a public network?",
       "ja": "公衆網上に暗号化トンネルを作る技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99623,7 +101066,6 @@
         "en": "SNMP",
         "ja": "SNMP",
         "ja_typings": [
-          "esuenuemupi-",
           "snmp"
         ]
       },
@@ -99631,7 +101073,6 @@
         "en": "SMTP",
         "ja": "SMTP",
         "ja_typings": [
-          "esuemuti-pi-",
           "smtp"
         ]
       },
@@ -99639,7 +101080,6 @@
         "en": "ICMP",
         "ja": "ICMP",
         "ja_typings": [
-          "aishi-emupi-",
           "icmp"
         ]
       },
@@ -99647,7 +101087,6 @@
         "en": "NTP",
         "ja": "NTP",
         "ja_typings": [
-          "enuti-pi-",
           "ntp"
         ]
       }
@@ -99659,7 +101098,8 @@
     "question_text": {
       "en": "Which protocol monitors and manages network devices?",
       "ja": "ネットワーク機器の監視・管理に使うプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99667,7 +101107,6 @@
         "en": "ECC",
         "ja": "ECCメモリ",
         "ja_typings": [
-          "i-shi-shi-memori",
           "eccmemori"
         ]
       },
@@ -99675,7 +101114,6 @@
         "en": "DDR",
         "ja": "DDRメモリ",
         "ja_typings": [
-          "di-di-a-rumemori",
           "ddrmemori"
         ]
       },
@@ -99683,7 +101121,6 @@
         "en": "SRAM",
         "ja": "SRAM",
         "ja_typings": [
-          "esuramu",
           "sram"
         ]
       },
@@ -99691,7 +101128,6 @@
         "en": "Flash",
         "ja": "Flashメモリ",
         "ja_typings": [
-          "furasshumemori",
           "flashmemori"
         ]
       }
@@ -99703,7 +101139,8 @@
     "question_text": {
       "en": "Which memory technology detects and corrects single-bit errors?",
       "ja": "1ビット誤りを検出・訂正できるメモリ技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99711,7 +101148,6 @@
         "en": "ZFS",
         "ja": "ZFS",
         "ja_typings": [
-          "zetto-efu-esu",
           "zfs"
         ]
       },
@@ -99719,7 +101155,6 @@
         "en": "Btrfs",
         "ja": "Btrfs",
         "ja_typings": [
-          "bata-efu-esu",
           "btrfs"
         ]
       },
@@ -99727,7 +101162,6 @@
         "en": "XFS",
         "ja": "XFS",
         "ja_typings": [
-          "ekkusu-efu-esu",
           "xfs"
         ]
       },
@@ -99735,7 +101169,6 @@
         "en": "ext4",
         "ja": "ext4",
         "ja_typings": [
-          "ikusutoyon",
           "ext4"
         ]
       }
@@ -99747,7 +101180,8 @@
     "question_text": {
       "en": "Which Sun-originated filesystem features copy-on-write and snapshots?",
       "ja": "Sun 発のコピーオンライトとスナップショットを持つファイルシステムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99755,7 +101189,6 @@
         "en": "exFAT",
         "ja": "exFAT",
         "ja_typings": [
-          "ekkusufatto",
           "exfat"
         ]
       },
@@ -99763,7 +101196,6 @@
         "en": "FAT32",
         "ja": "FAT32",
         "ja_typings": [
-          "fattosanjuni",
           "fat32"
         ]
       },
@@ -99771,7 +101203,6 @@
         "en": "NTFS",
         "ja": "NTFS",
         "ja_typings": [
-          "enuti-efu-esu",
           "ntfs"
         ]
       },
@@ -99779,7 +101210,6 @@
         "en": "ext4",
         "ja": "ext4",
         "ja_typings": [
-          "ikusutoyon",
           "ext4"
         ]
       }
@@ -99791,7 +101221,8 @@
     "question_text": {
       "en": "Which filesystem extends FAT for large flash drives beyond 32GB?",
       "ja": "32GB を超える大型フラッシュ向けに FAT を拡張したファイルシステムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99799,7 +101230,6 @@
         "en": "Intel",
         "ja": "Intel",
         "ja_typings": [
-          "interu",
           "intel"
         ]
       },
@@ -99807,7 +101237,6 @@
         "en": "AMD",
         "ja": "AMD",
         "ja_typings": [
-          "e-emudi-",
           "amd"
         ]
       },
@@ -99815,7 +101244,6 @@
         "en": "VIA",
         "ja": "VIA",
         "ja_typings": [
-          "bia",
           "via"
         ]
       },
@@ -99823,7 +101251,6 @@
         "en": "Cyrix",
         "ja": "Cyrix",
         "ja_typings": [
-          "sairikkusu",
           "cyrix"
         ]
       }
@@ -99835,7 +101262,8 @@
     "question_text": {
       "en": "Which is the largest x86 CPU vendor with brands like Core and Xeon?",
       "ja": "Core や Xeon を擁する最大の x86 CPU メーカーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99843,7 +101271,6 @@
         "en": "x86",
         "ja": "x86",
         "ja_typings": [
-          "ekkusuhachiroku",
           "x86"
         ]
       },
@@ -99851,7 +101278,6 @@
         "en": "ARM",
         "ja": "ARM",
         "ja_typings": [
-          "a-mu",
           "arm"
         ]
       },
@@ -99859,7 +101285,6 @@
         "en": "MIPS",
         "ja": "MIPS",
         "ja_typings": [
-          "mippusu",
           "mips"
         ]
       },
@@ -99867,8 +101292,6 @@
         "en": "RISC-V",
         "ja": "RISC-V",
         "ja_typings": [
-          "risukubu~i",
-          "risukubui-",
           "risc-v"
         ]
       }
@@ -99880,7 +101303,8 @@
     "question_text": {
       "en": "Which CISC instruction set architecture is used by Intel and AMD?",
       "ja": "Intel や AMD が採用する CISC 命令セットアーキテクチャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99888,7 +101312,6 @@
         "en": "MIPS",
         "ja": "MIPS",
         "ja_typings": [
-          "mippusu",
           "mips"
         ]
       },
@@ -99896,7 +101319,6 @@
         "en": "SPARC",
         "ja": "SPARC",
         "ja_typings": [
-          "supa-ku",
           "sparc"
         ]
       },
@@ -99904,7 +101326,6 @@
         "en": "PowerPC",
         "ja": "PowerPC",
         "ja_typings": [
-          "pawa-pi-shi-",
           "powerpc"
         ]
       },
@@ -99912,7 +101333,6 @@
         "en": "Alpha",
         "ja": "Alpha",
         "ja_typings": [
-          "arufa",
           "alpha"
         ]
       }
@@ -99924,7 +101344,8 @@
     "question_text": {
       "en": "Which RISC architecture originated at Stanford in the 1980s?",
       "ja": "1980年代にスタンフォードで生まれた RISC アーキテクチャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99932,7 +101353,6 @@
         "en": "SPARC",
         "ja": "SPARC",
         "ja_typings": [
-          "supa-ku",
           "sparc"
         ]
       },
@@ -99940,7 +101360,6 @@
         "en": "MIPS",
         "ja": "MIPS",
         "ja_typings": [
-          "mippusu",
           "mips"
         ]
       },
@@ -99948,7 +101367,6 @@
         "en": "PowerPC",
         "ja": "PowerPC",
         "ja_typings": [
-          "pawa-pi-shi-",
           "powerpc"
         ]
       },
@@ -99956,7 +101374,6 @@
         "en": "Alpha",
         "ja": "Alpha",
         "ja_typings": [
-          "arufa",
           "alpha"
         ]
       }
@@ -99968,7 +101385,8 @@
     "question_text": {
       "en": "Which RISC architecture was developed by Sun Microsystems?",
       "ja": "Sun Microsystems が開発した RISC アーキテクチャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99976,7 +101394,6 @@
         "en": "VGA",
         "ja": "VGA",
         "ja_typings": [
-          "bui-ji-e-",
           "vga"
         ]
       },
@@ -99984,7 +101401,6 @@
         "en": "XGA",
         "ja": "XGA",
         "ja_typings": [
-          "ekkusuji-e-",
           "xga"
         ]
       },
@@ -99992,7 +101408,6 @@
         "en": "SVGA",
         "ja": "SVGA",
         "ja_typings": [
-          "esubui-ji-e-",
           "svga"
         ]
       },
@@ -100000,7 +101415,6 @@
         "en": "CGA",
         "ja": "CGA",
         "ja_typings": [
-          "shi-ji-e-",
           "cga"
         ]
       }
@@ -100012,7 +101426,8 @@
     "question_text": {
       "en": "Which video display standard introduced 640x480 resolution on PCs?",
       "ja": "PC で 640x480 解像度を一般化したビデオ規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100020,7 +101435,6 @@
         "en": "Wi-Fi",
         "ja": "Wi-Fi",
         "ja_typings": [
-          "waifai",
           "wi-fi"
         ]
       },
@@ -100028,7 +101442,6 @@
         "en": "Bluetooth",
         "ja": "Bluetooth",
         "ja_typings": [
-          "buru-twu-su",
           "bluetooth"
         ]
       },
@@ -100036,7 +101449,6 @@
         "en": "Zigbee",
         "ja": "Zigbee",
         "ja_typings": [
-          "jigubi-",
           "zigbee"
         ]
       },
@@ -100044,7 +101456,6 @@
         "en": "LTE",
         "ja": "LTE",
         "ja_typings": [
-          "eruti-i-",
           "lte"
         ]
       }
@@ -100056,7 +101467,8 @@
     "question_text": {
       "en": "Which wireless standard is based on IEEE 802.11?",
       "ja": "IEEE 802.11 を基にした無線 LAN 規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100064,7 +101476,6 @@
         "en": "IMAP",
         "ja": "IMAP",
         "ja_typings": [
-          "aimappu",
           "imap"
         ]
       },
@@ -100072,7 +101483,6 @@
         "en": "POP3",
         "ja": "POP3",
         "ja_typings": [
-          "popputsuri-",
           "pop3"
         ]
       },
@@ -100080,7 +101490,6 @@
         "en": "SMTP",
         "ja": "SMTP",
         "ja_typings": [
-          "esuemuti-pi-",
           "smtp"
         ]
       },
@@ -100099,7 +101508,8 @@
     "question_text": {
       "en": "Which mail protocol synchronizes messages across multiple devices?",
       "ja": "複数端末でメッセージを同期するメール受信プロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100107,7 +101517,6 @@
         "en": "SCSI",
         "ja": "SCSI",
         "ja_typings": [
-          "sukajii",
           "scsi"
         ]
       },
@@ -100129,7 +101538,6 @@
         "en": "PCIe",
         "ja": "PCIe",
         "ja_typings": [
-          "pi-shi-ai-i-",
           "pcie"
         ]
       }
@@ -100141,7 +101549,8 @@
     "question_text": {
       "en": "Which parallel interface historically connected enterprise disks and scanners?",
       "ja": "業務用ディスクやスキャナを接続したパラレルインタフェースは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100149,7 +101558,6 @@
         "en": "port 21",
         "ja": "ポート21",
         "ja_typings": [
-          "po-tonijuichi",
           "po-to21"
         ]
       },
@@ -100157,7 +101565,6 @@
         "en": "port 22",
         "ja": "ポート22",
         "ja_typings": [
-          "po-toniju-ni",
           "po-to22"
         ]
       },
@@ -100165,7 +101572,6 @@
         "en": "port 23",
         "ja": "ポート23",
         "ja_typings": [
-          "po-toniju-san",
           "po-to23"
         ]
       },
@@ -100173,7 +101579,6 @@
         "en": "port 25",
         "ja": "ポート25",
         "ja_typings": [
-          "po-tonijugo",
           "po-to25"
         ]
       }
@@ -100185,7 +101590,8 @@
     "question_text": {
       "en": "Which TCP port is used for the FTP control connection?",
       "ja": "FTP の制御コネクションに使われる TCP ポートは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100193,7 +101599,6 @@
         "en": "23",
         "ja": "ポート23",
         "ja_typings": [
-          "po-toniju-san",
           "po-to23"
         ]
       },
@@ -100201,7 +101606,6 @@
         "en": "22",
         "ja": "ポート22",
         "ja_typings": [
-          "po-toniju-ni",
           "po-to22"
         ]
       },
@@ -100209,7 +101613,6 @@
         "en": "21",
         "ja": "ポート21",
         "ja_typings": [
-          "po-tonijuichi",
           "po-to21"
         ]
       },
@@ -100217,7 +101620,6 @@
         "en": "25",
         "ja": "ポート25",
         "ja_typings": [
-          "po-tonijugo",
           "po-to25"
         ]
       }
@@ -100229,7 +101631,8 @@
     "question_text": {
       "en": "Which TCP port does Telnet use by default?",
       "ja": "Telnet が既定で使う TCP ポートは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100244,7 +101647,6 @@
         "en": "HTTP",
         "ja": "HTTP",
         "ja_typings": [
-          "etchi-thi-thi-pi-",
           "http"
         ]
       },
@@ -100252,7 +101654,6 @@
         "en": "gRPC",
         "ja": "gRPC",
         "ja_typings": [
-          "ji-a-ru-pi-shi-",
           "grpc"
         ]
       },
@@ -100260,7 +101661,6 @@
         "en": "MQTT",
         "ja": "MQTT",
         "ja_typings": [
-          "emukyu-thi-thi-",
           "mqtt"
         ]
       }
@@ -100272,7 +101672,8 @@
     "question_text": {
       "en": "Which protocol enables full-duplex communication over a single TCP connection?",
       "ja": "単一の TCP 接続で全二重通信を行うプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100280,7 +101681,6 @@
         "en": "TPU",
         "ja": "TPU",
         "ja_typings": [
-          "thi-pi-yu-",
           "tpu"
         ]
       },
@@ -100288,7 +101688,6 @@
         "en": "GPU",
         "ja": "GPU",
         "ja_typings": [
-          "ji-pi-yu-",
           "gpu"
         ]
       },
@@ -100296,7 +101695,6 @@
         "en": "CPU",
         "ja": "CPU",
         "ja_typings": [
-          "shi-pi-yu-",
           "cpu"
         ]
       },
@@ -100304,7 +101702,6 @@
         "en": "FPGA",
         "ja": "FPGA",
         "ja_typings": [
-          "efupi-ji-e-",
           "fpga"
         ]
       }
@@ -100316,7 +101713,8 @@
     "question_text": {
       "en": "Which Google chip accelerates tensor computations for ML?",
       "ja": "Google が機械学習用に開発したテンソル演算アクセラレータは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100324,7 +101722,6 @@
         "en": "DSP",
         "ja": "DSP",
         "ja_typings": [
-          "di-esu-pi-",
           "dsp"
         ]
       },
@@ -100332,7 +101729,6 @@
         "en": "GPU",
         "ja": "GPU",
         "ja_typings": [
-          "ji-pi-yu-",
           "gpu"
         ]
       },
@@ -100340,7 +101736,6 @@
         "en": "CPU",
         "ja": "CPU",
         "ja_typings": [
-          "shi-pi-yu-",
           "cpu"
         ]
       },
@@ -100348,7 +101743,6 @@
         "en": "MCU",
         "ja": "MCU",
         "ja_typings": [
-          "emu-shi-yu-",
           "mcu"
         ]
       }
@@ -100360,7 +101754,8 @@
     "question_text": {
       "en": "Which specialized processor handles signal processing tasks?",
       "ja": "信号処理に特化した専用プロセッサは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100368,7 +101763,6 @@
         "en": "USB flash drive",
         "ja": "USBメモリ",
         "ja_typings": [
-          "yu-esubi-memori",
           "usbmemori"
         ]
       },
@@ -100383,7 +101777,6 @@
         "en": "FDD",
         "ja": "FDD",
         "ja_typings": [
-          "efu-di-di-",
           "fdd"
         ]
       },
@@ -100391,7 +101784,6 @@
         "en": "MO",
         "ja": "MO",
         "ja_typings": [
-          "emu-o-",
           "mo"
         ]
       }
@@ -100403,7 +101795,8 @@
     "question_text": {
       "en": "Which portable storage device uses NAND flash and USB?",
       "ja": "NAND フラッシュと USB を使う携帯型ストレージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100418,7 +101811,6 @@
         "en": "USB flash drive",
         "ja": "USBメモリ",
         "ja_typings": [
-          "yu-esubi-memori",
           "usbmemori"
         ]
       },
@@ -100426,7 +101818,6 @@
         "en": "FDD",
         "ja": "FDD",
         "ja_typings": [
-          "efu-di-di-",
           "fdd"
         ]
       },
@@ -100434,7 +101825,6 @@
         "en": "HDD",
         "ja": "HDD",
         "ja_typings": [
-          "etchi-di-di-",
           "hdd"
         ]
       }
@@ -100446,7 +101836,8 @@
     "question_text": {
       "en": "Which storage uses lasers to read pits (e.g., CD, DVD)?",
       "ja": "レーザーでピットを読み取る光学記憶媒体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100454,7 +101845,6 @@
         "en": "FDD",
         "ja": "FDD",
         "ja_typings": [
-          "efu-di-di-",
           "fdd"
         ]
       },
@@ -100462,7 +101852,6 @@
         "en": "HDD",
         "ja": "HDD",
         "ja_typings": [
-          "etchi-di-di-",
           "hdd"
         ]
       },
@@ -100470,7 +101859,6 @@
         "en": "MO",
         "ja": "MO",
         "ja_typings": [
-          "emu-o-",
           "mo"
         ]
       },
@@ -100478,7 +101866,6 @@
         "en": "ZIP",
         "ja": "ZIP",
         "ja_typings": [
-          "jippu",
           "zip"
         ]
       }
@@ -100490,7 +101877,8 @@
     "question_text": {
       "en": "Which legacy 3.5-inch removable magnetic storage was common in the 90s?",
       "ja": "90年代に普及した3.5インチの磁気フロッピーディスク装置は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100498,7 +101886,6 @@
         "en": "MO",
         "ja": "MO",
         "ja_typings": [
-          "emu-o-",
           "mo"
         ]
       },
@@ -100506,7 +101893,6 @@
         "en": "FDD",
         "ja": "FDD",
         "ja_typings": [
-          "efu-di-di-",
           "fdd"
         ]
       },
@@ -100514,7 +101900,6 @@
         "en": "ZIP",
         "ja": "ZIP",
         "ja_typings": [
-          "jippu",
           "zip"
         ]
       },
@@ -100522,7 +101907,6 @@
         "en": "DAT",
         "ja": "DAT",
         "ja_typings": [
-          "datto",
           "dat"
         ]
       }
@@ -100534,7 +101918,8 @@
     "question_text": {
       "en": "Which magneto-optical removable disc was popular in Japan in the 90s?",
       "ja": "90年代の日本で普及した光磁気ディスクは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100574,7 +101959,8 @@
     "question_text": {
       "en": "Which software lets the OS communicate with hardware devices?",
       "ja": "OS がハードウェアと通信するためのソフトウェアは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100614,7 +102000,8 @@
     "question_text": {
       "en": "Which reusable code collection can be linked into programs?",
       "ja": "プログラムにリンクして再利用するコードの集合は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100654,7 +102041,8 @@
     "question_text": {
       "en": "Which Unix term names a background service process?",
       "ja": "Unix でバックグラウンドサービスを指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100694,7 +102082,8 @@
     "question_text": {
       "en": "Which tool translates source code into machine code?",
       "ja": "ソースコードを機械語に変換するツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100734,7 +102123,8 @@
     "question_text": {
       "en": "Which Git term names a storage location for project history?",
       "ja": "Git でプロジェクト履歴を格納する場所を指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100774,7 +102164,8 @@
     "question_text": {
       "en": "Which tool steps through code to find bugs?",
       "ja": "プログラムを段階実行してバグを見つけるツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100815,7 +102206,8 @@
     "question_text": {
       "en": "Which medium carries data as light pulses through glass strands?",
       "ja": "ガラス繊維を通る光パルスでデータを伝える媒体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100830,7 +102222,6 @@
         "en": "VM",
         "ja": "VM",
         "ja_typings": [
-          "bui-emu",
           "vm"
         ]
       },
@@ -100856,7 +102247,8 @@
     "question_text": {
       "en": "Which OS-level virtualization unit packages an app with its deps?",
       "ja": "アプリと依存関係をまとめる OS レベル仮想化の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100896,7 +102288,8 @@
     "question_text": {
       "en": "Which Ethernet device forwards frames using MAC addresses?",
       "ja": "MAC アドレスでフレームを転送するイーサネット機器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100936,7 +102329,8 @@
     "question_text": {
       "en": "Which legacy device broadcasts all incoming traffic to every port?",
       "ja": "受信した信号を全ポートに送出する旧式の機器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100976,7 +102370,8 @@
     "question_text": {
       "en": "Which device regenerates signals to extend a network's reach?",
       "ja": "信号を増幅・整形してネットワーク到達距離を伸ばす機器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -100984,7 +102379,6 @@
         "en": "256 bits",
         "ja": "256ビット",
         "ja_typings": [
-          "nigorokuju-rokubitto",
           "256bitto"
         ]
       },
@@ -100992,7 +102386,6 @@
         "en": "128 bits",
         "ja": "128ビット",
         "ja_typings": [
-          "hyakunijuhachibitto",
           "128bitto"
         ]
       },
@@ -101000,7 +102393,6 @@
         "en": "192 bits",
         "ja": "192ビット",
         "ja_typings": [
-          "hyakukyuju-nibitto",
           "192bitto"
         ]
       },
@@ -101008,7 +102400,6 @@
         "en": "512 bits",
         "ja": "512ビット",
         "ja_typings": [
-          "gohyakuju-nibitto",
           "512bitto"
         ]
       }
@@ -101020,7 +102411,8 @@
     "question_text": {
       "en": "Which key length is standard for AES-256?",
       "ja": "AES-256 で使われる鍵長は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101044,7 +102436,7 @@
         "en": "Hash function",
         "ja": "ハッシュ関数",
         "ja_typings": [
-          "hasshukansu-"
+          "hasshukansuu"
         ]
       },
       {
@@ -101063,7 +102455,8 @@
     "question_text": {
       "en": "Which class of cryptography uses one shared key for encrypt and decrypt?",
       "ja": "暗号化と復号に同じ鍵を使う暗号方式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101104,7 +102497,8 @@
     "question_text": {
       "en": "Which technique hides messages inside other media (e.g., images)?",
       "ja": "画像などに情報を隠す技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101112,7 +102506,6 @@
         "en": "DES",
         "ja": "DES",
         "ja_typings": [
-          "di-i-esu",
           "des"
         ]
       },
@@ -101120,7 +102513,6 @@
         "en": "AES",
         "ja": "AES",
         "ja_typings": [
-          "e-i-esu",
           "aes"
         ]
       },
@@ -101128,7 +102520,6 @@
         "en": "RSA",
         "ja": "RSA",
         "ja_typings": [
-          "a-ru-esu-e-",
           "rsa"
         ]
       },
@@ -101147,7 +102538,8 @@
     "question_text": {
       "en": "Which now-deprecated symmetric block cipher uses a 56-bit key?",
       "ja": "56ビット鍵を使う旧式の対称ブロック暗号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101155,7 +102547,6 @@
         "en": "SHA",
         "ja": "SHA",
         "ja_typings": [
-          "esuetchie-",
           "sha"
         ]
       },
@@ -101163,7 +102554,6 @@
         "en": "MD5",
         "ja": "MD5",
         "ja_typings": [
-          "emudi-go",
           "md5"
         ]
       },
@@ -101171,7 +102561,6 @@
         "en": "CRC",
         "ja": "CRC",
         "ja_typings": [
-          "shi-a-ru-shi-",
           "crc"
         ]
       },
@@ -101179,7 +102568,6 @@
         "en": "HMAC",
         "ja": "HMAC",
         "ja_typings": [
-          "etchi-makku",
           "hmac"
         ]
       }
@@ -101191,7 +102579,8 @@
     "question_text": {
       "en": "Which family of cryptographic hash functions includes -1, -256, -512?",
       "ja": "-1 や -256 などのバリアントを持つ暗号ハッシュ関数群は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101214,7 +102603,7 @@
         "en": "Hash function",
         "ja": "ハッシュ関数",
         "ja_typings": [
-          "hasshukansu-"
+          "hasshukansuu"
         ]
       },
       {
@@ -101232,7 +102621,8 @@
     "question_text": {
       "en": "Which kind of algorithm reduces data size for storage or transmission?",
       "ja": "保存や伝送のためにデータサイズを小さくするアルゴリズムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101247,7 +102637,7 @@
         "en": "Hash function",
         "ja": "ハッシュ関数",
         "ja_typings": [
-          "hasshukansu-"
+          "hasshukansuu"
         ]
       },
       {
@@ -101273,7 +102663,8 @@
     "question_text": {
       "en": "Which cryptographic technique proves message authenticity using a key pair?",
       "ja": "鍵ペアを用いてメッセージの真正性を証明する技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101289,7 +102680,7 @@
         "en": "Hash function",
         "ja": "ハッシュ関数",
         "ja_typings": [
-          "hasshukansu-"
+          "hasshukansuu"
         ]
       },
       {
@@ -101315,7 +102706,8 @@
     "question_text": {
       "en": "Which component produces sequences for cryptography and simulations?",
       "ja": "暗号やシミュレーションに使う列を生成する装置は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101355,7 +102747,8 @@
     "question_text": {
       "en": "Which Egyptian city on the Mediterranean coast was home to a famous ancient library?",
       "ja": "エジプトの地中海沿岸に位置し、古代に大図書館があった都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101399,7 +102792,8 @@
     "question_text": {
       "en": "Which river in South America has one of the largest drainage basins in the world?",
       "ja": "南米大陸を流れる世界最大級の流域面積を持つ川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101439,7 +102833,8 @@
     "question_text": {
       "en": "Which is the northernmost ocean on Earth?",
       "ja": "地球で最も北に位置する海洋は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101479,7 +102874,8 @@
     "question_text": {
       "en": "Which Hokkaido city is located in the Kamikawa Basin near the center of the island?",
       "ja": "北海道のほぼ中央にあり、上川盆地に位置する都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101519,7 +102915,8 @@
     "question_text": {
       "en": "Which is the largest continent in the world?",
       "ja": "世界で最も広い大陸は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101559,7 +102956,8 @@
     "question_text": {
       "en": "What is the capital of Paraguay?",
       "ja": "パラグアイの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101599,7 +102997,8 @@
     "question_text": {
       "en": "Which ocean lies between Europe and the Americas?",
       "ja": "ヨーロッパとアメリカ大陸の間に広がる海洋は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101639,7 +103038,8 @@
     "question_text": {
       "en": "Which mountain range stretches across North Africa?",
       "ja": "北アフリカを横断する大山脈は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101679,7 +103079,8 @@
     "question_text": {
       "en": "Which Indian city is known as the center of the IT industry?",
       "ja": "インドのIT産業の中心地として知られる都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101719,7 +103120,8 @@
     "question_text": {
       "en": "Which city in northeastern Spain is home to the Sagrada Familia?",
       "ja": "サグラダ・ファミリアがあるスペイン北東部の都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101759,7 +103161,8 @@
     "question_text": {
       "en": "What is the capital of Germany?",
       "ja": "ドイツの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101799,7 +103202,8 @@
     "question_text": {
       "en": "Which Himalayan country is known for its focus on Gross National Happiness?",
       "ja": "ヒマラヤ山脈にある「幸福度」で知られる国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101843,7 +103247,8 @@
     "question_text": {
       "en": "Which is the third largest island in the world, located in Southeast Asia?",
       "ja": "東南アジアにある世界で3番目に大きい島は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101883,7 +103288,8 @@
     "question_text": {
       "en": "Iguazu Falls lies on the border between which two countries?",
       "ja": "イグアスの滝が国境にある国の組み合わせは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101923,7 +103329,8 @@
     "question_text": {
       "en": "What is the capital of Argentina?",
       "ja": "アルゼンチンの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101963,7 +103370,8 @@
     "question_text": {
       "en": "Which northwestern Turkish city was a former capital of the Ottoman Empire?",
       "ja": "トルコ北西部の旧オスマン帝国首都として知られる都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102003,7 +103411,8 @@
     "question_text": {
       "en": "Which is South Korea's second largest city and a major southeastern port?",
       "ja": "韓国第2の都市で南東部の主要港湾都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102043,7 +103452,8 @@
     "question_text": {
       "en": "Which resort city is on Mexico's Yucatan Peninsula?",
       "ja": "メキシコ・ユカタン半島のリゾート都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102083,7 +103493,8 @@
     "question_text": {
       "en": "Baku, the capital of Azerbaijan, is located on which shore?",
       "ja": "アゼルバイジャンのバクーがあるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102098,7 +103509,7 @@
         "en": "Ural Mountains",
         "ja": "ウラル山脈",
         "ja_typings": [
-          "ururusanmyaku"
+          "urarusanmyaku"
         ]
       },
       {
@@ -102123,7 +103534,8 @@
     "question_text": {
       "en": "Which mountain range lies between the Black Sea and the Caspian Sea?",
       "ja": "黒海とカスピ海の間に広がる山脈は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102163,7 +103575,8 @@
     "question_text": {
       "en": "Which U.S. city is located on the shore of Lake Michigan?",
       "ja": "アメリカ五大湖のミシガン湖畔に位置する都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102203,7 +103616,8 @@
     "question_text": {
       "en": "Which ancient Greek city stood at the isthmus of the Peloponnese?",
       "ja": "ペロポネソス半島の付け根にある古代ギリシャの都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102243,7 +103657,8 @@
     "question_text": {
       "en": "Which city is a major port in central Vietnam?",
       "ja": "ベトナム中部の主要港湾都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102283,7 +103698,8 @@
     "question_text": {
       "en": "What is the capital of Ireland?",
       "ja": "アイルランドの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102323,7 +103739,8 @@
     "question_text": {
       "en": "What is the capital of Scotland?",
       "ja": "スコットランドの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102363,7 +103780,8 @@
     "question_text": {
       "en": "Which Tuscan city is known as the birthplace of the Renaissance?",
       "ja": "イタリアのトスカーナ州の州都でルネサンス発祥の地は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102403,7 +103821,8 @@
     "question_text": {
       "en": "Which German city is the country's financial center?",
       "ja": "ドイツの金融の中心地として知られる都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102443,7 +103862,8 @@
     "question_text": {
       "en": "Which Okinawan city is known for hosting many U.S. military bases?",
       "ja": "沖縄本島中部の都市で米軍基地が多いことで知られるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102483,7 +103903,8 @@
     "question_text": {
       "en": "Which Egyptian city is home to the pyramids and the Sphinx?",
       "ja": "ピラミッドとスフィンクスがあるエジプトの都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102525,7 +103946,8 @@
     "question_text": {
       "en": "Which is the world's largest island, an autonomous territory of Denmark?",
       "ja": "世界最大の島でデンマーク自治領なのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102565,7 +103987,8 @@
     "question_text": {
       "en": "Which Mexican city is famous as the home of tequila?",
       "ja": "メキシコ第2の都市でテキーラの産地として有名な都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102605,7 +104028,8 @@
     "question_text": {
       "en": "Which Hokkaido port town is famous for its night view?",
       "ja": "北海道南部にある夜景が有名な港町は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102645,7 +104069,8 @@
     "question_text": {
       "en": "Which city is a major northern German port?",
       "ja": "ドイツ北部の主要港湾都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102685,7 +104110,8 @@
     "question_text": {
       "en": "What is the capital of Vietnam?",
       "ja": "ベトナムの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102725,7 +104151,8 @@
     "question_text": {
       "en": "Which is the largest city in southern Vietnam?",
       "ja": "ベトナム南部最大の都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102765,7 +104192,8 @@
     "question_text": {
       "en": "Which Special Administrative Region of southern China is a major financial hub?",
       "ja": "中国南部にある特別行政区で金融センターとして知られる都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102805,7 +104233,8 @@
     "question_text": {
       "en": "Which central Vietnamese city was the imperial capital under the Nguyen dynasty?",
       "ja": "ベトナム中部の旧王朝の都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102845,7 +104274,8 @@
     "question_text": {
       "en": "Which port city near Seoul hosts South Korea's main international airport?",
       "ja": "韓国の国際空港があるソウル近郊の港湾都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102885,7 +104315,8 @@
     "question_text": {
       "en": "Which is the most populous country in South Asia?",
       "ja": "南アジアで人口最多の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102925,7 +104356,8 @@
     "question_text": {
       "en": "Which ocean lies between Africa and Australia?",
       "ja": "アフリカとオーストラリアの間に広がる海洋は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102966,7 +104398,8 @@
     "question_text": {
       "en": "Which is the main island of the Yaeyama Islands?",
       "ja": "八重山諸島の中心の島は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103010,7 +104443,8 @@
     "question_text": {
       "en": "Which is the longest river in Hokkaido?",
       "ja": "北海道で最長の川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103050,7 +104484,8 @@
     "question_text": {
       "en": "Which is Turkey's third largest city, a port on the Aegean coast?",
       "ja": "トルコ第3の都市でエーゲ海沿岸の港湾都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103090,7 +104525,8 @@
     "question_text": {
       "en": "Which is Saudi Arabia's main city on the Red Sea coast?",
       "ja": "サウジアラビアの紅海沿岸の主要都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103130,7 +104566,8 @@
     "question_text": {
       "en": "Which desert covers much of southern Africa?",
       "ja": "南部アフリカに広がる砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103171,7 +104608,8 @@
     "question_text": {
       "en": "Which bridge spans the Kanmon Strait between Honshu and Kyushu?",
       "ja": "本州と九州を結ぶ関門海峡にかかる橋は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103211,7 +104649,8 @@
     "question_text": {
       "en": "Which large eastern Indian city was formerly called Calcutta?",
       "ja": "インド東部の大都市で旧称カルカッタの都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103251,7 +104690,8 @@
     "question_text": {
       "en": "Which port town in eastern Hokkaido is famous for its fog?",
       "ja": "北海道道東にある霧で有名な港町は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103291,7 +104731,8 @@
     "question_text": {
       "en": "Which lake in Djibouti is the lowest point on land?",
       "ja": "ジブチにある世界で最も標高の低い湖は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103331,7 +104772,8 @@
     "question_text": {
       "en": "Which Fukushima lake is the fourth largest in Japan?",
       "ja": "福島県にある日本で4番目に大きい湖は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103371,7 +104813,8 @@
     "question_text": {
       "en": "Which Ibaraki lake is the second largest in Japan?",
       "ja": "茨城県にある日本で2番目に大きい湖は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103411,7 +104854,8 @@
     "question_text": {
       "en": "Which is Japan's largest brackish lake, on Hokkaido's Sea of Okhotsk coast?",
       "ja": "北海道東部のオホーツク海に面した日本最大の汽水湖は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103451,7 +104895,8 @@
     "question_text": {
       "en": "Which is the largest city in Southern California?",
       "ja": "アメリカ・カリフォルニア州南部の大都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103491,7 +104936,8 @@
     "question_text": {
       "en": "Which southern Egyptian city is famous for the Karnak Temple?",
       "ja": "エジプト南部にあるカルナック神殿で有名な都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103533,7 +104979,8 @@
     "question_text": {
       "en": "Which is the fourth largest island in the world, off southeastern Africa?",
       "ja": "アフリカ南東沖にある世界で4番目に大きい島は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103573,7 +105020,8 @@
     "question_text": {
       "en": "What is the capital of Spain?",
       "ja": "スペインの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103613,7 +105061,8 @@
     "question_text": {
       "en": "Which northwestern English industrial city is famous for football?",
       "ja": "イギリス北西部の工業都市でサッカーが盛んな都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103653,7 +105102,8 @@
     "question_text": {
       "en": "Which Saudi Arabian city is Islam's holiest site?",
       "ja": "イスラム教最大の聖地はサウジアラビアの?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103693,7 +105143,8 @@
     "question_text": {
       "en": "Which city is Islam's second holiest, home to the Prophet Muhammad's tomb?",
       "ja": "イスラム教第2の聖地で預言者ムハンマドの墓がある都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103733,7 +105184,8 @@
     "question_text": {
       "en": "Tel Aviv and Beirut both face which coastal region?",
       "ja": "イスラエルのテルアビブやレバノンのベイルートが面しているのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103773,7 +105225,8 @@
     "question_text": {
       "en": "Which northern Italian city is its economic and fashion capital?",
       "ja": "イタリア北部の経済の中心地でファッションの都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103817,7 +105270,8 @@
     "question_text": {
       "en": "Which great river runs north-south through the central United States?",
       "ja": "アメリカ中部を南北に貫く大河は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103857,7 +105311,8 @@
     "question_text": {
       "en": "Which northern Mexican city is a major industrial center?",
       "ja": "メキシコ北部の工業都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103897,7 +105352,8 @@
     "question_text": {
       "en": "What is the capital of Uruguay?",
       "ja": "ウルグアイの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103937,7 +105393,8 @@
     "question_text": {
       "en": "Which is the largest city in Quebec, Canada?",
       "ja": "カナダ・ケベック州の最大都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103977,7 +105434,8 @@
     "question_text": {
       "en": "Which Northern Japan Alps peak rises to 3190 meters?",
       "ja": "北アルプスにある標高3190mの山は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104017,7 +105475,8 @@
     "question_text": {
       "en": "Which is Africa's highest mountain, located in Tanzania?",
       "ja": "タンザニアにあるアフリカ最高峰は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104057,7 +105516,8 @@
     "question_text": {
       "en": "Which Southern Japan Alps peak is Japan's second highest at 3193 meters?",
       "ja": "南アルプスにある標高3193mで日本第2位の高峰は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104097,7 +105557,8 @@
     "question_text": {
       "en": "Which is the former name of North America's highest peak in Alaska?",
       "ja": "アラスカにある北米最高峰の旧称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104137,7 +105598,8 @@
     "question_text": {
       "en": "Which mountain range lies on the border between Uganda and DR Congo?",
       "ja": "ウガンダとコンゴ民主共和国の国境にある山は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104177,7 +105639,8 @@
     "question_text": {
       "en": "Which Northern Japan Alps peak is famous for its spear-like summit?",
       "ja": "北アルプスの槍状の山頂で知られる山は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104217,7 +105680,8 @@
     "question_text": {
       "en": "Which is India's largest city, formerly known as Bombay?",
       "ja": "インド最大の都市で旧称ボンベイは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104257,7 +105721,8 @@
     "question_text": {
       "en": "What is the capital of Bavaria, Germany?",
       "ja": "ドイツ・バイエルン州の州都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104297,7 +105762,8 @@
     "question_text": {
       "en": "Which is the central city of northern Okinawa Island?",
       "ja": "沖縄本島北部の中心都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104337,7 +105803,8 @@
     "question_text": {
       "en": "Which former Chinese capital lies on the lower Yangtze River?",
       "ja": "中国の旧首都で長江下流域にある都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104377,7 +105844,8 @@
     "question_text": {
       "en": "Which landlocked South Asian country is home to Mount Everest?",
       "ja": "エベレストがある南アジアの内陸国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104417,7 +105885,8 @@
     "question_text": {
       "en": "Which European country has Amsterdam as its capital?",
       "ja": "アムステルダムを首都とするヨーロッパの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104460,7 +105929,8 @@
     "question_text": {
       "en": "Which is the world's second largest island, split between Indonesia and Papua New Guinea?",
       "ja": "世界第2位の大きさを持つ島でインドネシアとパプアニューギニアに分かれているのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104500,7 +105970,8 @@
     "question_text": {
       "en": "Which is the U.S. east coast's global city?",
       "ja": "アメリカ東海岸の世界都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104540,7 +106011,8 @@
     "question_text": {
       "en": "Which is the largest city in Siberia?",
       "ja": "シベリア最大の都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104580,7 +106052,8 @@
     "question_text": {
       "en": "What is the capital of Cambodia?",
       "ja": "カンボジアの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104595,7 +106068,6 @@
         "en": "Seoul",
         "ja": "ソウル",
         "ja_typings": [
-          "soru",
           "souru"
         ]
       },
@@ -104621,7 +106093,8 @@
     "question_text": {
       "en": "What is the capital of North Korea?",
       "ja": "北朝鮮の首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104636,7 +106109,7 @@
         "en": "Tokyo Bay Aqua-Line",
         "ja": "東京湾アクアライン",
         "ja_typings": [
-          "toukyouwanakurarain"
+          "toukyouwanakuarain"
         ]
       },
       {
@@ -104662,7 +106135,8 @@
     "question_text": {
       "en": "Which bridge connects Odaiba and Shibaura over Tokyo Bay?",
       "ja": "東京湾のお台場と芝浦を結ぶ橋は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104702,7 +106176,8 @@
     "question_text": {
       "en": "Which Brazilian city is famous for the Christ the Redeemer statue?",
       "ja": "ブラジルでコルコバードのキリスト像で有名な都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104742,7 +106217,8 @@
     "question_text": {
       "en": "Which Dutch port city houses Europoort, one of Europe's largest ports?",
       "ja": "オランダの主要港湾都市でユーロポートを擁するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104782,7 +106258,8 @@
     "question_text": {
       "en": "Which is Russia's former capital on the Baltic coast?",
       "ja": "ロシアの旧首都でバルト海沿岸の都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104822,7 +106299,8 @@
     "question_text": {
       "en": "What is the capital of Chile?",
       "ja": "チリの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104862,7 +106340,8 @@
     "question_text": {
       "en": "Which is the largest city in Brazil?",
       "ja": "ブラジル最大の都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104902,7 +106381,8 @@
     "question_text": {
       "en": "What is the capital of Andalusia in southern Spain?",
       "ja": "スペイン南部アンダルシア州の州都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104942,7 +106422,8 @@
     "question_text": {
       "en": "Which is China's largest city, located at the mouth of the Yangtze?",
       "ja": "中国最大の都市で長江河口の港湾都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104982,7 +106463,8 @@
     "question_text": {
       "en": "Which vast region covers eastern Russia?",
       "ja": "ロシア東部に広がる広大な地域は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105022,7 +106504,8 @@
     "question_text": {
       "en": "Which country at Africa's southern tip is home to Cape Town?",
       "ja": "ケープタウンを擁するアフリカ大陸南端の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105062,7 +106545,8 @@
     "question_text": {
       "en": "Which continent includes Brazil and Argentina?",
       "ja": "ブラジルやアルゼンチンを含む大陸は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105102,7 +106586,8 @@
     "question_text": {
       "en": "Which ancient Greek city-state was famous for its military?",
       "ja": "古代ギリシャの軍事都市国家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105146,7 +106631,8 @@
     "question_text": {
       "en": "Which river flows from Nagano through Shizuoka into Enshu-nada Sea?",
       "ja": "長野県・静岡県を流れて遠州灘に注ぐ川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105186,7 +106672,8 @@
     "question_text": {
       "en": "Which Dutch city is home to the International Court of Justice?",
       "ja": "国際司法裁判所が置かれるオランダの都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105226,7 +106713,8 @@
     "question_text": {
       "en": "Which is Greece's second largest city?",
       "ja": "ギリシャ第2の都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105234,7 +106722,7 @@
         "en": "Tokyo Bay Aqua-Line",
         "ja": "東京湾アクアライン",
         "ja_typings": [
-          "toukyouwanakurarain"
+          "toukyouwanakuarain"
         ]
       },
       {
@@ -105267,7 +106755,8 @@
     "question_text": {
       "en": "Which highway crosses Tokyo Bay between Tokyo area and Kanagawa?",
       "ja": "東京と神奈川を結ぶ東京湾を横断する道路は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105311,7 +106800,8 @@
     "question_text": {
       "en": "Which Kanto Plain river has Japan's largest drainage basin?",
       "ja": "関東平野を流れる日本最大の流域面積を持つ川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105351,7 +106841,8 @@
     "question_text": {
       "en": "Which is the largest city in Canada?",
       "ja": "カナダ最大の都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105380,7 +106871,7 @@
         "en": "Qaidam Basin",
         "ja": "ツァイダム盆地",
         "ja_typings": [
-          "tsuaidamubonchi"
+          "tsaidamubonchi"
         ]
       }
     ],
@@ -105391,7 +106882,8 @@
     "question_text": {
       "en": "Which depression in China's Xinjiang region is the country's lowest point?",
       "ja": "中国新疆ウイグル自治区にある中国で最も低い場所は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105431,7 +106923,8 @@
     "question_text": {
       "en": "The Rio Grande forms the border between which two countries?",
       "ja": "リオ・グランデ川が国境を流れている国の組み合わせは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105471,7 +106964,8 @@
     "question_text": {
       "en": "Which Dutch central city is a major university town?",
       "ja": "オランダ中央部の大学都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105511,7 +107005,8 @@
     "question_text": {
       "en": "Which eastern Spanish city on the Mediterranean is the birthplace of paella?",
       "ja": "スペイン東部地中海沿岸の都市でパエリア発祥地は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105551,7 +107046,8 @@
     "question_text": {
       "en": "Which is Canada's main west coast port city?",
       "ja": "カナダ西海岸の港湾都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105591,7 +107087,8 @@
     "question_text": {
       "en": "Which northeastern Italian city is famous for its canals?",
       "ja": "イタリア北東部の運河の街は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105631,7 +107128,8 @@
     "question_text": {
       "en": "What is the capital of Laos?",
       "ja": "ラオスの首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105671,7 +107169,8 @@
     "question_text": {
       "en": "Which is the largest city in the Russian Far East?",
       "ja": "ロシア極東の最大都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105714,7 +107213,8 @@
     "question_text": {
       "en": "Which is Asia's longest river, flowing through China?",
       "ja": "中国を流れるアジア最長の川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105754,7 +107254,8 @@
     "question_text": {
       "en": "Victoria Falls lies on the border between which two countries?",
       "ja": "ビクトリアの滝が国境にある国の組み合わせは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105794,7 +107295,8 @@
     "question_text": {
       "en": "Which is one of the typical default maximum TTL values used in IPv4?",
       "ja": "IPv4でルータが特別な用途で予約しているTTLのデフォルト最大値の1つは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105834,7 +107336,8 @@
     "question_text": {
       "en": "What is the maximum value of an 8-bit unsigned integer?",
       "ja": "8ビット符号なし整数で表せる最大値は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105874,7 +107377,8 @@
     "question_text": {
       "en": "How many bits does C's short type typically have?",
       "ja": "C言語のshort型で多くの環境におけるビット数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105914,7 +107418,8 @@
     "question_text": {
       "en": "How many distinct values can be represented with 8 bits?",
       "ja": "8ビット整数で表現できる値の総数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105954,7 +107459,8 @@
     "question_text": {
       "en": "How many bits wide is a general purpose register in x86_64?",
       "ja": "x86_64アーキテクチャでの汎用レジスタの幅は何ビット?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105994,7 +107500,8 @@
     "question_text": {
       "en": "How many bits is one octet in IPv4?",
       "ja": "IPv4の1オクテットは何ビット?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106034,7 +107541,8 @@
     "question_text": {
       "en": "Which protocol resolves IP addresses to MAC addresses?",
       "ja": "IPアドレスからMACアドレスを解決するプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106074,7 +107582,8 @@
     "question_text": {
       "en": "Which agentless configuration management tool uses YAML playbooks?",
       "ja": "サーバ構成管理ツールでYAMLで定義しエージェントレスで動作するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106114,7 +107623,8 @@
     "question_text": {
       "en": "Which old XML-based build tool is used for Java projects?",
       "ja": "Javaのビルドツールで古くから使われているXMLベースのものは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106154,7 +107664,8 @@
     "question_text": {
       "en": "Which browser was made by The Browser Company with a focus on tabs and workflows?",
       "ja": "Mozillaが開発したJavaScriptランタイム向けの新ブラウザは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106194,7 +107705,8 @@
     "question_text": {
       "en": "Which program translates assembly language into machine code?",
       "ja": "アセンブリ言語を機械語に変換するプログラムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106234,7 +107746,8 @@
     "question_text": {
       "en": "Which low-level language directly represents CPU instructions?",
       "ja": "CPUの命令を直接表現する低水準言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106274,7 +107787,8 @@
     "question_text": {
       "en": "What is the operation of setting a value into a variable called?",
       "ja": "プログラミングで変数に値を入れる操作は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106314,7 +107828,8 @@
     "question_text": {
       "en": "Which profiling metric shows the average number of times a function ran?",
       "ja": "プロファイラで関数の平均実行回数を示す指標は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106354,7 +107869,8 @@
     "question_text": {
       "en": "Which graph traversal explores all neighbors level by level?",
       "ja": "グラフ探索で全方向に広く探索する手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106394,7 +107910,8 @@
     "question_text": {
       "en": "Which unit represents bits transferred per second?",
       "ja": "ビットレートの単位で1秒間のビット数を表すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106402,16 +107919,14 @@
         "en": "Bad Request",
         "ja": "Bad Request",
         "ja_typings": [
-          "bad request",
-          "badrequest"
+          "bad request"
         ]
       },
       {
         "en": "Not Found",
         "ja": "Not Found",
         "ja_typings": [
-          "not found",
-          "notfound"
+          "not found"
         ]
       },
       {
@@ -106436,7 +107951,8 @@
     "question_text": {
       "en": "What does HTTP status code 400 indicate?",
       "ja": "HTTPステータスコード400が示すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106476,7 +107992,8 @@
     "question_text": {
       "en": "Which is the standard shell on most Linux distributions?",
       "ja": "Linuxで標準的に使われるシェルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106484,32 +108001,28 @@
         "en": "Bill Joy",
         "ja": "Bill Joy",
         "ja_typings": [
-          "bill joy",
-          "billjoy"
+          "bill joy"
         ]
       },
       {
         "en": "Bjarne Stroustrup",
         "ja": "Bjarne Stroustrup",
         "ja_typings": [
-          "bjarne stroustrup",
-          "bjarnestroustrup"
+          "bjarne stroustrup"
         ]
       },
       {
         "en": "Linus Torvalds",
         "ja": "Linus Torvalds",
         "ja_typings": [
-          "linus torvalds",
-          "linustorvalds"
+          "linus torvalds"
         ]
       },
       {
         "en": "Richard Stallman",
         "ja": "Richard Stallman",
         "ja_typings": [
-          "richard stallman",
-          "richardstallman"
+          "richard stallman"
         ]
       }
     ],
@@ -106520,7 +108033,8 @@
     "question_text": {
       "en": "Who is the author of the vi editor?",
       "ja": "viエディタを開発した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106560,7 +108074,8 @@
     "question_text": {
       "en": "Which bitwise operation returns 1 if either bit is 1?",
       "ja": "ビット単位で「どちらかが1なら1」を取る演算は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106568,32 +108083,28 @@
         "en": "Bjarne Stroustrup",
         "ja": "Bjarne Stroustrup",
         "ja_typings": [
-          "bjarne stroustrup",
-          "bjarnestroustrup"
+          "bjarne stroustrup"
         ]
       },
       {
         "en": "Dennis Ritchie",
         "ja": "Dennis Ritchie",
         "ja_typings": [
-          "dennis ritchie",
-          "dennisritchie"
+          "dennis ritchie"
         ]
       },
       {
         "en": "Bill Joy",
         "ja": "Bill Joy",
         "ja_typings": [
-          "bill joy",
-          "billjoy"
+          "bill joy"
         ]
       },
       {
         "en": "Brian Kernighan",
         "ja": "Brian Kernighan",
         "ja_typings": [
-          "brian kernighan",
-          "briankernighan"
+          "brian kernighan"
         ]
       }
     ],
@@ -106604,7 +108115,8 @@
     "question_text": {
       "en": "Who designed the C++ programming language?",
       "ja": "C++を設計した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106644,7 +108156,8 @@
     "question_text": {
       "en": "Which Rust smart pointer places a single value on the heap?",
       "ja": "Rustのヒープに値を1つ置くスマートポインタ型は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106652,32 +108165,28 @@
         "en": "Brendan Eich",
         "ja": "Brendan Eich",
         "ja_typings": [
-          "brendan eich",
-          "brendaneich"
+          "brendan eich"
         ]
       },
       {
         "en": "Guido van Rossum",
         "ja": "Guido van Rossum",
         "ja_typings": [
-          "guido van rossum",
-          "guidovanrossum"
+          "guido van rossum"
         ]
       },
       {
         "en": "Larry Wall",
         "ja": "Larry Wall",
         "ja_typings": [
-          "larry wall",
-          "larrywall"
+          "larry wall"
         ]
       },
       {
         "en": "Yukihiro Matsumoto",
         "ja": "Yukihiro Matsumoto",
         "ja_typings": [
-          "yukihiro matsumoto",
-          "yukihiromatsumoto"
+          "yukihiro matsumoto"
         ]
       }
     ],
@@ -106688,7 +108197,8 @@
     "question_text": {
       "en": "Who designed JavaScript?",
       "ja": "JavaScriptを設計した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106696,32 +108206,28 @@
         "en": "Brian Kernighan",
         "ja": "Brian Kernighan",
         "ja_typings": [
-          "brian kernighan",
-          "briankernighan"
+          "brian kernighan"
         ]
       },
       {
         "en": "Dennis Ritchie",
         "ja": "Dennis Ritchie",
         "ja_typings": [
-          "dennis ritchie",
-          "dennisritchie"
+          "dennis ritchie"
         ]
       },
       {
         "en": "Bjarne Stroustrup",
         "ja": "Bjarne Stroustrup",
         "ja_typings": [
-          "bjarne stroustrup",
-          "bjarnestroustrup"
+          "bjarne stroustrup"
         ]
       },
       {
         "en": "Bill Joy",
         "ja": "Bill Joy",
         "ja_typings": [
-          "bill joy",
-          "billjoy"
+          "bill joy"
         ]
       }
     ],
@@ -106732,7 +108238,8 @@
     "question_text": {
       "en": "Who co-authored 'The C Programming Language' and co-created AWK?",
       "ja": "AWKの開発者の1人で『プログラミング言語C』の共著者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106772,7 +108279,8 @@
     "question_text": {
       "en": "Which structured language was developed on UNIX in the 1970s?",
       "ja": "UNIX上で生まれた構造化プログラミング言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106812,7 +108320,8 @@
     "question_text": {
       "en": "What is the abbreviation for .NET's common language runtime?",
       "ja": ".NETの共通言語ランタイムの略称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106852,7 +108361,8 @@
     "question_text": {
       "en": "Which programming language was designed in 1959 for business processing?",
       "ja": "事務処理用に1959年に作られた言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106892,7 +108402,8 @@
     "question_text": {
       "en": "Which language styles HTML documents?",
       "ja": "HTMLの見た目を装飾する言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106932,7 +108443,8 @@
     "question_text": {
       "en": "What is Rust's package manager and build tool called?",
       "ja": "Rustのパッケージマネージャ兼ビルドツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106972,7 +108484,8 @@
     "question_text": {
       "en": "Which distributed NoSQL database uses a column-family store?",
       "ja": "分散NoSQLデータベースの1つで列指向ストアなのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107012,7 +108525,8 @@
     "question_text": {
       "en": "What category does HTTP 4xx status code belong to?",
       "ja": "HTTPの4xx系ステータスコードが意味するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107052,7 +108566,8 @@
     "question_text": {
       "en": "Which software translates source code into machine code?",
       "ja": "ソースコードを機械語などに翻訳するソフトウェアは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107092,7 +108607,8 @@
     "question_text": {
       "en": "Which graph traversal explores as deep as possible first?",
       "ja": "グラフ探索でできるだけ深く進むのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107132,7 +108648,8 @@
     "question_text": {
       "en": "Which gaming metric measures damage dealt per second?",
       "ja": "1秒間に与えるダメージ量の指標は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107172,7 +108689,8 @@
     "question_text": {
       "en": "Which tool lets you step through code and inspect variables?",
       "ja": "プログラムをステップ実行・変数監視できるツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107216,7 +108734,8 @@
     "question_text": {
       "en": "Which numeral system uses digits 0 through 9?",
       "ja": "0から9までの記号を使う数値表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107224,32 +108743,28 @@
         "en": "Dennis Ritchie",
         "ja": "Dennis Ritchie",
         "ja_typings": [
-          "dennis ritchie",
-          "dennisritchie"
+          "dennis ritchie"
         ]
       },
       {
         "en": "Brian Kernighan",
         "ja": "Brian Kernighan",
         "ja_typings": [
-          "brian kernighan",
-          "briankernighan"
+          "brian kernighan"
         ]
       },
       {
         "en": "Bjarne Stroustrup",
         "ja": "Bjarne Stroustrup",
         "ja_typings": [
-          "bjarne stroustrup",
-          "bjarnestroustrup"
+          "bjarne stroustrup"
         ]
       },
       {
         "en": "Bill Joy",
         "ja": "Bill Joy",
         "ja_typings": [
-          "bill joy",
-          "billjoy"
+          "bill joy"
         ]
       }
     ],
@@ -107260,7 +108775,8 @@
     "question_text": {
       "en": "Who developed the C programming language?",
       "ja": "C言語を開発した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107268,8 +108784,7 @@
         "en": "Docker Compose",
         "ja": "Docker Compose",
         "ja_typings": [
-          "docker compose",
-          "dockercompose"
+          "docker compose"
         ]
       },
       {
@@ -107301,7 +108816,8 @@
     "question_text": {
       "en": "Which tool runs multi-container Docker applications via YAML?",
       "ja": "複数のコンテナをまとめて定義・起動するツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107341,7 +108857,8 @@
     "question_text": {
       "en": "Which term describes a language whose types are determined at runtime?",
       "ja": "実行時に型が決まる言語の性質を表す語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107381,7 +108898,8 @@
     "question_text": {
       "en": "Which OOP concept hides internal state and exposes a public interface?",
       "ja": "オブジェクト指向で内部状態を隠す概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107421,7 +108939,8 @@
     "question_text": {
       "en": "Which SQL statement retrieves rows from a cursor?",
       "ja": "SQLでデータを取得するために使われるカーソル操作の文は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107461,7 +108980,8 @@
     "question_text": {
       "en": "Which fast file system was developed for BSD UNIX?",
       "ja": "BSD系UNIXで使われた高速ファイルシステムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107501,7 +109021,8 @@
     "question_text": {
       "en": "Which classic protocol is used to transfer files?",
       "ja": "ファイルを転送する古典的なプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107516,7 +109037,6 @@
         "en": "Singleton",
         "ja": "シングルトン",
         "ja_typings": [
-          "shingoruton",
           "shinguruton"
         ]
       },
@@ -107542,7 +109062,8 @@
     "question_text": {
       "en": "Which is one of the GoF creational design patterns?",
       "ja": "GoFのデザインパターンで生成系の1つは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107582,7 +109103,8 @@
     "question_text": {
       "en": "Which term refers to lightweight threads scheduled by a runtime?",
       "ja": "軽量スレッドのことを指す概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107604,16 +109126,14 @@
         "en": "Not Found",
         "ja": "Not Found",
         "ja_typings": [
-          "not found",
-          "notfound"
+          "not found"
         ]
       },
       {
         "en": "Bad Request",
         "ja": "Bad Request",
         "ja_typings": [
-          "bad request",
-          "badrequest"
+          "bad request"
         ]
       }
     ],
@@ -107624,7 +109144,8 @@
     "question_text": {
       "en": "What does HTTP status code 403 indicate?",
       "ja": "HTTPステータスコード403が示すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107664,7 +109185,8 @@
     "question_text": {
       "en": "Which language was created in 1957 for scientific computation?",
       "ja": "科学計算用に1957年に作られた言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107704,7 +109226,8 @@
     "question_text": {
       "en": "Which SQL clause aggregates rows by column values?",
       "ja": "SQLで列ごとに集計するための句は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107744,7 +109267,8 @@
     "question_text": {
       "en": "Which Google-designed statically typed language emphasizes concurrency?",
       "ja": "Googleが開発した静的型付きの並行処理向け言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107784,7 +109308,8 @@
     "question_text": {
       "en": "Which data structure represents relations with nodes and edges?",
       "ja": "ノードとエッジで関係を表すデータ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107792,32 +109317,28 @@
         "en": "Guido van Rossum",
         "ja": "Guido van Rossum",
         "ja_typings": [
-          "guido van rossum",
-          "guidovanrossum"
+          "guido van rossum"
         ]
       },
       {
         "en": "Brendan Eich",
         "ja": "Brendan Eich",
         "ja_typings": [
-          "brendan eich",
-          "brendaneich"
+          "brendan eich"
         ]
       },
       {
         "en": "Larry Wall",
         "ja": "Larry Wall",
         "ja_typings": [
-          "larry wall",
-          "larrywall"
+          "larry wall"
         ]
       },
       {
         "en": "Yukihiro Matsumoto",
         "ja": "Yukihiro Matsumoto",
         "ja_typings": [
-          "yukihiro matsumoto",
-          "yukihiromatsumoto"
+          "yukihiro matsumoto"
         ]
       }
     ],
@@ -107828,7 +109349,8 @@
     "question_text": {
       "en": "Who designed the Python programming language?",
       "ja": "Pythonを設計した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107868,7 +109390,8 @@
     "question_text": {
       "en": "Which HTTP method fetches only headers without a body?",
       "ja": "HTTPでヘッダだけ取得するメソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107908,7 +109431,8 @@
     "question_text": {
       "en": "Which markup language describes the structure of a web page?",
       "ja": "Webページの構造を記述するマークアップ言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107952,7 +109476,8 @@
     "question_text": {
       "en": "Which numeral system uses digits 0-9 and A-F?",
       "ja": "0からF までの記号を使う数値表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107992,7 +109517,8 @@
     "question_text": {
       "en": "Which IP control message protocol does ping use?",
       "ja": "pingで使われるIP制御メッセージプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108032,7 +109558,8 @@
     "question_text": {
       "en": "Which term describes objects that cannot be modified after creation?",
       "ja": "一度作ったら変更できない性質を表す語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108040,24 +109567,21 @@
         "en": "Internal Server Error",
         "ja": "Internal Server Error",
         "ja_typings": [
-          "internal server error",
-          "internalservererror"
+          "internal server error"
         ]
       },
       {
         "en": "Bad Request",
         "ja": "Bad Request",
         "ja_typings": [
-          "bad request",
-          "badrequest"
+          "bad request"
         ]
       },
       {
         "en": "Not Found",
         "ja": "Not Found",
         "ja_typings": [
-          "not found",
-          "notfound"
+          "not found"
         ]
       },
       {
@@ -108075,7 +109599,8 @@
     "question_text": {
       "en": "What does HTTP status code 500 indicate?",
       "ja": "HTTPステータスコード500が示すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108115,7 +109640,8 @@
     "question_text": {
       "en": "Which software executes source code line by line?",
       "ja": "ソースコードを逐次解釈実行するソフトウェアは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108130,7 +109656,7 @@
         "en": "It indicates return values",
         "ja": "戻り値を表す",
         "ja_typings": [
-          "modoriatewohyousu"
+          "modorichiwohyousu"
         ]
       },
       {
@@ -108155,7 +109681,8 @@
     "question_text": {
       "en": "What does the `#` symbol indicate in Python?",
       "ja": "Pythonで `#` 記号の役割は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108163,7 +109690,7 @@
         "en": "It indicates return values",
         "ja": "戻り値を表す",
         "ja_typings": [
-          "modoriatewohyousu"
+          "modorichiwohyousu"
         ]
       },
       {
@@ -108195,7 +109722,8 @@
     "question_text": {
       "en": "What does the `->` arrow indicate in a function signature?",
       "ja": "関数定義で `->` 記号が示すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108217,7 +109745,7 @@
         "en": "It indicates return values",
         "ja": "戻り値を表す",
         "ja_typings": [
-          "modoriatewohyousu"
+          "modorichiwohyousu"
         ]
       },
       {
@@ -108235,7 +109763,8 @@
     "question_text": {
       "en": "What does the `:` colon indicate in TypeScript annotations like `: number`?",
       "ja": "TypeScriptで `: number` のように書く記号 `:` の役割は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108275,7 +109804,8 @@
     "question_text": {
       "en": "Which is a common (incorrect) fake expansion of JSON?",
       "ja": "JSONのフルネームの誤った候補として混同されがちなのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108315,7 +109845,8 @@
     "question_text": {
       "en": "Which dynamic language runs in web browsers?",
       "ja": "ブラウザで動く動的言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108355,7 +109886,8 @@
     "question_text": {
       "en": "Which is another common false expansion of JSON?",
       "ja": "JSONの正式名称として誤って語られがちなのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108395,7 +109927,8 @@
     "question_text": {
       "en": "Which is another false expansion sometimes given for JSON?",
       "ja": "JSONの誤った命名候補としてしばしば挙げられるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108403,32 +109936,28 @@
         "en": "Junio Hamano",
         "ja": "Junio Hamano",
         "ja_typings": [
-          "junio hamano",
-          "juniohamano"
+          "junio hamano"
         ]
       },
       {
         "en": "Yukihiro Matsumoto",
         "ja": "Yukihiro Matsumoto",
         "ja_typings": [
-          "yukihiro matsumoto",
-          "yukihiromatsumoto"
+          "yukihiro matsumoto"
         ]
       },
       {
         "en": "Linus Torvalds",
         "ja": "Linus Torvalds",
         "ja_typings": [
-          "linus torvalds",
-          "linustorvalds"
+          "linus torvalds"
         ]
       },
       {
         "en": "Brian Kernighan",
         "ja": "Brian Kernighan",
         "ja_typings": [
-          "brian kernighan",
-          "briankernighan"
+          "brian kernighan"
         ]
       }
     ],
@@ -108439,7 +109968,8 @@
     "question_text": {
       "en": "Which Japanese developer maintains Git?",
       "ja": "Gitの現在のメンテナを務める日本人開発者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108479,7 +110009,8 @@
     "question_text": {
       "en": "Which compiler infrastructure is used by Clang and Swift?",
       "ja": "Clang/Swiftなどが利用するコンパイラ基盤は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108487,32 +110018,28 @@
         "en": "Larry Wall",
         "ja": "Larry Wall",
         "ja_typings": [
-          "larry wall",
-          "larrywall"
+          "larry wall"
         ]
       },
       {
         "en": "Guido van Rossum",
         "ja": "Guido van Rossum",
         "ja_typings": [
-          "guido van rossum",
-          "guidovanrossum"
+          "guido van rossum"
         ]
       },
       {
         "en": "Brendan Eich",
         "ja": "Brendan Eich",
         "ja_typings": [
-          "brendan eich",
-          "brendaneich"
+          "brendan eich"
         ]
       },
       {
         "en": "Yukihiro Matsumoto",
         "ja": "Yukihiro Matsumoto",
         "ja_typings": [
-          "yukihiro matsumoto",
-          "yukihiromatsumoto"
+          "yukihiro matsumoto"
         ]
       }
     ],
@@ -108523,7 +110050,8 @@
     "question_text": {
       "en": "Who designed the Perl programming language?",
       "ja": "Perlを設計した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108563,7 +110091,8 @@
     "question_text": {
       "en": "Which tool combines object files into an executable?",
       "ja": "オブジェクトファイルをまとめて実行ファイルを作るのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108571,32 +110100,28 @@
         "en": "Linus Torvalds",
         "ja": "Linus Torvalds",
         "ja_typings": [
-          "linus torvalds",
-          "linustorvalds"
+          "linus torvalds"
         ]
       },
       {
         "en": "Richard Stallman",
         "ja": "Richard Stallman",
         "ja_typings": [
-          "richard stallman",
-          "richardstallman"
+          "richard stallman"
         ]
       },
       {
         "en": "Dennis Ritchie",
         "ja": "Dennis Ritchie",
         "ja_typings": [
-          "dennis ritchie",
-          "dennisritchie"
+          "dennis ritchie"
         ]
       },
       {
         "en": "Brian Kernighan",
         "ja": "Brian Kernighan",
         "ja_typings": [
-          "brian kernighan",
-          "briankernighan"
+          "brian kernighan"
         ]
       }
     ],
@@ -108607,7 +110132,8 @@
     "question_text": {
       "en": "Who originally developed the Linux kernel?",
       "ja": "Linuxカーネルを最初に開発した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108647,7 +110173,8 @@
     "question_text": {
       "en": "Which logical operation returns true only when both operands are true?",
       "ja": "ビット単位で「両方1のときだけ1」を取る演算の論理版は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108655,7 +110182,6 @@
         "en": "O(n log n)",
         "ja": "O(n log n)",
         "ja_typings": [
-          "o(nlogn)",
           "o(n log n)"
         ]
       },
@@ -108677,7 +110203,6 @@
         "en": "O(log n)",
         "ja": "O(log n)",
         "ja_typings": [
-          "o(logn)",
           "o(log n)"
         ]
       }
@@ -108689,7 +110214,8 @@
     "question_text": {
       "en": "What is the proven lower bound of complexity for comparison-based sorting?",
       "ja": "比較ソートで証明されている計算量の下限は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108729,7 +110255,8 @@
     "question_text": {
       "en": "Which SQL statement combines INSERT and UPDATE in one operation?",
       "ja": "SQLでINSERT/UPDATEを一度に行う命令は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108769,7 +110296,8 @@
     "question_text": {
       "en": "Which form of instructions is directly executed by the CPU?",
       "ja": "CPUが直接実行できるバイナリ表現の命令は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108809,7 +110337,8 @@
     "question_text": {
       "en": "Which Java build tool uses pom.xml configuration?",
       "ja": "JavaのXMLベースのビルドツールでpom.xmlを使うのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108817,7 +110346,6 @@
         "en": "Memory Leak",
         "ja": "メモリリーク",
         "ja_typings": [
-          "memori-ri-ku",
           "memoriri-ku"
         ]
       },
@@ -108825,7 +110353,7 @@
         "en": "Segmentation Fault",
         "ja": "セグメンテーション違反",
         "ja_typings": [
-          "segumente-shonihan"
+          "segumente-shonnihan"
         ]
       },
       {
@@ -108850,7 +110378,8 @@
     "question_text": {
       "en": "Which bug refers to memory that is never released?",
       "ja": "解放されないメモリが蓄積する不具合は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108890,7 +110419,8 @@
     "question_text": {
       "en": "Which profiling metric shows how much memory the program uses?",
       "ja": "プロファイラで「メモリの使用量」を示す指標は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108919,7 +110449,7 @@
         "en": "Insertion Sort",
         "ja": "挿入ソート",
         "ja_typings": [
-          "so-nyuuso-to"
+          "sounyuuso-to"
         ]
       }
     ],
@@ -108930,7 +110460,8 @@
     "question_text": {
       "en": "Which divide-and-conquer stable sort guarantees O(n log n)?",
       "ja": "分割統治法による安定ソートでO(n log n)を保証するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108970,7 +110501,8 @@
     "question_text": {
       "en": "Which is a leading document-oriented NoSQL database?",
       "ja": "ドキュメント指向NoSQLの代表例は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109010,7 +110542,8 @@
     "question_text": {
       "en": "Which primitive ensures only one thread accesses a resource at a time?",
       "ja": "複数スレッドが同時にアクセスしないよう制御する仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109050,7 +110583,8 @@
     "question_text": {
       "en": "Which popular open-source relational database starts with 'M'?",
       "ja": "オープンソースの代表的なリレーショナルDBで「m」で始まるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109090,7 +110624,8 @@
     "question_text": {
       "en": "Which is a leading graph database?",
       "ja": "グラフ型データベースの代表は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109098,8 +110633,7 @@
         "en": "Not Found",
         "ja": "Not Found",
         "ja_typings": [
-          "not found",
-          "notfound"
+          "not found"
         ]
       },
       {
@@ -109113,8 +110647,7 @@
         "en": "Bad Request",
         "ja": "Bad Request",
         "ja_typings": [
-          "bad request",
-          "badrequest"
+          "bad request"
         ]
       },
       {
@@ -109132,7 +110665,8 @@
     "question_text": {
       "en": "What does HTTP status code 404 indicate?",
       "ja": "HTTPステータスコード404が示すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109172,7 +110706,8 @@
     "question_text": {
       "en": "What is the average-case lookup complexity of a hash table?",
       "ja": "ハッシュテーブルの平均的な検索計算量は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109212,7 +110747,8 @@
     "question_text": {
       "en": "What is the time complexity of binary search?",
       "ja": "二分探索の計算量は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109252,7 +110788,8 @@
     "question_text": {
       "en": "What is the best achievable complexity for comparison sorting?",
       "ja": "比較ソートの最良計算量は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109292,7 +110829,8 @@
     "question_text": {
       "en": "What is the time complexity of a single-pass linear search?",
       "ja": "配列を1度走査する線形探索の計算量は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109307,16 +110845,14 @@
         "en": "Bad Request",
         "ja": "Bad Request",
         "ja_typings": [
-          "bad request",
-          "badrequest"
+          "bad request"
         ]
       },
       {
         "en": "Not Found",
         "ja": "Not Found",
         "ja_typings": [
-          "not found",
-          "notfound"
+          "not found"
         ]
       },
       {
@@ -109334,7 +110870,8 @@
     "question_text": {
       "en": "What does HTTP status code 200 indicate?",
       "ja": "HTTPステータスコード200が示すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109349,7 +110886,6 @@
         "en": "Singleton",
         "ja": "シングルトン",
         "ja_typings": [
-          "shingoruton",
           "shinguruton"
         ]
       },
@@ -109375,7 +110911,8 @@
     "question_text": {
       "en": "Which GoF pattern notifies subscribers of state changes?",
       "ja": "GoFパターンで状態変化を購読者に通知するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109419,7 +110956,8 @@
     "question_text": {
       "en": "Which numeral system uses digits 0-7?",
       "ja": "0から7までの数字で表す進数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109459,7 +110997,8 @@
     "question_text": {
       "en": "Which HTTP method represents a partial update of a resource?",
       "ja": "HTTPでリソースの一部更新を表すメソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109499,7 +111038,8 @@
     "question_text": {
       "en": "Which server-side language is widely used for generating dynamic web pages?",
       "ja": "サーバサイドで動的Webページを生成する人気言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109539,7 +111079,8 @@
     "question_text": {
       "en": "Which HTTP method commonly submits data to the server?",
       "ja": "HTTPでデータをサーバに送信する代表的なメソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109579,7 +111120,8 @@
     "question_text": {
       "en": "Which HTTP method replaces a resource entirely?",
       "ja": "HTTPでリソース全体を置き換えるメソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109619,7 +111161,8 @@
     "question_text": {
       "en": "Which educational language was designed by Niklaus Wirth?",
       "ja": "Niklaus Wirthが設計した教育用言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109659,7 +111202,8 @@
     "question_text": {
       "en": "Which OOP concept lets one interface serve many implementations?",
       "ja": "オブジェクト指向で同じインタフェースで多様な振る舞いをする概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109699,7 +111243,8 @@
     "question_text": {
       "en": "Which is a feature-rich, extensible open-source RDBMS?",
       "ja": "高機能で拡張性に優れたオープンソースRDBは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109739,7 +111284,8 @@
     "question_text": {
       "en": "Which OS-managed execution unit has its own memory space?",
       "ja": "OSが管理する実行単位でメモリ空間を独立して持つのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109779,7 +111325,8 @@
     "question_text": {
       "en": "Which tool measures and analyzes a program's performance?",
       "ja": "プログラムの性能を測定し分析するツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109819,7 +111366,8 @@
     "question_text": {
       "en": "Which data structure follows FIFO (first-in, first-out)?",
       "ja": "FIFO方式で出し入れするデータ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109859,7 +111407,8 @@
     "question_text": {
       "en": "Which Rust smart pointer is a single-threaded reference counter?",
       "ja": "Rustのシングルスレッド向け参照カウントスマートポインタは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109899,7 +111448,8 @@
     "question_text": {
       "en": "What is the meaning of the HTTP 3xx status family?",
       "ja": "HTTPで別URLに転送することを表す3xx系の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109907,32 +111457,28 @@
         "en": "Richard Stallman",
         "ja": "Richard Stallman",
         "ja_typings": [
-          "richard stallman",
-          "richardstallman"
+          "richard stallman"
         ]
       },
       {
         "en": "Linus Torvalds",
         "ja": "Linus Torvalds",
         "ja_typings": [
-          "linus torvalds",
-          "linustorvalds"
+          "linus torvalds"
         ]
       },
       {
         "en": "Bill Joy",
         "ja": "Bill Joy",
         "ja_typings": [
-          "bill joy",
-          "billjoy"
+          "bill joy"
         ]
       },
       {
         "en": "Dennis Ritchie",
         "ja": "Dennis Ritchie",
         "ja_typings": [
-          "dennis ritchie",
-          "dennisritchie"
+          "dennis ritchie"
         ]
       }
     ],
@@ -109943,7 +111489,8 @@
     "question_text": {
       "en": "Who founded the GNU Project?",
       "ja": "GNUプロジェクトを創設した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109983,7 +111530,8 @@
     "question_text": {
       "en": "Which protocol is used to send emails?",
       "ja": "メール送信に使われるプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110023,7 +111571,8 @@
     "question_text": {
       "en": "Which standard language manipulates relational databases?",
       "ja": "リレーショナルDBを操作する標準言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110063,7 +111612,8 @@
     "question_text": {
       "en": "Which lightweight embedded RDBMS stores data in a single file?",
       "ja": "ファイル1つで動く軽量な組み込みRDBは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110071,14 +111621,13 @@
         "en": "Segmentation Fault",
         "ja": "セグメンテーション違反",
         "ja_typings": [
-          "segumente-shonihan"
+          "segumente-shonnihan"
         ]
       },
       {
         "en": "Memory Leak",
         "ja": "メモリリーク",
         "ja_typings": [
-          "memori-ri-ku",
           "memoriri-ku"
         ]
       },
@@ -110093,8 +111642,7 @@
         "en": "Bad Request",
         "ja": "Bad Request",
         "ja_typings": [
-          "bad request",
-          "badrequest"
+          "bad request"
         ]
       }
     ],
@@ -110105,7 +111653,8 @@
     "question_text": {
       "en": "Which error is typically caused by invalid memory access?",
       "ja": "不正なメモリアクセスで発生する典型的なエラーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110145,7 +111694,8 @@
     "question_text": {
       "en": "Which Unix mechanism sends notifications to processes?",
       "ja": "Unixでプロセスに送る通知の仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110153,7 +111703,6 @@
         "en": "Singleton",
         "ja": "シングルトン",
         "ja_typings": [
-          "shingoruton",
           "shinguruton"
         ]
       },
@@ -110186,7 +111735,8 @@
     "question_text": {
       "en": "Which GoF pattern restricts a class to a single instance?",
       "ja": "GoFパターンでインスタンスを1つに制限するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110201,7 +111751,6 @@
         "en": "Memory Leak",
         "ja": "メモリリーク",
         "ja_typings": [
-          "memori-ri-ku",
           "memoriri-ku"
         ]
       },
@@ -110227,7 +111776,8 @@
     "question_text": {
       "en": "Which file maps minified code back to the original source?",
       "ja": "ミニファイされたコードと元のコードを対応付けるファイルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110267,7 +111817,8 @@
     "question_text": {
       "en": "Which data structure follows LIFO (last-in, first-out)?",
       "ja": "LIFO方式で出し入れするデータ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110282,7 +111833,6 @@
         "en": "Memory Leak",
         "ja": "メモリリーク",
         "ja_typings": [
-          "memori-ri-ku",
           "memoriri-ku"
         ]
       },
@@ -110290,7 +111840,7 @@
         "en": "Segmentation Fault",
         "ja": "セグメンテーション違反",
         "ja_typings": [
-          "segumente-shonihan"
+          "segumente-shonnihan"
         ]
       },
       {
@@ -110308,7 +111858,8 @@
     "question_text": {
       "en": "Which error occurs when the call stack exceeds its limit?",
       "ja": "スタック領域が溢れたときに起きるエラーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110348,7 +111899,8 @@
     "question_text": {
       "en": "Which term describes a language whose types are checked at compile time?",
       "ja": "コンパイル時に型が決まる言語の性質を表す語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110388,7 +111940,8 @@
     "question_text": {
       "en": "What is the meaning of the HTTP 2xx status family?",
       "ja": "HTTPの2xx系ステータスコードのカテゴリ名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110428,7 +111981,8 @@
     "question_text": {
       "en": "Which old remote-login protocol transmits data unencrypted?",
       "ja": "古くからある暗号化されないリモートログインプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110450,8 +112004,7 @@
         "en": "Docker Compose",
         "ja": "Docker Compose",
         "ja_typings": [
-          "docker compose",
-          "dockercompose"
+          "docker compose"
         ]
       },
       {
@@ -110469,7 +112022,8 @@
     "question_text": {
       "en": "Which HashiCorp tool provisions infrastructure declaratively?",
       "ja": "HashiCorpが開発するインフラ宣言型ツールは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110509,7 +112063,8 @@
     "question_text": {
       "en": "Which execution unit runs in a process and shares its memory?",
       "ja": "プロセス内で並行実行されメモリ空間を共有する単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110517,32 +112072,28 @@
         "en": "Tim Berners-Lee",
         "ja": "Tim Berners-Lee",
         "ja_typings": [
-          "tim berners-lee",
-          "timberners-lee"
+          "tim berners-lee"
         ]
       },
       {
         "en": "Linus Torvalds",
         "ja": "Linus Torvalds",
         "ja_typings": [
-          "linus torvalds",
-          "linustorvalds"
+          "linus torvalds"
         ]
       },
       {
         "en": "Brendan Eich",
         "ja": "Brendan Eich",
         "ja_typings": [
-          "brendan eich",
-          "brendaneich"
+          "brendan eich"
         ]
       },
       {
         "en": "Dennis Ritchie",
         "ja": "Dennis Ritchie",
         "ja_typings": [
-          "dennis ritchie",
-          "dennisritchie"
+          "dennis ritchie"
         ]
       }
     ],
@@ -110553,7 +112104,8 @@
     "question_text": {
       "en": "Who invented the World Wide Web?",
       "ja": "World Wide Webを発明した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110593,7 +112145,8 @@
     "question_text": {
       "en": "Which data structure represents hierarchical relations with nodes and branches?",
       "ja": "節点と枝で階層構造を表すデータ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110633,7 +112186,8 @@
     "question_text": {
       "en": "Which transport protocol is connectionless and unreliable?",
       "ja": "コネクションレスで信頼性を保証しないトランスポート層プロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110655,16 +112209,14 @@
         "en": "Bad Request",
         "ja": "Bad Request",
         "ja_typings": [
-          "bad request",
-          "badrequest"
+          "bad request"
         ]
       },
       {
         "en": "Not Found",
         "ja": "Not Found",
         "ja_typings": [
-          "not found",
-          "notfound"
+          "not found"
         ]
       }
     ],
@@ -110675,7 +112227,8 @@
     "question_text": {
       "en": "What does HTTP status code 401 indicate?",
       "ja": "HTTPステータスコード401が示すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110715,7 +112268,8 @@
     "question_text": {
       "en": "Which JavaScript engine powers Google Chrome?",
       "ja": "GoogleのChromeなどで動くJavaScriptエンジンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110755,7 +112309,8 @@
     "question_text": {
       "en": "Which highly extensible terminal text editor is beloved by Linux users?",
       "ja": "Linuxユーザに愛される高機能テキストエディタは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110795,7 +112350,8 @@
     "question_text": {
       "en": "Which OGC service provides geospatial vector features over the web?",
       "ja": "OGC仕様の地理空間ベクタフィーチャ取得サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110803,32 +112359,28 @@
         "en": "Yukihiro Matsumoto",
         "ja": "Yukihiro Matsumoto",
         "ja_typings": [
-          "yukihiro matsumoto",
-          "yukihiromatsumoto"
+          "yukihiro matsumoto"
         ]
       },
       {
         "en": "Guido van Rossum",
         "ja": "Guido van Rossum",
         "ja_typings": [
-          "guido van rossum",
-          "guidovanrossum"
+          "guido van rossum"
         ]
       },
       {
         "en": "Brendan Eich",
         "ja": "Brendan Eich",
         "ja_typings": [
-          "brendan eich",
-          "brendaneich"
+          "brendan eich"
         ]
       },
       {
         "en": "Larry Wall",
         "ja": "Larry Wall",
         "ja_typings": [
-          "larry wall",
-          "larrywall"
+          "larry wall"
         ]
       }
     ],
@@ -110839,7 +112391,8 @@
     "question_text": {
       "en": "Who designed the Ruby programming language?",
       "ja": "Rubyを設計した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110847,7 +112400,6 @@
         "en": "`#`",
         "ja": "`#`",
         "ja_typings": [
-          "#",
           "`#`"
         ]
       },
@@ -110855,7 +112407,6 @@
         "en": "`$`",
         "ja": "`$`",
         "ja_typings": [
-          "$",
           "`$`"
         ]
       },
@@ -110863,7 +112414,6 @@
         "en": "`%`",
         "ja": "`%`",
         "ja_typings": [
-          "%",
           "`%`"
         ]
       },
@@ -110871,7 +112421,6 @@
         "en": "`@`",
         "ja": "`@`",
         "ja_typings": [
-          "@",
           "`@`"
         ]
       }
@@ -110883,7 +112432,8 @@
     "question_text": {
       "en": "Which character commonly starts a line comment in many languages?",
       "ja": "多くの言語でコメント開始を表す記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110891,7 +112441,6 @@
         "en": "`$`",
         "ja": "`$`",
         "ja_typings": [
-          "$",
           "`$`"
         ]
       },
@@ -110899,7 +112448,6 @@
         "en": "`#`",
         "ja": "`#`",
         "ja_typings": [
-          "#",
           "`#`"
         ]
       },
@@ -110907,7 +112455,6 @@
         "en": "`%`",
         "ja": "`%`",
         "ja_typings": [
-          "%",
           "`%`"
         ]
       },
@@ -110915,7 +112462,6 @@
         "en": "`&`",
         "ja": "`&`",
         "ja_typings": [
-          "&",
           "`&`"
         ]
       }
@@ -110927,7 +112473,8 @@
     "question_text": {
       "en": "Which character is used to reference shell variables?",
       "ja": "シェルで変数を参照するときに使う記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110935,7 +112482,6 @@
         "en": "`%`",
         "ja": "`%`",
         "ja_typings": [
-          "%",
           "`%`"
         ]
       },
@@ -110943,7 +112489,6 @@
         "en": "`*`",
         "ja": "`*`",
         "ja_typings": [
-          "*",
           "`*`"
         ]
       },
@@ -110951,7 +112496,6 @@
         "en": "`#`",
         "ja": "`#`",
         "ja_typings": [
-          "#",
           "`#`"
         ]
       },
@@ -110959,7 +112503,6 @@
         "en": "`$`",
         "ja": "`$`",
         "ja_typings": [
-          "$",
           "`$`"
         ]
       }
@@ -110971,7 +112514,8 @@
     "question_text": {
       "en": "Which operator represents modulo in C-like languages?",
       "ja": "C系言語で剰余演算を表す記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110979,7 +112523,6 @@
         "en": "`&`",
         "ja": "`&`",
         "ja_typings": [
-          "&",
           "`&`"
         ]
       },
@@ -110987,7 +112530,6 @@
         "en": "`*`",
         "ja": "`*`",
         "ja_typings": [
-          "*",
           "`*`"
         ]
       },
@@ -110995,7 +112537,6 @@
         "en": "`@`",
         "ja": "`@`",
         "ja_typings": [
-          "@",
           "`@`"
         ]
       },
@@ -111003,7 +112544,6 @@
         "en": "`#`",
         "ja": "`#`",
         "ja_typings": [
-          "#",
           "`#`"
         ]
       }
@@ -111015,7 +112555,8 @@
     "question_text": {
       "en": "Which shell character runs a command in the background?",
       "ja": "シェルでコマンドをバックグラウンド実行する記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111023,7 +112564,6 @@
         "en": "`*`",
         "ja": "`*`",
         "ja_typings": [
-          "*",
           "`*`"
         ]
       },
@@ -111031,7 +112571,6 @@
         "en": "`&`",
         "ja": "`&`",
         "ja_typings": [
-          "&",
           "`&`"
         ]
       },
@@ -111039,7 +112578,6 @@
         "en": "`%`",
         "ja": "`%`",
         "ja_typings": [
-          "%",
           "`%`"
         ]
       },
@@ -111047,7 +112585,6 @@
         "en": "`#`",
         "ja": "`#`",
         "ja_typings": [
-          "#",
           "`#`"
         ]
       }
@@ -111059,7 +112596,8 @@
     "question_text": {
       "en": "Which operator dereferences pointers or denotes multiplication in C?",
       "ja": "C系言語でポインタの参照外しや乗算を表す記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111067,7 +112605,6 @@
         "en": "`@`",
         "ja": "`@`",
         "ja_typings": [
-          "@",
           "`@`"
         ]
       },
@@ -111075,7 +112612,6 @@
         "en": "`#`",
         "ja": "`#`",
         "ja_typings": [
-          "#",
           "`#`"
         ]
       },
@@ -111083,7 +112619,6 @@
         "en": "`$`",
         "ja": "`$`",
         "ja_typings": [
-          "$",
           "`$`"
         ]
       },
@@ -111091,7 +112626,6 @@
         "en": "`&`",
         "ja": "`&`",
         "ja_typings": [
-          "&",
           "`&`"
         ]
       }
@@ -111103,7 +112637,8 @@
     "question_text": {
       "en": "Which character marks a decorator in Python?",
       "ja": "Pythonでデコレータを表す記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111111,7 +112646,6 @@
         "en": "`await`",
         "ja": "`await`",
         "ja_typings": [
-          "await",
           "`await`"
         ]
       },
@@ -111119,7 +112653,6 @@
         "en": "`yield`",
         "ja": "`yield`",
         "ja_typings": [
-          "yield",
           "`yield`"
         ]
       },
@@ -111127,7 +112660,6 @@
         "en": "`return`",
         "ja": "`return`",
         "ja_typings": [
-          "return",
           "`return`"
         ]
       },
@@ -111135,7 +112667,6 @@
         "en": "`defer`",
         "ja": "`defer`",
         "ja_typings": [
-          "defer",
           "`defer`"
         ]
       }
@@ -111147,7 +112678,8 @@
     "question_text": {
       "en": "Which keyword in Python and JS waits for an async result?",
       "ja": "非同期関数の完了を待つPython/JSのキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111155,7 +112687,6 @@
         "en": "`def`",
         "ja": "`def`",
         "ja_typings": [
-          "def",
           "`def`"
         ]
       },
@@ -111163,7 +112694,6 @@
         "en": "`fn`",
         "ja": "`fn`",
         "ja_typings": [
-          "fn",
           "`fn`"
         ]
       },
@@ -111171,7 +112701,6 @@
         "en": "`return`",
         "ja": "`return`",
         "ja_typings": [
-          "return",
           "`return`"
         ]
       },
@@ -111179,7 +112708,6 @@
         "en": "`yield`",
         "ja": "`yield`",
         "ja_typings": [
-          "yield",
           "`yield`"
         ]
       }
@@ -111191,7 +112719,8 @@
     "question_text": {
       "en": "Which Python keyword defines a function?",
       "ja": "Pythonで関数を定義するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111199,7 +112728,6 @@
         "en": "`defer`",
         "ja": "`defer`",
         "ja_typings": [
-          "defer",
           "`defer`"
         ]
       },
@@ -111207,7 +112735,6 @@
         "en": "`await`",
         "ja": "`await`",
         "ja_typings": [
-          "await",
           "`await`"
         ]
       },
@@ -111215,7 +112742,6 @@
         "en": "`yield`",
         "ja": "`yield`",
         "ja_typings": [
-          "yield",
           "`yield`"
         ]
       },
@@ -111223,7 +112749,6 @@
         "en": "`return`",
         "ja": "`return`",
         "ja_typings": [
-          "return",
           "`return`"
         ]
       }
@@ -111235,7 +112760,8 @@
     "question_text": {
       "en": "Which Go keyword schedules a call to run when the function returns?",
       "ja": "Goで関数終了時に処理を予約するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111243,7 +112769,6 @@
         "en": "`fn`",
         "ja": "`fn`",
         "ja_typings": [
-          "fn",
           "`fn`"
         ]
       },
@@ -111251,7 +112776,6 @@
         "en": "`def`",
         "ja": "`def`",
         "ja_typings": [
-          "def",
           "`def`"
         ]
       },
@@ -111259,7 +112783,6 @@
         "en": "`return`",
         "ja": "`return`",
         "ja_typings": [
-          "return",
           "`return`"
         ]
       },
@@ -111267,7 +112790,6 @@
         "en": "`yield`",
         "ja": "`yield`",
         "ja_typings": [
-          "yield",
           "`yield`"
         ]
       }
@@ -111279,7 +112801,8 @@
     "question_text": {
       "en": "Which Rust keyword defines a function?",
       "ja": "Rustで関数を定義するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111287,7 +112810,6 @@
         "en": "`return`",
         "ja": "`return`",
         "ja_typings": [
-          "return",
           "`return`"
         ]
       },
@@ -111295,7 +112817,6 @@
         "en": "`yield`",
         "ja": "`yield`",
         "ja_typings": [
-          "yield",
           "`yield`"
         ]
       },
@@ -111303,7 +112824,6 @@
         "en": "`await`",
         "ja": "`await`",
         "ja_typings": [
-          "await",
           "`await`"
         ]
       },
@@ -111311,7 +112831,6 @@
         "en": "`defer`",
         "ja": "`defer`",
         "ja_typings": [
-          "defer",
           "`defer`"
         ]
       }
@@ -111323,7 +112842,8 @@
     "question_text": {
       "en": "Which keyword returns a value from a function in most languages?",
       "ja": "関数から値を返すための多くの言語で共通のキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111331,7 +112851,6 @@
         "en": "`yield`",
         "ja": "`yield`",
         "ja_typings": [
-          "yield",
           "`yield`"
         ]
       },
@@ -111339,7 +112858,6 @@
         "en": "`return`",
         "ja": "`return`",
         "ja_typings": [
-          "return",
           "`return`"
         ]
       },
@@ -111347,7 +112865,6 @@
         "en": "`await`",
         "ja": "`await`",
         "ja_typings": [
-          "await",
           "`await`"
         ]
       },
@@ -111355,7 +112872,6 @@
         "en": "`defer`",
         "ja": "`defer`",
         "ja_typings": [
-          "defer",
           "`defer`"
         ]
       }
@@ -111367,7 +112883,8 @@
     "question_text": {
       "en": "Which keyword produces values one at a time from a generator?",
       "ja": "ジェネレータで値を1つずつ生成するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111407,7 +112924,8 @@
     "question_text": {
       "en": "Which is the standard package installer for Python?",
       "ja": "Pythonのパッケージインストーラは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111447,7 +112965,8 @@
     "question_text": {
       "en": "Which credential string identifies a client to a web API?",
       "ja": "Web API でクライアントを識別する資格情報文字列は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111487,7 +113006,8 @@
     "question_text": {
       "en": "Which Google-backed SPA framework uses TypeScript and decorators?",
       "ja": "Google が開発した TypeScript ベースの SPA フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111527,7 +113047,8 @@
     "question_text": {
       "en": "Which HTTP status family message says credentials are required?",
       "ja": "認証情報が必要であることを示す HTTP メッセージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111567,7 +113088,8 @@
     "question_text": {
       "en": "Which early MVC JavaScript framework popularized models and collections?",
       "ja": "モデルとコレクションで知られた初期の MVC 系 JS フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111607,7 +113129,8 @@
     "question_text": {
       "en": "Which scheme sends username:password Base64-encoded in HTTP headers?",
       "ja": "ユーザー名とパスワードを Base64 で送る HTTP 認証方式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111647,7 +113170,8 @@
     "question_text": {
       "en": "Which CSS framework popularized grid systems and component classes from Twitter?",
       "ja": "Twitter 発のグリッドとコンポーネントクラスを広めた CSS フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111655,14 +113179,14 @@
         "en": "Built on UDP",
         "ja": "UDP上に構築",
         "ja_typings": [
-          "udpjounikoutiku"
+          "udpjounikouchiku"
         ]
       },
       {
         "en": "Built on TCP",
         "ja": "TCP上に構築",
         "ja_typings": [
-          "tcpjounikoutiku"
+          "tcpjounikouchiku"
         ]
       },
       {
@@ -111687,7 +113211,8 @@
     "question_text": {
       "en": "Which phrase describes the QUIC protocol's transport choice?",
       "ja": "QUIC プロトコルのトランスポート選択を表す表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111727,7 +113252,8 @@
     "question_text": {
       "en": "What collective name covers tools like webpack, Rollup, and Vite?",
       "ja": "webpack や Rollup、Vite などをまとめて指す呼称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111767,7 +113293,8 @@
     "question_text": {
       "en": "Which HTTP header lets a server declare allowed script sources?",
       "ja": "許可するスクリプト配信元をサーバーが宣言するための HTTP ヘッダの略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111807,7 +113334,8 @@
     "question_text": {
       "en": "Which rendering strategy generates HTML on the server per request?",
       "ja": "リクエストごとにサーバーで HTML を生成する描画方式の略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111847,7 +113375,8 @@
     "question_text": {
       "en": "Which attack tricks a logged-in user into submitting unwanted requests?",
       "ja": "ログイン中のユーザーに意図しないリクエストを送らせる攻撃の略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111887,7 +113416,8 @@
     "question_text": {
       "en": "What collective name describes libraries like Bootstrap and Tailwind?",
       "ja": "Bootstrap や Tailwind のようなライブラリ群の総称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111927,7 +113457,8 @@
     "question_text": {
       "en": "Which Service Worker API caches HTTP request/response pairs?",
       "ja": "Service Worker でリクエストとレスポンスのペアをキャッシュする API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111967,7 +113498,8 @@
     "question_text": {
       "en": "Which JavaScript pattern passes a function to be executed later?",
       "ja": "後で実行される関数を引数として渡す JS のパターンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112007,7 +113539,8 @@
     "question_text": {
       "en": "Which small piece of data does a server store in the user's browser?",
       "ja": "サーバーがユーザーのブラウザに保存する小さなデータは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112047,7 +113580,8 @@
     "question_text": {
       "en": "Which attack floods a service with traffic from many sources?",
       "ja": "多数のソースから大量のトラフィックでサービスを麻痺させる攻撃の略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112087,7 +113621,8 @@
     "question_text": {
       "en": "Which step resolves a domain name into an IP address?",
       "ja": "ドメイン名を IP アドレスに解決する手順は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112102,7 +113637,6 @@
         "en": "Document Object Model",
         "ja": "ドキュメントオブジェクトモデル",
         "ja_typings": [
-          "dokyumentobujekutomoderu",
           "dokyumentoobujekutomoderu"
         ]
       },
@@ -112128,7 +113662,8 @@
     "question_text": {
       "en": "Which option is a decoy expansion sometimes confused with DOM?",
       "ja": "DOM と紛らわしいダミーの展開語はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112168,7 +113703,8 @@
     "question_text": {
       "en": "Which authentication scheme hashes credentials with a server nonce?",
       "ja": "サーバーのノンスで資格情報をハッシュ化する認証方式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112183,7 +113719,6 @@
         "en": "Document Object Model",
         "ja": "ドキュメントオブジェクトモデル",
         "ja_typings": [
-          "dokyumentobujekutomoderu",
           "dokyumentoobujekutomoderu"
         ]
       },
@@ -112209,7 +113744,8 @@
     "question_text": {
       "en": "Which DOM expansion is also a decoy display-oriented term?",
       "ja": "DOM に似せたディスプレイ系の誤答候補はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112238,7 +113774,6 @@
         "en": "Document Object Model",
         "ja": "ドキュメントオブジェクトモデル",
         "ja_typings": [
-          "dokyumentobujekutomoderu",
           "dokyumentoobujekutomoderu"
         ]
       }
@@ -112250,7 +113785,8 @@
     "question_text": {
       "en": "Which DOM-like decoy uses the word 'Module' instead of 'Model'?",
       "ja": "Model ではなく Module を使った DOM 風の誤答候補は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112290,7 +113826,8 @@
     "question_text": {
       "en": "Which Chrome DevTools tab shows the live DOM tree of a page?",
       "ja": "Chrome DevTools でページの DOM ツリーを表示するタブは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112330,7 +113867,8 @@
     "question_text": {
       "en": "Which early MVC framework was built on top of Handlebars?",
       "ja": "Handlebars を採用した初期の MVC 系 JS フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112370,7 +113908,8 @@
     "question_text": {
       "en": "Which HTTP status message says the server refuses to authorize the request?",
       "ja": "サーバーが認可を拒否することを示す HTTP メッセージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112410,7 +113949,8 @@
     "question_text": {
       "en": "Which URL part follows a `#` and is not sent to the server?",
       "ja": "URL の `#` 以降にあたり、サーバーに送られない部分は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112450,7 +113990,8 @@
     "question_text": {
       "en": "Which HTTP method retrieves a resource without modifying it?",
       "ja": "リソースを変更せず取得する HTTP メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112490,7 +114031,8 @@
     "question_text": {
       "en": "Which markup language describes the structure of a web page?",
       "ja": "Web ページの構造を記述するマークアップ言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112530,7 +114072,8 @@
     "question_text": {
       "en": "Which HTTP version introduced persistent connections by default?",
       "ja": "持続的接続を既定で導入した HTTP のバージョンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112570,7 +114113,8 @@
     "question_text": {
       "en": "Which browser API stores large structured data with key-based access?",
       "ja": "キーで大きな構造化データを保存するブラウザ API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112610,7 +114154,8 @@
     "question_text": {
       "en": "Which HTTP status message indicates an unexpected server-side failure?",
       "ja": "サーバー側で予期しない失敗が起きたことを示す HTTP メッセージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112650,7 +114195,8 @@
     "question_text": {
       "en": "Which lightweight text format is widely used for web APIs?",
       "ja": "Web API で広く使われる軽量テキスト形式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112690,7 +114236,8 @@
     "question_text": {
       "en": "What collective term covers Node.js, Deno, and Bun?",
       "ja": "Node.js や Deno、Bun の総称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112730,7 +114277,8 @@
     "question_text": {
       "en": "Which network authentication protocol uses tickets and a KDC?",
       "ja": "チケットと KDC を使うネットワーク認証プロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112770,7 +114318,8 @@
     "question_text": {
       "en": "Which Core Web Vitals metric measures the largest visible content paint time?",
       "ja": "最大の可視コンテンツ描画時間を測る Core Web Vitals 指標の略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112810,7 +114359,8 @@
     "question_text": {
       "en": "Which directory access protocol underpins many enterprise auth systems?",
       "ja": "多くの企業認証の基盤になるディレクトリアクセスプロトコルの略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112850,7 +114400,8 @@
     "question_text": {
       "en": "Which technique keeps an HTTP request open until the server has data?",
       "ja": "サーバーにデータが届くまで HTTP リクエストを開いたままにする手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112890,7 +114441,8 @@
     "question_text": {
       "en": "Which standard labels content types like text/html and image/png?",
       "ja": "text/html や image/png のようにコンテンツ種別を表す標準は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112905,14 +114457,14 @@
         "en": "Optional encryption",
         "ja": "暗号化任意",
         "ja_typings": [
-          "angoukanin'i"
+          "angoukaninni"
         ]
       },
       {
         "en": "Built on UDP",
         "ja": "UDP上に構築",
         "ja_typings": [
-          "udpjounikoutiku"
+          "udpjounikouchiku"
         ]
       },
       {
@@ -112930,7 +114482,8 @@
     "question_text": {
       "en": "Which phrase describes HTTPS being required with no plaintext fallback?",
       "ja": "平文へのフォールバックなしに HTTPS を必須とする方針を表す表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112970,7 +114523,8 @@
     "question_text": {
       "en": "In GraphQL, which root operation type changes server-side data?",
       "ja": "GraphQL でサーバーのデータを変更するルート操作タイプは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113010,7 +114564,8 @@
     "question_text": {
       "en": "Which Chrome DevTools tab shows HTTP requests made by the page?",
       "ja": "ページが行った HTTP リクエストを表示する DevTools のタブは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113050,7 +114605,8 @@
     "question_text": {
       "en": "Which one-syllable word names the React-based meta-framework by Vercel?",
       "ja": "Vercel が作る React ベースのメタフレームワークの省略形は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113090,7 +114646,8 @@
     "question_text": {
       "en": "Which framework's full name pairs Next with the `.js` suffix?",
       "ja": "Next にファイル拡張子 `.js` を付けた正式名のフレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113130,7 +114687,8 @@
     "question_text": {
       "en": "Which HTTP method applies a partial update to a resource?",
       "ja": "リソースに部分的な更新を適用する HTTP メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113170,7 +114728,8 @@
     "question_text": {
       "en": "Which HTTP method replaces a resource at a given URL?",
       "ja": "指定 URL のリソースを丸ごと置き換える HTTP メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113210,7 +114769,8 @@
     "question_text": {
       "en": "Which acronym describes installable, offline-capable web apps?",
       "ja": "インストール可能でオフライン対応の Web アプリの略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113250,7 +114810,8 @@
     "question_text": {
       "en": "In GraphQL, which root operation type reads data without changing it?",
       "ja": "GraphQL でデータを変更せず読み取るルート操作タイプは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113290,7 +114851,8 @@
     "question_text": {
       "en": "Which architectural style uses URIs, verbs, and stateless servers?",
       "ja": "URI と HTTP 動詞、ステートレスサーバを用いる API アーキテクチャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113330,7 +114892,8 @@
     "question_text": {
       "en": "Which Meta-developed UI library popularized the virtual DOM?",
       "ja": "仮想 DOM を広めた Meta 製の UI ライブラリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113370,7 +114933,8 @@
     "question_text": {
       "en": "Which HTTP status message says the request was processed successfully?",
       "ja": "リクエストが正常に処理されたことを示す HTTP メッセージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113410,7 +114974,8 @@
     "question_text": {
       "en": "Which HTTP status message indicates the URL has no matching resource?",
       "ja": "URL に該当するリソースが無いことを示す HTTP メッセージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113450,7 +115015,8 @@
     "question_text": {
       "en": "Which IETF transport protocol provides message-oriented streams?",
       "ja": "メッセージ指向のストリームを提供する IETF のトランスポートプロトコルの略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113490,7 +115056,8 @@
     "question_text": {
       "en": "Which XML-based RPC protocol pre-dates REST in enterprise services?",
       "ja": "企業向けで REST 以前に広まった XML ベースの RPC プロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113530,7 +115097,8 @@
     "question_text": {
       "en": "Which browser policy restricts cross-origin scripting access by default?",
       "ja": "クロスオリジンのスクリプトアクセスを既定で制限するブラウザの方針の略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113570,7 +115138,8 @@
     "question_text": {
       "en": "Which acronym describes a client-side app that updates one HTML shell?",
       "ja": "1 枚の HTML を更新し続けるクライアント側アプリの略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113610,7 +115179,8 @@
     "question_text": {
       "en": "Which rendering strategy builds all pages at build time?",
       "ja": "ビルド時にすべてのページを生成する描画方式の略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113650,7 +115220,8 @@
     "question_text": {
       "en": "In GraphQL, which document defines the available types and fields?",
       "ja": "GraphQL で利用可能な型とフィールドを定義する文書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113690,7 +115261,8 @@
     "question_text": {
       "en": "Which identifier ties subsequent HTTP requests to one user session?",
       "ja": "後続の HTTP リクエストを 1 つのユーザーセッションに紐づける識別子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113731,7 +115303,8 @@
     "question_text": {
       "en": "Which attack steals or reuses a valid user session token?",
       "ja": "正規のセッショントークンを盗んだり再利用する攻撃は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113771,7 +115344,8 @@
     "question_text": {
       "en": "Which Web Worker variant can be reached from multiple browsing contexts?",
       "ja": "複数のブラウジングコンテキストから利用できる Web Worker は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113811,7 +115385,8 @@
     "question_text": {
       "en": "Which Chrome DevTools tab shows the original JavaScript sources?",
       "ja": "オリジナルの JavaScript ソースを表示する DevTools のタブは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113851,7 +115426,8 @@
     "question_text": {
       "en": "Which framework compiles components to plain JS at build time?",
       "ja": "コンポーネントをビルド時に素の JS にコンパイルするフレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113891,7 +115467,8 @@
     "question_text": {
       "en": "Which transport protocol provides reliable, ordered byte streams?",
       "ja": "信頼性のある順序付きバイトストリームを提供するトランスポートは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113931,7 +115508,8 @@
     "question_text": {
       "en": "Which protocol encrypts HTTP between browser and server?",
       "ja": "ブラウザとサーバ間の HTTP を暗号化するプロトコルの略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113971,7 +115549,8 @@
     "question_text": {
       "en": "Which Web Vitals metric measures the time to the first response byte?",
       "ja": "最初のレスポンスバイトまでの時間を測る Web Vitals 指標の略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114011,7 +115590,8 @@
     "question_text": {
       "en": "Which utility-first CSS framework uses class names like `flex` and `gap-4`?",
       "ja": "`flex` や `gap-4` のようなユーティリティクラス中心の CSS フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114033,7 +115613,7 @@
         "en": "Built on UDP",
         "ja": "UDP上に構築",
         "ja_typings": [
-          "udpjounikoutiku"
+          "udpjounikouchiku"
         ]
       },
       {
@@ -114051,7 +115631,8 @@
     "question_text": {
       "en": "Which phrase describes HTTP/1.1 as human-readable on the wire?",
       "ja": "HTTP/1.1 が人間可読な形式で送られることを表す表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114091,7 +115672,8 @@
     "question_text": {
       "en": "Which unit of execution is scheduled by the OS within a process?",
       "ja": "プロセス内で OS がスケジュールする実行単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114131,7 +115713,8 @@
     "question_text": {
       "en": "Which progressive JS framework was created by Evan You?",
       "ja": "Evan You が作った漸進的に採用できる JS フレームワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114171,7 +115754,8 @@
     "question_text": {
       "en": "Which worker type lets web pages run scripts off the main thread?",
       "ja": "メインスレッド外でスクリプトを実行できるワーカーの基本形は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114211,7 +115795,8 @@
     "question_text": {
       "en": "Which protocol gives full-duplex communication over a single TCP connection?",
       "ja": "1 本の TCP 接続で全二重通信を提供するプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114251,7 +115836,8 @@
     "question_text": {
       "en": "Which attack injects malicious scripts that run in other users' browsers?",
       "ja": "他ユーザーのブラウザで悪意あるスクリプトを実行させる攻撃の略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114291,7 +115877,8 @@
     "question_text": {
       "en": "Which JavaScript operator tests for strict inequality?",
       "ja": "厳密な不等価を判定する JavaScript 演算子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114331,7 +115918,8 @@
     "question_text": {
       "en": "Which symbol starts a URL fragment identifier?",
       "ja": "URL のフラグメント識別子の先頭に来る記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114371,7 +115959,8 @@
     "question_text": {
       "en": "Which symbol separates query parameters in a URL?",
       "ja": "URL のクエリパラメータを区切る記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114411,7 +116000,8 @@
     "question_text": {
       "en": "Which CSS selector matches any element?",
       "ja": "任意の要素にマッチする CSS セレクタ記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114451,7 +116041,8 @@
     "question_text": {
       "en": "Which CSS selector prefix matches by class name?",
       "ja": "クラス名で一致させる CSS セレクタの先頭記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114491,7 +116082,8 @@
     "question_text": {
       "en": "Which CSS character prefixes a pseudo-class like `:hover`?",
       "ja": "`:hover` のような擬似クラスの先頭に置かれる CSS の文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114531,7 +116123,8 @@
     "question_text": {
       "en": "Which HTML element serves responsive images via multiple `<source>` children?",
       "ja": "複数の `<source>` でレスポンシブ画像を提供する HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114571,7 +116164,8 @@
     "question_text": {
       "en": "Which JavaScript operator tests for loose equality with type coercion?",
       "ja": "型変換ありで等価を判定する JavaScript 演算子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114611,7 +116205,8 @@
     "question_text": {
       "en": "Which JavaScript operator assigns a value to a variable?",
       "ja": "JavaScript で変数に値を代入する演算子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114651,7 +116246,8 @@
     "question_text": {
       "en": "Which symbol separates a user name from a host in an email address?",
       "ja": "メールアドレスでユーザー名とホストを区切る記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114691,7 +116287,8 @@
     "question_text": {
       "en": "Which CSS shorthand property sets all four borders at once?",
       "ja": "4 辺のボーダーを一括で指定する CSS のショートハンドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114731,7 +116328,8 @@
     "question_text": {
       "en": "Which Java/Dart keyword prevents reassignment of a variable?",
       "ja": "Java や Dart で再代入を禁じる変数宣言キーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114771,7 +116369,8 @@
     "question_text": {
       "en": "Which JavaScript array method executes a callback for each element without returning a new array?",
       "ja": "新しい配列を返さず各要素にコールバックを実行する JS の配列メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114811,7 +116410,8 @@
     "question_text": {
       "en": "Which modern CSS property sets spacing between flex or grid items?",
       "ja": "Flex/Grid 項目間の間隔を指定する現代的な CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114851,7 +116451,8 @@
     "question_text": {
       "en": "Which CSS shorthand sets top/right/bottom/left for positioned elements?",
       "ja": "配置済み要素の上下左右オフセットを一括指定する CSS プロパティは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114891,7 +116492,8 @@
     "question_text": {
       "en": "Which JavaScript keyword declares a block-scoped mutable variable?",
       "ja": "ブロックスコープで可変な変数を宣言する JS キーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114931,7 +116533,8 @@
     "question_text": {
       "en": "Which JavaScript array method returns a new array with each element transformed?",
       "ja": "各要素を変換した新しい配列を返す JS の配列メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114971,7 +116574,8 @@
     "question_text": {
       "en": "Which CSS shorthand sets the outer space around an element?",
       "ja": "要素の外側の余白を一括指定する CSS のショートハンドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115011,7 +116615,8 @@
     "question_text": {
       "en": "Which CSS shorthand sets the inner space inside an element's border?",
       "ja": "要素の内側の余白を一括指定する CSS のショートハンドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115051,7 +116656,8 @@
     "question_text": {
       "en": "Which JavaScript array method reduces values to a single accumulated result?",
       "ja": "配列の値を 1 つの累積値にまとめる JS の配列メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115091,7 +116697,8 @@
     "question_text": {
       "en": "Which JavaScript array method checks whether at least one element passes a test?",
       "ja": "少なくとも 1 要素が条件を満たすかを判定する JS の配列メソッドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115131,7 +116738,8 @@
     "question_text": {
       "en": "Which Tailwind-style class word is used for inter-item gap utilities?",
       "ja": "Tailwind 系で要素間の間隔ユーティリティに使われる語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115171,7 +116779,8 @@
     "question_text": {
       "en": "Which legacy JavaScript keyword declares a function-scoped variable?",
       "ja": "関数スコープで変数を宣言する従来からの JS キーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115211,7 +116820,8 @@
     "question_text": {
       "en": "Which all-in-one JavaScript runtime by Jarred Sumner ships its own bundler?",
       "ja": "Jarred Sumner が作るバンドラ同梱の JS ランタイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115251,7 +116861,8 @@
     "question_text": {
       "en": "Which Google-made high-performance RPC framework uses HTTP/2 and protobuf?",
       "ja": "HTTP/2 と Protocol Buffers を使う Google 製の高性能 RPC は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115291,7 +116902,8 @@
     "question_text": {
       "en": "Which package manager stores dependencies in a content-addressable store with hard links?",
       "ja": "コンテンツアドレス指定のストアとハードリンクで依存を管理する Node のパッケージマネージャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115331,7 +116943,8 @@
     "question_text": {
       "en": "Which Web Storage API persists key/value pairs only until the tab closes?",
       "ja": "タブを閉じるまでキー/値を保持する Web Storage API は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115371,7 +116984,8 @@
     "question_text": {
       "en": "Which Node package manager was originally created by Facebook?",
       "ja": "Facebook が最初に作った Node のパッケージマネージャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115411,7 +117025,8 @@
     "question_text": {
       "en": "Which Public Safety Devil Hunter partners with Denji in Chainsaw Man?",
       "ja": "チェンソーマンでデンジと組む公安のデビルハンターは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115452,7 +117067,8 @@
     "question_text": {
       "en": "Which veteran voice actor is known for Ryo Saeba in City Hunter?",
       "ja": "シティーハンターの冴羽獠を演じたベテラン声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115492,7 +117108,8 @@
     "question_text": {
       "en": "Which Symbol of Peace is the No.1 hero in My Hero Academia?",
       "ja": "ヒロアカで「平和の象徴」と呼ばれる No.1 ヒーローは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115532,7 +117149,8 @@
     "question_text": {
       "en": "Which younger Elric brother has his soul bound to a suit of armor?",
       "ja": "魂を鎧に定着させた弟のエルリック兄弟は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115572,7 +117190,8 @@
     "question_text": {
       "en": "Which pink-haired telepath is the daughter in the Forger family?",
       "ja": "フォージャー家のピンク髪の超能力少女は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115612,7 +117231,8 @@
     "question_text": {
       "en": "Which short blond strategist of the Survey Corps is Eren's friend?",
       "ja": "調査兵団でエレンの友人にあたる金髪の戦略家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115620,7 +117240,7 @@
         "en": "Asuka Langley Soryu",
         "ja": "惣流・アスカ・ラングレー",
         "ja_typings": [
-          "souryuuasukarangure-"
+          "souryuu/asuka/rangure-"
         ]
       },
       {
@@ -115634,7 +117254,7 @@
         "en": "Mari Makinami",
         "ja": "真希波・マリ",
         "ja_typings": [
-          "makinamimari"
+          "makinami/mari"
         ]
       },
       {
@@ -115653,7 +117273,8 @@
     "question_text": {
       "en": "Which redheaded Eva pilot is designated the Second Child?",
       "ja": "セカンドチルドレンに指定された赤毛のエヴァパイロットは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115694,7 +117315,8 @@
     "question_text": {
       "en": "Which deep-voiced veteran voice actor is associated with characters like Dorf and General Revil?",
       "ja": "ドルフやレビル将軍などで知られる重低音のベテラン声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115734,7 +117356,8 @@
     "question_text": {
       "en": "Which masked blond Zeon ace is also known as 'the Red Comet'?",
       "ja": "「赤い彗星」と呼ばれる仮面のジオンのエースは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115742,7 +117365,7 @@
         "en": "Chimera Shadow Garden",
         "ja": "嵌合暗翳庭",
         "ja_typings": [
-          "kangouan'eitei"
+          "kangouanneitei"
         ]
       },
       {
@@ -115774,7 +117397,8 @@
     "question_text": {
       "en": "Which Domain Expansion belongs to Megumi Fushiguro in Jujutsu Kaisen?",
       "ja": "呪術廻戦で伏黒恵が使う領域展開の名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115803,7 +117427,7 @@
         "en": "Chimera Shadow Garden",
         "ja": "嵌合暗翳庭",
         "ja_typings": [
-          "kangouan'eitei"
+          "kangouanneitei"
         ]
       }
     ],
@@ -115814,7 +117438,8 @@
     "question_text": {
       "en": "Which Hashira's Domain Expansion name belongs to Muzan-adjacent foe Akaza? (decoy set: which name from JJK's signature domains is *not* in JJK?)",
       "ja": "呪術廻戦の代表的領域展開のうち、上弦ぽいけど実在しない名前はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115822,7 +117447,7 @@
         "en": "Fujiko F. Fujio",
         "ja": "藤子・F・不二雄",
         "ja_typings": [
-          "hujikofhujio"
+          "fujiko/f/fujio"
         ]
       },
       {
@@ -115854,7 +117479,8 @@
     "question_text": {
       "en": "Which manga artist created Doraemon as one half of his duo pen name?",
       "ja": "コンビ筆名の片割れとしてドラえもんを描いた漫画家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115894,7 +117520,8 @@
     "question_text": {
       "en": "Which studio produced Neon Genesis Evangelion in the 1990s?",
       "ja": "1990 年代に新世紀エヴァンゲリオンを制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115934,7 +117561,8 @@
     "question_text": {
       "en": "Which manga author created Jujutsu Kaisen?",
       "ja": "呪術廻戦の原作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -115942,7 +117570,7 @@
         "en": "Giorno Giovanna",
         "ja": "ジョルノ・ジョバァーナ",
         "ja_typings": [
-          "joruno/joba--na"
+          "joruno/jobaa-na"
         ]
       },
       {
@@ -115956,7 +117584,7 @@
         "en": "Josuke Higashikata",
         "ja": "東方仗助",
         "ja_typings": [
-          "higasikatajousuke"
+          "higashikatajousuke"
         ]
       },
       {
@@ -115974,7 +117602,8 @@
     "question_text": {
       "en": "Which blond protagonist of JoJo Part 5 wants to become a Gang-Star?",
       "ja": "ジョジョ第5部でギャングのトップを目指す金髪の主人公は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116014,7 +117643,8 @@
     "question_text": {
       "en": "Which manga author created Attack on Titan?",
       "ja": "進撃の巨人の原作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116054,7 +117684,8 @@
     "question_text": {
       "en": "Which Gainax co-founder directed the original Neon Genesis Evangelion?",
       "ja": "新世紀エヴァンゲリオンを監督した Gainax の共同創業者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116094,7 +117725,8 @@
     "question_text": {
       "en": "Which wild boar-headed Demon Slayer fights with twin nichirin blades?",
       "ja": "猪の頭をかぶり、二刀流で戦う鬼殺隊士は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116134,7 +117766,8 @@
     "question_text": {
       "en": "Which Ghibli co-founder directed Grave of the Fireflies?",
       "ja": "火垂るの墓を監督したジブリの共同創業者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116163,7 +117796,7 @@
         "en": "Giorno Giovanna",
         "ja": "ジョルノ・ジョバァーナ",
         "ja_typings": [
-          "joruno/joba--na"
+          "joruno/jobaa-na"
         ]
       }
     ],
@@ -116174,7 +117807,8 @@
     "question_text": {
       "en": "Which 19th-century English gentleman is the first JoJo of Part 1?",
       "ja": "第1部の主人公にあたる 19 世紀イギリス紳士のジョジョは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116182,14 +117816,14 @@
         "en": "Josuke Higashikata",
         "ja": "東方仗助",
         "ja_typings": [
-          "higasikatajousuke"
+          "higashikatajousuke"
         ]
       },
       {
         "en": "Giorno Giovanna",
         "ja": "ジョルノ・ジョバァーナ",
         "ja_typings": [
-          "joruno/joba--na"
+          "joruno/jobaa-na"
         ]
       },
       {
@@ -116214,7 +117848,8 @@
     "question_text": {
       "en": "Which pompadour-haired Part 4 hero protects Morioh from Stand users?",
       "ja": "杜王町を守るリーゼント髪のジョジョ第4部の主人公は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116254,7 +117889,8 @@
     "question_text": {
       "en": "Which protagonist of Zeta Gundam's sequel ZZ pilots the Double Zeta Gundam?",
       "ja": "機動戦士ガンダムZZでΖΖガンダムに乗る主人公は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116294,7 +117930,8 @@
     "question_text": {
       "en": "Which voice actor for Tobio Kageyama in Haikyu!! also voices many shōnen leads?",
       "ja": "ハイキュー!! の影山飛雄役を演じた声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116334,7 +117971,8 @@
     "question_text": {
       "en": "Which silver-haired ninja with a Sharingan eye leads Team 7 in Naruto?",
       "ja": "ナルトで第七班を率いる写輪眼を持つ銀髪の忍は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116374,7 +118012,8 @@
     "question_text": {
       "en": "Which moody Newtype pilots the Zeta Gundam in its title series?",
       "ja": "機動戦士Ζガンダムで Ζガンダムに乗るニュータイプは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116415,7 +118054,8 @@
     "question_text": {
       "en": "Which Tsuguko of the Insect Hashira wields a sword with two crescent blades?",
       "ja": "蟲柱の継子で二日月型の刀を使う鬼殺隊士は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116455,7 +118095,8 @@
     "question_text": {
       "en": "Which explosive-quirk classmate of Deku calls himself the future No.1 hero?",
       "ja": "デクの同級生で爆破個性を持ち、未来の No.1 を自称するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116478,7 +118119,7 @@
         "en": "Asuka Langley Soryu",
         "ja": "惣流・アスカ・ラングレー",
         "ja_typings": [
-          "souryuuasukarangure-"
+          "souryuu/asuka/rangure-"
         ]
       },
       {
@@ -116496,7 +118137,8 @@
     "question_text": {
       "en": "Which gray-haired Evangelion pilot is designated the Fifth Child?",
       "ja": "フィフスチルドレンに指定された灰色の髪のエヴァパイロットは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116537,7 +118179,8 @@
     "question_text": {
       "en": "Which voice actor was famous for booming villains like Raoh in Fist of the North Star?",
       "ja": "北斗の拳のラオウ等の威厳ある悪役で知られた声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116577,7 +118220,8 @@
     "question_text": {
       "en": "Which manga author created My Hero Academia?",
       "ja": "僕のヒーローアカデミアの原作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116617,7 +118261,8 @@
     "question_text": {
       "en": "Which voice actor for L (Death Note) is also known for Echizen in Prince of Tennis?",
       "ja": "デスノートのＬや越前リョーマを演じた声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116657,7 +118302,8 @@
     "question_text": {
       "en": "Which short, bald Z-Fighter is one of Goku's oldest friends?",
       "ja": "悟空の最古参の親友にあたる坊主頭の Z 戦士は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116697,7 +118343,8 @@
     "question_text": {
       "en": "Which white-haired detective in Death Note uses the alias 'L'?",
       "ja": "デスノートで L を名乗る白髪交じりの探偵の本名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116737,7 +118384,8 @@
     "question_text": {
       "en": "Which Survey Corps captain is humanity's strongest soldier?",
       "ja": "人類最強の兵士と呼ばれる調査兵団の兵長は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116777,7 +118425,8 @@
     "question_text": {
       "en": "Which Chainsaw Man character is a control devil who recruits Denji?",
       "ja": "チェンソーマンでデンジを勧誘する支配の悪魔の姿の女性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116792,7 +118441,7 @@
         "en": "Chimera Shadow Garden",
         "ja": "嵌合暗翳庭",
         "ja_typings": [
-          "kangouan'eitei"
+          "kangouanneitei"
         ]
       },
       {
@@ -116817,7 +118466,8 @@
     "question_text": {
       "en": "Which Domain Expansion belongs to Ryomen Sukuna in Jujutsu Kaisen?",
       "ja": "呪術廻戦で両面宿儺が使う領域展開の名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116857,7 +118507,8 @@
     "question_text": {
       "en": "Which director helmed Summer Wars and Mirai (Mirai no Mirai)?",
       "ja": "サマーウォーズや未来のミライを監督したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116897,7 +118548,8 @@
     "question_text": {
       "en": "Which director helmed Ghost in the Shell (1995)?",
       "ja": "1995 年の劇場版『攻殻機動隊』を監督したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116937,7 +118589,8 @@
     "question_text": {
       "en": "Which longtime Japanese voice actress played Krillin and Luffy?",
       "ja": "クリリンやルフィを演じた長年の女性声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116945,7 +118598,7 @@
         "en": "Megumi Fushiguro",
         "ja": "伏黒恵",
         "ja_typings": [
-          "fukuromegumi"
+          "fushiguromegumi"
         ]
       },
       {
@@ -116977,7 +118630,8 @@
     "question_text": {
       "en": "Which shadow-summoning sorcerer is the Ten Shadows user in JJK?",
       "ja": "呪術廻戦で十種影法術を使う影使いの呪術師は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117017,7 +118671,8 @@
     "question_text": {
       "en": "Which prolific voice actress played Rei Ayanami and Faye Valentine?",
       "ja": "綾波レイやフェイ・バレンタインを演じた女性声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117057,7 +118712,8 @@
     "question_text": {
       "en": "Which voice actress is associated with Shinji Ikari and Sailor Uranus?",
       "ja": "碇シンジや天王はるかを演じた女性声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117097,7 +118753,8 @@
     "question_text": {
       "en": "Which voice actress played Revy in Black Lagoon and Winry in FMA?",
       "ja": "ブラックラグーンのレヴィや FMA のウィンリィを演じた女性声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117137,7 +118794,8 @@
     "question_text": {
       "en": "Which black-haired Ackerman is Eren's adoptive sister and a top soldier?",
       "ja": "エレンの義妹で最強クラスの兵士、アッカーマン家の黒髪少女は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117177,7 +118835,8 @@
     "question_text": {
       "en": "Which voice actress plays Conan Edogawa in Detective Conan?",
       "ja": "名探偵コナンで江戸川コナンを演じる女性声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117217,7 +118876,8 @@
     "question_text": {
       "en": "Which Death Note heroine becomes the second Kira out of love for Light?",
       "ja": "デスノートでライトへの愛から第二のキラになるヒロインは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117258,7 +118918,8 @@
     "question_text": {
       "en": "Which Demon Slayer Love Hashira fights with a uniquely flexible katana?",
       "ja": "鬼殺隊の恋柱で柔軟な刀を扱うのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117298,7 +118959,8 @@
     "question_text": {
       "en": "Which orange-haired navigator of the Straw Hat Pirates loves money?",
       "ja": "麦わら海賊団の航海士で金が大好きなオレンジ髪の女性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117339,7 +119001,8 @@
     "question_text": {
       "en": "Which pink-clad demon-girl in a box is Tanjiro's younger sister?",
       "ja": "炭治郎の妹で、箱に入った桃色の鬼の少女は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117354,7 +119017,7 @@
         "en": "Megumi Fushiguro",
         "ja": "伏黒恵",
         "ja_typings": [
-          "fukuromegumi"
+          "fushiguromegumi"
         ]
       },
       {
@@ -117368,7 +119031,7 @@
         "en": "Maki Zenin",
         "ja": "禪院真希",
         "ja_typings": [
-          "zen'inmaki"
+          "zenninmaki"
         ]
       }
     ],
@@ -117379,7 +119042,8 @@
     "question_text": {
       "en": "Which hammer-wielding female student of Tokyo Jujutsu High wears short hair?",
       "ja": "東京呪術高専所属で金槌を扱うショートヘアの女子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117419,7 +119083,8 @@
     "question_text": {
       "en": "Which voice actress is the original Doraemon (1979–2005)?",
       "ja": "1979 年版のオリジナル・ドラえもんを演じた声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117459,7 +119124,8 @@
     "question_text": {
       "en": "Which Bleach heroine is Ichigo's longtime crush with healing powers?",
       "ja": "BLEACH で一護の幼馴染にあたる治癒能力者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117481,7 +119147,7 @@
         "en": "Fujiko F. Fujio",
         "ja": "藤子・F・不二雄",
         "ja_typings": [
-          "hujikofhujio"
+          "fujiko/f/fujio"
         ]
       },
       {
@@ -117499,7 +119165,8 @@
     "question_text": {
       "en": "Which manga artist is called 'the God of Manga' for works like Astro Boy?",
       "ja": "鉄腕アトムなどで「漫画の神様」と呼ばれる漫画家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117539,7 +119206,8 @@
     "question_text": {
       "en": "Which green-skinned Namekian is Goku's former rival turned ally?",
       "ja": "悟空の元ライバルで仲間になった緑の肌のナメック星人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117579,7 +119247,8 @@
     "question_text": {
       "en": "Which Chainsaw Man devil is Aki Hayakawa's blood-loving partner?",
       "ja": "チェンソーマンで早川アキの相棒となる血を好む悪魔は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117594,7 +119263,7 @@
         "en": "Asuka Langley Soryu",
         "ja": "惣流・アスカ・ラングレー",
         "ja_typings": [
-          "souryuuasukarangure-"
+          "souryuu/asuka/rangure-"
         ]
       },
       {
@@ -117609,7 +119278,7 @@
         "en": "Mari Makinami",
         "ja": "真希波・マリ",
         "ja_typings": [
-          "makinamimari"
+          "makinami/mari"
         ]
       }
     ],
@@ -117620,7 +119289,8 @@
     "question_text": {
       "en": "Which blue-haired Eva pilot is designated the First Child?",
       "ja": "ファーストチルドレンに指定された青髪のエヴァパイロットは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117635,7 +119305,7 @@
         "en": "Slice of life",
         "ja": "日常系",
         "ja_typings": [
-          "nitijoukei"
+          "nichijoukei"
         ]
       },
       {
@@ -117660,7 +119330,8 @@
     "question_text": {
       "en": "Which anime genre is the term for love-comedy series?",
       "ja": "恋愛コメディ系のアニメジャンルを指す英語表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117700,7 +119371,8 @@
     "question_text": {
       "en": "Which green-haired swordsman of the Straw Hats uses three swords at once?",
       "ja": "麦わら海賊団で三刀流を使う緑髪の剣士は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117740,7 +119412,8 @@
     "question_text": {
       "en": "Which Flame Alchemist colonel in FMA can snap fire from his fingers?",
       "ja": "鋼の錬金術師で指を鳴らして炎を操る大佐は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117780,7 +119453,8 @@
     "question_text": {
       "en": "Which black-haired shinigami lieutenant lent her powers to Ichigo in Bleach?",
       "ja": "BLEACH で一護に死神の力を貸した黒髪の死神は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117820,7 +119494,8 @@
     "question_text": {
       "en": "Which apple-loving shinigami drops the Death Note in the human world?",
       "ja": "リンゴ好きで人間界にデスノートを落とした死神は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117860,7 +119535,8 @@
     "question_text": {
       "en": "Which chivalrous, kicking-only chef of the Straw Hats has a curly eyebrow?",
       "ja": "麦わら海賊団で蹴り技専門のコック、ぐるぐる眉毛のキャラは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117900,7 +119576,8 @@
     "question_text": {
       "en": "Which raven-haired prodigy rival to Naruto wields the Sharingan?",
       "ja": "ナルトのライバルで写輪眼を持つ黒髪の天才忍者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117915,7 +119592,7 @@
         "en": "Megumi Fushiguro",
         "ja": "伏黒恵",
         "ja_typings": [
-          "fukuromegumi"
+          "fushiguromegumi"
         ]
       },
       {
@@ -117940,7 +119617,8 @@
     "question_text": {
       "en": "Which white-haired strongest jujutsu sorcerer wears a blindfold?",
       "ja": "目隠しを巻いた最強の呪術師は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117980,7 +119658,8 @@
     "question_text": {
       "en": "Which director helmed Perfect Blue and Paprika before his early death?",
       "ja": "パーフェクトブルーやパプリカを監督した、夭折のアニメ監督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118020,7 +119699,8 @@
     "question_text": {
       "en": "Which studio is known for Bakemonogatari and the Monogatari series?",
       "ja": "化物語など〈物語〉シリーズで知られる制作スタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118061,7 +119741,8 @@
     "question_text": {
       "en": "Which Insect Hashira fights with poison-laced thrust attacks?",
       "ja": "毒を仕込んだ突き技で戦う蟲柱は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118083,7 +119764,7 @@
         "en": "Fujiko F. Fujio",
         "ja": "藤子・F・不二雄",
         "ja_typings": [
-          "hujikofhujio"
+          "fujiko/f/fujio"
         ]
       },
       {
@@ -118101,7 +119782,8 @@
     "question_text": {
       "en": "Which manga artist created Kamen Rider and Cyborg 009?",
       "ja": "仮面ライダーやサイボーグ009を創造した漫画家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118141,7 +119823,8 @@
     "question_text": {
       "en": "Which half-and-half-haired classmate of Deku has both fire and ice quirks?",
       "ja": "デクの同級生で炎と氷の両方の個性を持つハーフカラー髪のヒーローは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118149,7 +119832,7 @@
         "en": "Slice of life",
         "ja": "日常系",
         "ja_typings": [
-          "nitijoukei"
+          "nichijoukei"
         ]
       },
       {
@@ -118181,7 +119864,8 @@
     "question_text": {
       "en": "Which anime genre label describes laid-back everyday-life shows?",
       "ja": "日々の生活をのんびり描くアニメのジャンル英語表記は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118196,7 +119880,7 @@
         "en": "Slice of life",
         "ja": "日常系",
         "ja_typings": [
-          "nitijoukei"
+          "nichijoukei"
         ]
       },
       {
@@ -118221,7 +119905,8 @@
     "question_text": {
       "en": "Which broad anime genre covers Haikyu!!, Slam Dunk, and Captain Tsubasa?",
       "ja": "ハイキュー!! や SLAM DUNK、キャプテン翼を含む広いジャンルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118261,7 +119946,8 @@
     "question_text": {
       "en": "Which Tokyo-based studio produced Spirited Away and Princess Mononoke?",
       "ja": "千と千尋の神隠しやもののけ姫を制作した東京のスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118301,7 +119987,8 @@
     "question_text": {
       "en": "Which studio is led by Hideaki Anno and produced the Rebuild of Evangelion films?",
       "ja": "庵野秀明が率い、新劇場版エヴァンゲリオンを制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118341,7 +120028,8 @@
     "question_text": {
       "en": "Which studio is the historical home of Gundam, Cowboy Bebop, and Code Geass?",
       "ja": "ガンダム、カウボーイビバップ、コードギアスの伝統的な制作スタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118381,7 +120069,8 @@
     "question_text": {
       "en": "Which manga author created Chainsaw Man and Fire Punch?",
       "ja": "チェンソーマンとファイアパンチの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118421,7 +120110,8 @@
     "question_text": {
       "en": "Which black-haired Nekoma captain in Haikyu!! tangles with Karasuno?",
       "ja": "ハイキュー!! で烏野と戦う音駒高校の黒髪キャプテンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118450,7 +120140,7 @@
         "en": "Chimera Shadow Garden",
         "ja": "嵌合暗翳庭",
         "ja_typings": [
-          "kangouan'eitei"
+          "kangouanneitei"
         ]
       }
     ],
@@ -118461,7 +120151,8 @@
     "question_text": {
       "en": "Which Jujutsu Kaisen domain belongs to Kenjaku and traps targets in time?",
       "ja": "呪術廻戦で羂索が用いる時間制圧の領域展開は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118501,7 +120192,8 @@
     "question_text": {
       "en": "Which Karasuno setter has prodigious aim and a fierce temper in Haikyu!!?",
       "ja": "ハイキュー!! の烏野のセッターで気性の荒い天才は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118541,7 +120233,8 @@
     "question_text": {
       "en": "Which classic anime studio is famous for Dragon Ball, Sailor Moon, and One Piece?",
       "ja": "ドラゴンボール、セーラームーン、ワンピースを制作した老舗スタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118582,7 +120275,8 @@
     "question_text": {
       "en": "Which iconic voice actor played Amuro Ray and Tuxedo Mask?",
       "ja": "アムロ・レイやタキシード仮面を演じた往年の男性声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118622,7 +120316,8 @@
     "question_text": {
       "en": "Which Aoba Johsai setter rivals Kageyama as 'the Grand King' in Haikyu!!?",
       "ja": "ハイキュー!! で影山のライバル、青葉城西の「大王様」と呼ばれるセッターは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118662,7 +120357,8 @@
     "question_text": {
       "en": "Which busty blonde Sannin becomes the Fifth Hokage in Naruto?",
       "ja": "ナルトで五代目火影に就任する金髪・巨乳の伝説の三忍は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118684,7 +120380,7 @@
         "en": "Chimera Shadow Garden",
         "ja": "嵌合暗翳庭",
         "ja_typings": [
-          "kangouan'eitei"
+          "kangouanneitei"
         ]
       },
       {
@@ -118702,7 +120398,8 @@
     "question_text": {
       "en": "Which Gojo domain forces total sensory input on everyone inside it?",
       "ja": "五条悟の領域展開で内部の全員に膨大な情報を流し込むのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118742,7 +120439,8 @@
     "question_text": {
       "en": "Which Bleach Quincy archer is one of Ichigo's school friends?",
       "ja": "BLEACH で一護のクラスメイトの滅却師の弓使いは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118782,7 +120480,8 @@
     "question_text": {
       "en": "Which proud Saiyan prince is Goku's longtime rival and ally?",
       "ja": "悟空のライバルにして仲間となる誇り高きサイヤ人の王子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118822,7 +120521,8 @@
     "question_text": {
       "en": "Which studio produced Attack on Titan seasons 1–3?",
       "ja": "進撃の巨人 シーズン1～3を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118862,7 +120562,8 @@
     "question_text": {
       "en": "Which blonde automail mechanic in FMA grew up with the Elric brothers?",
       "ja": "鋼の錬金術師でエルリック兄弟と幼馴染の機械鎧技師は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118902,7 +120603,8 @@
     "question_text": {
       "en": "Which masked maternal-uncle bodyguard of young Gaara dies in early Naruto?",
       "ja": "ナルト初期で幼少の我愛羅の世話役だった仮面の母方の叔父は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118942,7 +120644,8 @@
     "question_text": {
       "en": "Which dark-haired Spy x Family mother is secretly the assassin 'Thorn Princess'?",
       "ja": "スパイファミリーの母親で正体が殺し屋「いばら姫」の女性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118982,7 +120685,8 @@
     "question_text": {
       "en": "Which veteran director created Mobile Suit Gundam and is called the 'father of Gundam'?",
       "ja": "機動戦士ガンダムを生み「ガンダムの父」と呼ばれる監督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119022,7 +120726,8 @@
     "question_text": {
       "en": "Which sister-obsessed State Security officer is Yor's younger brother?",
       "ja": "スパイファミリーでヨルを溺愛する弟・国家保安局員は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119062,7 +120767,8 @@
     "question_text": {
       "en": "Which cowardly thunder-breathing Demon Slayer is in love with Nezuko?",
       "ja": "禰豆子に惚れている雷の呼吸の臆病な鬼殺隊士は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119102,7 +120808,8 @@
     "question_text": {
       "en": "Which studio is known for high-quality battle animation in Demon Slayer and Fate/Zero?",
       "ja": "鬼滅の刃や Fate/Zero の戦闘作画で知られるスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119117,7 +120824,7 @@
         "en": "Splatoon",
         "ja": "スプラトゥーン",
         "ja_typings": [
-          "supuratu-n"
+          "supuratwu-n"
         ]
       },
       {
@@ -119142,7 +120849,8 @@
     "question_text": {
       "en": "Which Nintendo Switch fighting game uses extendable arms?",
       "ja": "ニンテンドースイッチで腕が伸びる格闘ゲームはどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119182,7 +120890,8 @@
     "question_text": {
       "en": "Which company publishes Call of Duty?",
       "ja": "コール オブ デューティを発売している会社はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119222,7 +120931,8 @@
     "question_text": {
       "en": "Who is the bald assassin protagonist of the Hitman series?",
       "ja": "ヒットマンシリーズの主人公である禿頭の暗殺者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119262,7 +120972,8 @@
     "question_text": {
       "en": "Who is the Tojo Clan captain who Kiryu fought in Yakuza?",
       "ja": "龍が如くで桐生が戦う東城会の若頭は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119302,7 +121013,8 @@
     "question_text": {
       "en": "Which Respawn battle royale features Legends with unique abilities?",
       "ja": "リスポーンのバトルロイヤルでレジェンドが登場する作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119331,7 +121043,6 @@
         "en": "Shadowverse",
         "ja": "シャドウバース",
         "ja_typings": [
-          "shadoba-su",
           "shadouba-su"
         ]
       }
@@ -119343,7 +121054,8 @@
     "question_text": {
       "en": "Which mobile game features anthropomorphized warship girls?",
       "ja": "艦船を擬人化したモバイルゲームはどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119383,7 +121095,8 @@
     "question_text": {
       "en": "Which EA first-person shooter series competes with Call of Duty?",
       "ja": "EAが出すCoDのライバルとなるFPSシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119423,7 +121136,8 @@
     "question_text": {
       "en": "Which studio makes The Elder Scrolls and Fallout?",
       "ja": "エルダースクロールズやフォールアウトを作る会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119445,8 +121159,6 @@
         "en": "Guild Wars 2",
         "ja": "ギルドウォーズ2",
         "ja_typings": [
-          "girudouo-zu2",
-          "girudouo-zutsu-",
           "girudowo-zu2"
         ]
       },
@@ -119465,7 +121177,8 @@
     "question_text": {
       "en": "Which Korean MMORPG known for graphics was made by Pearl Abyss?",
       "ja": "パールアビスが開発した韓国産MMORPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119505,7 +121218,8 @@
     "question_text": {
       "en": "Which Hudson classic features a character planting bombs in a maze?",
       "ja": "ハドソンの爆弾を置く迷路ゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119545,7 +121259,8 @@
     "question_text": {
       "en": "Which Supercell game has players raiding tropical beaches?",
       "ja": "スーパーセル社の南の島を攻略するゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119560,7 +121275,7 @@
         "en": "Doom",
         "ja": "ドゥーム",
         "ja_typings": [
-          "du-mu"
+          "dwu-mu"
         ]
       },
       {
@@ -119585,7 +121300,8 @@
     "question_text": {
       "en": "Which 2K loot-shooter series features cel-shaded graphics on Pandora?",
       "ja": "2Kのトゥーン調FPSでパンドラ星を舞台にする作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119625,7 +121341,8 @@
     "question_text": {
       "en": "Which Supercell mobile game features 3v3 team brawls?",
       "ja": "スーパーセルの3対3のチーム対戦モバイルゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119665,7 +121382,8 @@
     "question_text": {
       "en": "Which Atari classic involves bouncing a ball to break bricks?",
       "ja": "ボールでブロックを崩すアタリのゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119705,7 +121423,8 @@
     "question_text": {
       "en": "Which studio created Destiny and Halo?",
       "ja": "ヘイローやデスティニーを作ったスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119745,7 +121464,8 @@
     "question_text": {
       "en": "Which competitive FPS is short for Counter-Strike: Global Offensive?",
       "ja": "カウンターストライクの略称で語られる対戦FPSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119774,7 +121494,7 @@
         "en": "Doom",
         "ja": "ドゥーム",
         "ja_typings": [
-          "du-mu"
+          "dwu-mu"
         ]
       }
     ],
@@ -119785,7 +121505,8 @@
     "question_text": {
       "en": "Which Activision FPS series has Modern Warfare entries?",
       "ja": "モダンウォーフェアを含むアクティビジョンのFPSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119825,7 +121546,8 @@
     "question_text": {
       "en": "Which Sega puzzle game involves matching colored stones in columns?",
       "ja": "セガの落ちもの宝石パズルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119865,7 +121587,8 @@
     "question_text": {
       "en": "Which CD Projekt RED dystopian RPG was released in 2020?",
       "ja": "CDプロジェクト製の2020年発売SF RPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119905,7 +121628,8 @@
     "question_text": {
       "en": "Which Sony post-apocalyptic biker game features Deacon St. John?",
       "ja": "ディーコンが主人公のソニーのバイクゾンビゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119946,7 +121670,8 @@
     "question_text": {
       "en": "Which Kojima Productions delivery game features Sam Bridges?",
       "ja": "サム・ブリッジズが配達するコジマプロの作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119975,7 +121700,7 @@
         "en": "Doom",
         "ja": "ドゥーム",
         "ja_typings": [
-          "du-mu"
+          "dwu-mu"
         ]
       }
     ],
@@ -119986,7 +121711,8 @@
     "question_text": {
       "en": "Which Quantic Dream game depicts a society of sentient androids?",
       "ja": "クアンティック・ドリームのアンドロイドが主役の作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120008,7 +121734,6 @@
         "en": "Shadowrun",
         "ja": "シャドウラン",
         "ja_typings": [
-          "shadoran",
           "shadouran"
         ]
       },
@@ -120027,7 +121752,8 @@
     "question_text": {
       "en": "Which cyberpunk RPG series features augmented agent Adam Jensen?",
       "ja": "アダム・ジェンセンが主人公のサイバーパンクRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120067,7 +121793,8 @@
     "question_text": {
       "en": "Which Namco classic involves a character pumping up underground monsters?",
       "ja": "地中の敵を膨らませて倒すナムコのゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120075,7 +121802,7 @@
         "en": "Doom",
         "ja": "ドゥーム",
         "ja_typings": [
-          "du-mu"
+          "dwu-mu"
         ]
       },
       {
@@ -120107,7 +121834,8 @@
     "question_text": {
       "en": "Which id Software FPS features a Space Marine fighting demons?",
       "ja": "id Softwareの悪魔を倒す宇宙海兵FPSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120115,8 +121843,7 @@
         "en": "Dota 2",
         "ja": "ドータ2",
         "ja_typings": [
-          "do-ta2",
-          "do-tatsu-"
+          "do-ta2"
         ]
       },
       {
@@ -120148,7 +121875,8 @@
     "question_text": {
       "en": "Which Valve MOBA features heroes battling for ancients?",
       "ja": "Valveのエンシェントを破壊するMOBAは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120188,7 +121916,8 @@
     "question_text": {
       "en": "Which Game Boy puzzle game has Mario throwing pills at viruses?",
       "ja": "マリオがウイルスを薬で倒すゲームボーイのパズルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120196,32 +121925,28 @@
         "en": "Dragon Quest X",
         "ja": "ドラゴンクエストX",
         "ja_typings": [
-          "doragonkuesutox",
-          "doragonkuesutoten"
+          "doragonkuesutox"
         ]
       },
       {
         "en": "Dragon Quest IX",
         "ja": "ドラゴンクエストIX",
         "ja_typings": [
-          "doragonkuesutoix",
-          "doragonkuesutonain"
+          "doragonkuesutoix"
         ]
       },
       {
         "en": "Dragon Quest XI",
         "ja": "ドラゴンクエストXI",
         "ja_typings": [
-          "doragonkuesutoxi",
-          "doragonkuesutoirebun"
+          "doragonkuesutoxi"
         ]
       },
       {
         "en": "Dragon Quest VIII",
         "ja": "ドラゴンクエストVIII",
         "ja_typings": [
-          "doragonkuesutoviii",
-          "doragonkuesutoeito"
+          "doragonkuesutoviii"
         ]
       }
     ],
@@ -120232,7 +121957,8 @@
     "question_text": {
       "en": "Which Dragon Quest entry is the MMORPG numbered ten?",
       "ja": "ドラクエシリーズで唯一のMMORPGの番号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120272,7 +121998,8 @@
     "question_text": {
       "en": "Which company makes Unreal Engine and Fortnite?",
       "ja": "アンリアルエンジンとフォートナイトの会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120294,8 +122021,6 @@
         "en": "Guild Wars 2",
         "ja": "ギルドウォーズ2",
         "ja_typings": [
-          "girudouo-zu2",
-          "girudouo-zutsu-",
           "girudowo-zu2"
         ]
       },
@@ -120314,7 +122039,8 @@
     "question_text": {
       "en": "Which classic Sony Online MMORPG predated World of Warcraft?",
       "ja": "WoW登場以前のソニー製代表的MMORPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120354,7 +122080,8 @@
     "question_text": {
       "en": "Which Bethesda post-apocalyptic RPG features Vault Boy?",
       "ja": "ベセスダのVault Boyが象徴のポストアポカリプスRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120394,7 +122121,8 @@
     "question_text": {
       "en": "Which SEGA Sports Interactive series simulates soccer team management?",
       "ja": "セガが出すサッカークラブ経営シミュは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120434,7 +122162,8 @@
     "question_text": {
       "en": "Which Namco shooter has insects forming attack formations?",
       "ja": "編隊で攻撃してくるナムコのシューティングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120474,7 +122203,8 @@
     "question_text": {
       "en": "Which Namco shooter from 1979 preceded Galaga?",
       "ja": "ギャラガの前作にあたる1979年のナムコ作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120515,7 +122245,8 @@
     "question_text": {
       "en": "Which Sucker Punch samurai game is set on a Mongol-invaded island?",
       "ja": "サッカーパンチ社の蒙古襲来を舞台にしたサムライ作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120555,7 +122286,8 @@
     "question_text": {
       "en": "Who founded Grasshopper Manufacture and directed No More Heroes?",
       "ja": "ノーモア★ヒーローズを生んだグラスホッパー創業者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120595,7 +122327,8 @@
     "question_text": {
       "en": "Who is the eyepatch-wearing Mad Dog of Shimano in Yakuza?",
       "ja": "龍が如くで眼帯姿の嶋野の狂犬は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120617,7 +122350,6 @@
         "en": "Shadowverse",
         "ja": "シャドウバース",
         "ja_typings": [
-          "shadoba-su",
           "shadouba-su"
         ]
       },
@@ -120636,7 +122368,8 @@
     "question_text": {
       "en": "Which Cygames fantasy mobile RPG features sky-faring adventurers?",
       "ja": "サイゲームスの空の旅を描くファンタジーRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120644,8 +122377,6 @@
         "en": "Guild Wars 2",
         "ja": "ギルドウォーズ2",
         "ja_typings": [
-          "girudouo-zu2",
-          "girudouo-zutsu-",
           "girudowo-zu2"
         ]
       },
@@ -120678,7 +122409,8 @@
     "question_text": {
       "en": "Which ArenaNet MMORPG sequel released in 2012 has no monthly fee?",
       "ja": "アリーナネットの月額無料MMORPG続編は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120718,7 +122450,8 @@
     "question_text": {
       "en": "Who created the Game & Watch and Game Boy at Nintendo?",
       "ja": "ゲーム&ウオッチとゲームボーイの生みの親は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120758,7 +122491,8 @@
     "question_text": {
       "en": "Which action game genre is abbreviated H&S?",
       "ja": "ハクスラとも呼ばれるアクションゲームのジャンルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120798,7 +122532,8 @@
     "question_text": {
       "en": "Which Niantic AR game uses the Harry Potter universe?",
       "ja": "ナイアンティックのハリーポッターAR位置情報ゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120838,7 +122573,8 @@
     "question_text": {
       "en": "Which Supercell game has players running a small farm?",
       "ja": "スーパーセル製の農場経営モバイルゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120853,8 +122589,7 @@
         "en": "Dota 2",
         "ja": "ドータ2",
         "ja_typings": [
-          "do-ta2",
-          "do-tatsu-"
+          "do-ta2"
         ]
       },
       {
@@ -120879,7 +122614,8 @@
     "question_text": {
       "en": "Which Blizzard MOBA features characters from across its franchises?",
       "ja": "ブリザード全作品のキャラが集うMOBAは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120919,7 +122655,8 @@
     "question_text": {
       "en": "Who directed Bayonetta and founded PlatinumGames?",
       "ja": "ベヨネッタの監督でプラチナゲームズ創業者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120959,7 +122696,8 @@
     "question_text": {
       "en": "Who created Metal Gear Solid and Death Stranding?",
       "ja": "メタルギアやデス・ストランディングの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120999,7 +122737,8 @@
     "question_text": {
       "en": "Who created the Final Fantasy series at Square?",
       "ja": "ファイナルファンタジーシリーズの生みの親は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121039,7 +122778,8 @@
     "question_text": {
       "en": "Which HoYoverse space-themed turn-based RPG launched in 2023?",
       "ja": "ホヨバースの2023年宇宙ターン制RPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121079,7 +122819,8 @@
     "question_text": {
       "en": "Who is the protagonist of Yakuza: Like a Dragon?",
       "ja": "龍が如く7の主人公は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121119,7 +122860,8 @@
     "question_text": {
       "en": "Which Niantic AR game predated Pokemon GO?",
       "ja": "ナイアンティックがポケモンGOより前に出した位置情報ARゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121159,7 +122901,8 @@
     "question_text": {
       "en": "Which Square board-game series features Dragon Quest characters?",
       "ja": "ドラクエキャラが登場するスクウェアの双六ゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121188,7 +122931,7 @@
         "en": "Sly Cooper",
         "ja": "怪盗スライ",
         "ja_typings": [
-          "kaitousuraikuupaa"
+          "kaitousurai"
         ]
       }
     ],
@@ -121199,7 +122942,8 @@
     "question_text": {
       "en": "Which Naughty Dog PS2 platformer pairs a boy with a furry sidekick?",
       "ja": "ノーティードッグのPS2ジャンプアクションは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121239,7 +122983,8 @@
     "question_text": {
       "en": "Who created Mega Man at Capcom?",
       "ja": "カプコンでロックマンを生んだ人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121279,7 +123024,8 @@
     "question_text": {
       "en": "Who created the original Dragon Quest game system at Chunsoft?",
       "ja": "ドラクエ初代のプログラマでチュンソフト創業者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121308,8 +123054,6 @@
         "en": "Guild Wars 2",
         "ja": "ギルドウォーズ2",
         "ja_typings": [
-          "girudouo-zu2",
-          "girudouo-zutsu-",
           "girudowo-zu2"
         ]
       }
@@ -121321,7 +123065,8 @@
     "question_text": {
       "en": "Which Smilegate MMORPG with isometric view launched globally in 2022?",
       "ja": "スマイルゲートの2022年世界配信トップダウンMMORPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121361,7 +123106,8 @@
     "question_text": {
       "en": "Which genre includes League of Legends and Dota 2?",
       "ja": "LoLやDota 2のジャンル名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121401,7 +123147,8 @@
     "question_text": {
       "en": "Which Nintendo racing series features banana peels and shells?",
       "ja": "甲羅やバナナを投げる任天堂レースゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121441,7 +123188,8 @@
     "question_text": {
       "en": "Which Nintendo party game series features minigame board play?",
       "ja": "ミニゲーム集の任天堂パーティーゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121481,7 +123229,8 @@
     "question_text": {
       "en": "Who directed Super Smash Bros. and Kirby?",
       "ja": "スマブラやカービィの生みの親は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121503,7 +123252,7 @@
         "en": "Doom",
         "ja": "ドゥーム",
         "ja_typings": [
-          "du-mu"
+          "dwu-mu"
         ]
       },
       {
@@ -121521,7 +123270,8 @@
     "question_text": {
       "en": "Which EA WWII FPS series competed with early Call of Duty?",
       "ja": "EAの第二次大戦FPSで初期CoDの競合は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121561,7 +123311,8 @@
     "question_text": {
       "en": "Which Capcom blue-armored robot hero series began in 1987?",
       "ja": "1987年に始まった青い鎧のカプコンロボットは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121601,7 +123352,8 @@
     "question_text": {
       "en": "Which Konami baseball series features pixel-style players?",
       "ja": "燃えろプロ野球の二頭身プロ野球ゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121642,7 +123394,8 @@
     "question_text": {
       "en": "Which Capcom action series has hunters slaying giant beasts?",
       "ja": "巨大モンスターを狩るカプコン代表作は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121682,7 +123435,8 @@
     "question_text": {
       "en": "Which 1980 Nichibutsu shooter sequel to Cosmos features docking?",
       "ja": "三段ロケットがドッキングする日物のシューティングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121722,7 +123476,8 @@
     "question_text": {
       "en": "Who is the Final Fantasy XIII director at Square Enix?",
       "ja": "FF13シリーズの監督を務めたスクエニ社員は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121730,16 +123485,14 @@
         "en": "Nintendo 3DS",
         "ja": "ニンテンドー3DS",
         "ja_typings": [
-          "nintendo-3ds",
-          "nintendo-suri-dei-esu"
+          "nintendo-3ds"
         ]
       },
       {
         "en": "Nintendo DS",
         "ja": "ニンテンドーDS",
         "ja_typings": [
-          "nintendo-ds",
-          "nintendo-dei-esu"
+          "nintendo-ds"
         ]
       },
       {
@@ -121764,7 +123517,8 @@
     "question_text": {
       "en": "Which Nintendo handheld introduced stereoscopic 3D without glasses?",
       "ja": "裸眼3D表示を搭載した任天堂の携帯機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121772,16 +123526,14 @@
         "en": "Nintendo DS",
         "ja": "ニンテンドーDS",
         "ja_typings": [
-          "nintendo-ds",
-          "nintendo-dei-esu"
+          "nintendo-ds"
         ]
       },
       {
         "en": "Nintendo 3DS",
         "ja": "ニンテンドー3DS",
         "ja_typings": [
-          "nintendo-3ds",
-          "nintendo-suri-dei-esu"
+          "nintendo-3ds"
         ]
       },
       {
@@ -121806,7 +123558,8 @@
     "question_text": {
       "en": "Which Nintendo dual-screen handheld launched in 2004?",
       "ja": "2004年発売の任天堂二画面携帯機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121846,7 +123599,8 @@
     "question_text": {
       "en": "Which Blizzard hero shooter features Tracer and Reinhardt?",
       "ja": "トレーサーやラインハルトが登場するブリザードのFPSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121886,7 +123640,8 @@
     "question_text": {
       "en": "Which Mario spin-off RPG uses 2D paper visuals?",
       "ja": "紙のような2D表現を使うマリオRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121908,7 +123663,7 @@
         "en": "Splatoon",
         "ja": "スプラトゥーン",
         "ja_typings": [
-          "supuratu-n"
+          "supuratwu-n"
         ]
       },
       {
@@ -121926,7 +123681,8 @@
     "question_text": {
       "en": "Which Miyamoto strategy series has players directing tiny plant creatures?",
       "ja": "宮本茂作の植物人間を率いる戦略アクションは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121966,7 +123722,8 @@
     "question_text": {
       "en": "Which Niantic walking-AR app uses Pikmin to track steps?",
       "ja": "ピクミンが歩数を彩るナイアンティックの散歩アプリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122006,7 +123763,8 @@
     "question_text": {
       "en": "Which Sony game console brand started in 1994?",
       "ja": "1994年発売のソニー据置ゲーム機ブランドは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122046,7 +123804,8 @@
     "question_text": {
       "en": "Which Sony streaming handheld plays PS5 games over Wi-Fi?",
       "ja": "PS5の映像をWi-Fi越しに遊ぶソニーの携帯端末は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122075,7 +123834,7 @@
         "en": "Doom",
         "ja": "ドゥーム",
         "ja_typings": [
-          "du-mu"
+          "dwu-mu"
         ]
       }
     ],
@@ -122086,7 +123845,8 @@
     "question_text": {
       "en": "Which Valve puzzle game features a portal-creating gun?",
       "ja": "ポータルを撃つValveのパズルゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122115,7 +123875,6 @@
         "en": "Shadowverse",
         "ja": "シャドウバース",
         "ja_typings": [
-          "shadoba-su",
           "shadouba-su"
         ]
       }
@@ -122127,7 +123886,8 @@
     "question_text": {
       "en": "Which Cygames anime-style mobile RPG features a guild of girls?",
       "ja": "サイゲームスの美少女ギルド系モバイルRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122167,7 +123927,8 @@
     "question_text": {
       "en": "Which Konami baseball series is abbreviated as Pro Spi?",
       "ja": "プロスピと略されるコナミ野球ゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122207,7 +123968,8 @@
     "question_text": {
       "en": "Which Konami simulation series is the official Pro Yakyu game?",
       "ja": "プロ野球の正式ライセンスを持つコナミの本格野球シミュは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122247,7 +124009,8 @@
     "question_text": {
       "en": "Which Compile/Sega puzzle game features chain-clearing colored blobs?",
       "ja": "連鎖で消すコンパイル/セガのカラフルパズルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122262,7 +124025,7 @@
         "en": "Doom",
         "ja": "ドゥーム",
         "ja_typings": [
-          "du-mu"
+          "dwu-mu"
         ]
       },
       {
@@ -122287,7 +124050,8 @@
     "question_text": {
       "en": "Which id Software FPS succeeded Doom with full 3D graphics?",
       "ja": "ドゥームに続くid Softwareの3D FPSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122327,7 +124091,8 @@
     "question_text": {
       "en": "Which ASUS Windows handheld competes with Steam Deck?",
       "ja": "Steam Deckの競合となるASUSのWindows携帯機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122367,7 +124132,8 @@
     "question_text": {
       "en": "Which genre includes Final Fantasy and Dragon Quest?",
       "ja": "FFやドラクエが代表するジャンル名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122407,7 +124173,8 @@
     "question_text": {
       "en": "Which genre includes StarCraft and Age of Empires?",
       "ja": "StarCraftやAge of Empiresのジャンル名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122447,7 +124214,8 @@
     "question_text": {
       "en": "Which Ubisoft tactical shooter is named after Tom Clancy's novel?",
       "ja": "トム・クランシー原作のユービーアイ戦術シューターは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122487,7 +124255,8 @@
     "question_text": {
       "en": "Which 2015 Ubisoft 5v5 attack-defend shooter became an esports staple?",
       "ja": "2015年発売の5対5攻防シューター(R6)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122516,7 +124285,7 @@
         "en": "Sly Cooper",
         "ja": "怪盗スライ",
         "ja_typings": [
-          "kaitousuraikuupaa"
+          "kaitousurai"
         ]
       }
     ],
@@ -122527,7 +124296,8 @@
     "question_text": {
       "en": "Which Insomniac PS series pairs a lombax with a robot?",
       "ja": "ロンバックスとロボットが冒険するインソムニアックの作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122556,8 +124326,7 @@
         "en": "Dota 2",
         "ja": "ドータ2",
         "ja_typings": [
-          "do-ta2",
-          "do-tatsu-"
+          "do-ta2"
         ]
       }
     ],
@@ -122568,7 +124337,8 @@
     "question_text": {
       "en": "Which Psyonix game combines soccer with rocket-powered cars?",
       "ja": "ロケット推進の車でサッカーをするPsyonixのゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122608,7 +124378,8 @@
     "question_text": {
       "en": "Which Marvelous farming RPG was once called Harvest Moon overseas?",
       "ja": "海外でハーベストムーン名義だった牧場経営RPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122648,7 +124419,8 @@
     "question_text": {
       "en": "Which Sega series features the Imperial Floral Assault Troupe?",
       "ja": "帝国華撃団が活躍するセガの作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122688,7 +124460,8 @@
     "question_text": {
       "en": "Who is the bald Splinter Cell stealth agent?",
       "ja": "スプリンターセルの主人公の禿頭スパイは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122728,7 +124501,8 @@
     "question_text": {
       "en": "Who was the Nintendo president and HAL Laboratory programmer?",
       "ja": "任天堂社長を務めた元HAL研プログラマは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122768,7 +124542,8 @@
     "question_text": {
       "en": "Who founded Game Freak and created Pokemon?",
       "ja": "ゲームフリークを創業しポケモンを生んだ人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122809,7 +124584,8 @@
     "question_text": {
       "en": "Which FromSoftware Sengoku-era stealth-action game won Game of the Year 2019?",
       "ja": "2019年GOTYのフロムソフトウェア戦国忍者ゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122849,7 +124625,8 @@
     "question_text": {
       "en": "Which Capcom series features over-the-top Sengoku warriors?",
       "ja": "派手な戦国武将アクションのカプコン作は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122857,7 +124634,6 @@
         "en": "Shadowrun",
         "ja": "シャドウラン",
         "ja_typings": [
-          "shadoran",
           "shadouran"
         ]
       },
@@ -122865,7 +124641,6 @@
         "en": "Shadowverse",
         "ja": "シャドウバース",
         "ja_typings": [
-          "shadoba-su",
           "shadouba-su"
         ]
       },
@@ -122891,7 +124666,8 @@
     "question_text": {
       "en": "Which tabletop-origin RPG mixes cyberpunk with fantasy races?",
       "ja": "サイバーパンクとファンタジー種族が混ざるテーブルトークRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122899,7 +124675,6 @@
         "en": "Shadowverse",
         "ja": "シャドウバース",
         "ja_typings": [
-          "shadoba-su",
           "shadouba-su"
         ]
       },
@@ -122907,7 +124682,6 @@
         "en": "Shadowrun",
         "ja": "シャドウラン",
         "ja_typings": [
-          "shadoran",
           "shadouran"
         ]
       },
@@ -122933,7 +124707,8 @@
     "question_text": {
       "en": "Which Cygames digital card battler launched in 2016?",
       "ja": "サイゲームスの2016年デジタルカードゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122973,7 +124748,8 @@
     "question_text": {
       "en": "Who directed Resident Evil 1 and founded Tango Gameworks?",
       "ja": "バイオハザード1の監督でタンゴ創業者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122988,8 +124764,7 @@
         "en": "Dota 2",
         "ja": "ドータ2",
         "ja_typings": [
-          "do-ta2",
-          "do-tatsu-"
+          "do-ta2"
         ]
       },
       {
@@ -123014,7 +124789,8 @@
     "question_text": {
       "en": "Which MOBA features gods and mythological figures in third-person view?",
       "ja": "神話のキャラがTPS視点で戦うMOBAは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123054,7 +124830,8 @@
     "question_text": {
       "en": "Which 1978 Taito arcade game popularized the shooter genre?",
       "ja": "1978年タイトーの和製シューティングの金字塔は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123062,7 +124839,7 @@
         "en": "Splatoon",
         "ja": "スプラトゥーン",
         "ja_typings": [
-          "supuratu-n"
+          "supuratwu-n"
         ]
       },
       {
@@ -123094,7 +124871,8 @@
     "question_text": {
       "en": "Which Nintendo shooter has squids inking turf?",
       "ja": "イカが街にインクを塗る任天堂のシューターは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123109,7 +124887,7 @@
         "en": "Splatoon",
         "ja": "スプラトゥーン",
         "ja_typings": [
-          "supuratu-n"
+          "supuratwu-n"
         ]
       },
       {
@@ -123134,7 +124912,8 @@
     "question_text": {
       "en": "Which Nintendo on-rails shooter stars a fox pilot?",
       "ja": "キツネのパイロットが宇宙を飛ぶ任天堂作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123174,7 +124953,8 @@
     "question_text": {
       "en": "Which Valve handheld runs SteamOS and launched in 2022?",
       "ja": "SteamOSを搭載する2022年Valveの携帯機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123214,7 +124994,8 @@
     "question_text": {
       "en": "Which Marvelous farm simulation is the rebrand of Bokujou Monogatari?",
       "ja": "牧場物語の海外向け新ブランド名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123254,7 +125035,8 @@
     "question_text": {
       "en": "Which company owns Rockstar Games and 2K?",
       "ja": "ロックスターと2Kを傘下に持つ会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123294,7 +125076,8 @@
     "question_text": {
       "en": "Which Valve class-based shooter is famous for the Sandvich?",
       "ja": "サンドビッチで知られるValveのクラスFPSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123334,7 +125117,8 @@
     "question_text": {
       "en": "Who is the Final Fantasy character designer behind Kingdom Hearts?",
       "ja": "キングダムハーツのキャラデザを担当したFF美術家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123374,7 +125158,8 @@
     "question_text": {
       "en": "Which Bethesda fantasy RPG series includes Skyrim and Oblivion?",
       "ja": "スカイリムやオブリビオンを擁するベセスダのRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123414,7 +125199,8 @@
     "question_text": {
       "en": "Which classic Hasbro board game simulates birth-to-retirement?",
       "ja": "誕生から引退までを辿るハズブロのボードゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123422,7 +125208,7 @@
         "en": "The Legend of Zelda: Skyward Sword",
         "ja": "ゼルダの伝説 スカイウォードソード",
         "ja_typings": [
-          "zerudanodensetsusukaiwa-dosa-do"
+          "zerudanodensetsusukaiwo-doso-do"
         ]
       },
       {
@@ -123454,7 +125240,8 @@
     "question_text": {
       "en": "Which Zelda title introduced motion-controlled sword combat on Wii?",
       "ja": "Wiiで剣のモーション操作を導入したゼルダは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123469,7 +125256,7 @@
         "en": "The Legend of Zelda: Skyward Sword",
         "ja": "ゼルダの伝説 スカイウォードソード",
         "ja_typings": [
-          "zerudanodensetsusukaiwa-dosa-do"
+          "zerudanodensetsusukaiwo-doso-do"
         ]
       },
       {
@@ -123494,7 +125281,8 @@
     "question_text": {
       "en": "Which 2023 Switch Zelda sequel features a sky-falling Hyrule?",
       "ja": "2023年発売のスイッチのゼルダ続編は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123509,7 +125297,7 @@
         "en": "The Legend of Zelda: Skyward Sword",
         "ja": "ゼルダの伝説 スカイウォードソード",
         "ja_typings": [
-          "zerudanodensetsusukaiwa-dosa-do"
+          "zerudanodensetsusukaiwo-doso-do"
         ]
       },
       {
@@ -123534,7 +125322,8 @@
     "question_text": {
       "en": "Which 2006 Wii/GC Zelda features Link transforming into a wolf?",
       "ja": "リンクが狼になる2006年のゼルダ作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123575,7 +125364,8 @@
     "question_text": {
       "en": "Which Square Enix series stars Lara Croft as a treasure hunter?",
       "ja": "ララ・クロフトが活躍するスクエニの冒険シリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123615,7 +125405,8 @@
     "question_text": {
       "en": "Who is the founder of Team Ninja and director of Ninja Gaiden?",
       "ja": "Team Ninja創設者でニンジャガイデン監督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123655,7 +125446,8 @@
     "question_text": {
       "en": "Which Hotta Studio open-world MMORPG resembles Genshin Impact?",
       "ja": "原神に類似した中国産オープンワールドMMORPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123695,7 +125487,8 @@
     "question_text": {
       "en": "Which strategy genre is abbreviated TBS?",
       "ja": "TBSと略される戦略ゲームのジャンルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123735,7 +125528,8 @@
     "question_text": {
       "en": "Which French publisher makes Assassin's Creed?",
       "ja": "アサシンクリードのフランスの発売会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123775,7 +125569,8 @@
     "question_text": {
       "en": "Which Naughty Dog series stars treasure hunter Nathan Drake?",
       "ja": "ネイサン・ドレイクが活躍するノーティードッグ作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123815,7 +125610,8 @@
     "question_text": {
       "en": "Which Riot Games tactical 5v5 shooter launched in 2020?",
       "ja": "2020年公開のライオット製5対5戦術FPSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123855,7 +125651,8 @@
     "question_text": {
       "en": "Which narrative game genre features text and character art (NVL)?",
       "ja": "立ち絵とテキストで物語を進めるADVのジャンル名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123877,8 +125674,7 @@
         "en": "Nintendo 3DS",
         "ja": "ニンテンドー3DS",
         "ja_typings": [
-          "nintendo-3ds",
-          "nintendo-suri-dei-esu"
+          "nintendo-3ds"
         ]
       },
       {
@@ -123896,7 +125692,8 @@
     "question_text": {
       "en": "Which Nintendo home console launched in 2012 had a tablet controller?",
       "ja": "タブレット型コントローラの2012年任天堂据置機は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123936,7 +125733,8 @@
     "question_text": {
       "en": "Which Konami soccer series was rebranded to eFootball?",
       "ja": "eFootballに改名されたコナミのサッカーシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123976,7 +125774,8 @@
     "question_text": {
       "en": "Which CD Projekt RED series follows Geralt of Rivia?",
       "ja": "ゲラルトが主人公のCD Projekt RPGシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123998,8 +125797,6 @@
         "en": "Guild Wars 2",
         "ja": "ギルドウォーズ2",
         "ja_typings": [
-          "girudouo-zu2",
-          "girudouo-zutsu-",
           "girudowo-zu2"
         ]
       },
@@ -124018,7 +125815,8 @@
     "question_text": {
       "en": "Which Blizzard MMORPG launched in 2004 and dominated the genre?",
       "ja": "2004年公開のブリザード製MMORPGの代名詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124058,7 +125856,8 @@
     "question_text": {
       "en": "Which Namco 1982 vertical-scrolling shooter features Solvalou?",
       "ja": "ソルバルウが主人公の1982年ナムコ縦シューは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124098,7 +125897,8 @@
     "question_text": {
       "en": "Who is the creator of the Dragon Quest series?",
       "ja": "ドラゴンクエストシリーズの生みの親は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124138,7 +125938,8 @@
     "question_text": {
       "en": "Who programmed Sonic the Hedgehog at Sega?",
       "ja": "セガのソニックを生んだプログラマは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124178,7 +125979,8 @@
     "question_text": {
       "en": "In which year did the French Revolution begin?",
       "ja": "フランス革命が勃発した年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124218,7 +126020,8 @@
     "question_text": {
       "en": "In which year did the War of 1812 between the US and Britain begin?",
       "ja": "米英戦争が始まった年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124258,7 +126061,8 @@
     "question_text": {
       "en": "In which year did the American Civil War end?",
       "ja": "アメリカ南北戦争が終結した年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124298,7 +126102,8 @@
     "question_text": {
       "en": "Which Islamic caliphate ruled from Baghdad starting in 750?",
       "ja": "750年からバグダッドで統治したイスラム王朝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124339,7 +126144,8 @@
     "question_text": {
       "en": "Which Russian envoy arrived in Nemuro in 1792 demanding trade with Japan?",
       "ja": "1792年に根室に来航し通商を要求したロシア使節は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124379,7 +126185,8 @@
     "question_text": {
       "en": "Who led Nazi Germany during World War II?",
       "ja": "第二次大戦時のナチス・ドイツの指導者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124419,7 +126226,8 @@
     "question_text": {
       "en": "Who was the first US Secretary of the Treasury?",
       "ja": "アメリカ初代財務長官は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124459,7 +126267,8 @@
     "question_text": {
       "en": "Who led Russia's Provisional Government in 1917 before the Bolsheviks?",
       "ja": "1917年ロシア臨時政府を率いた人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124499,7 +126308,8 @@
     "question_text": {
       "en": "Which 1941 Japanese strike brought the US into WWII?",
       "ja": "1941年に米国を参戦させた日本の奇襲は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124539,7 +126349,8 @@
     "question_text": {
       "en": "Which 1942-43 battle marked the turning point on the Eastern Front?",
       "ja": "1942-43年東部戦線の転換点となった戦いは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124547,7 +126358,7 @@
         "en": "Behistun Inscription",
         "ja": "ベヒストゥン碑文",
         "ja_typings": [
-          "behisutunhibun"
+          "behisutwunhibun"
         ]
       },
       {
@@ -124579,7 +126390,8 @@
     "question_text": {
       "en": "Which Iranian trilingual inscription helped decipher cuneiform?",
       "ja": "楔形文字解読の鍵となったイランの三言語碑文は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124619,7 +126431,8 @@
     "question_text": {
       "en": "Who flew a kite during a thunderstorm and signed the Declaration of Independence?",
       "ja": "雷雨に凧を上げ独立宣言にも署名した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124659,7 +126472,8 @@
     "question_text": {
       "en": "Which B-29 dropped the atomic bomb on Nagasaki?",
       "ja": "長崎に原爆を投下したB-29の機名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124699,7 +126513,8 @@
     "question_text": {
       "en": "Which 1900 anti-foreign uprising in China was suppressed by an eight-nation alliance?",
       "ja": "1900年に8カ国連合軍が鎮圧した中国の排外運動は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124739,7 +126554,8 @@
     "question_text": {
       "en": "Who was the second American to walk on the Moon, after Armstrong?",
       "ja": "アームストロングに次いで月面に立ったアメリカ人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124754,7 +126570,6 @@
         "en": "Crossbow",
         "ja": "クロスボウ",
         "ja_typings": [
-          "kurosubo",
           "kurosubou"
         ]
       },
@@ -124780,7 +126595,8 @@
     "question_text": {
       "en": "Which gunpowder weapon revolutionized warfare in the late Middle Ages?",
       "ja": "中世末期に戦争を変えた火薬兵器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124820,7 +126636,8 @@
     "question_text": {
       "en": "Which Wei king during China's Three Kingdoms period is known as a brilliant strategist?",
       "ja": "三国志で魏を築いた知将は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124842,7 +126659,6 @@
         "en": "Crossbow",
         "ja": "クロスボウ",
         "ja_typings": [
-          "kurosubo",
           "kurosubou"
         ]
       },
@@ -124861,7 +126677,8 @@
     "question_text": {
       "en": "Which ancient siege weapon hurled stones using torsion or counterweight?",
       "ja": "投石で城を攻めた古代の兵器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124901,7 +126718,8 @@
     "question_text": {
       "en": "Who was the Italian-born queen of France during the Wars of Religion?",
       "ja": "宗教戦争期のフランス王妃でイタリア出身の女性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124943,7 +126761,8 @@
     "question_text": {
       "en": "Who united the Franks and converted to Christianity around 496?",
       "ja": "フランク王国を統一しキリスト教に改宗した王は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124958,7 +126777,7 @@
         "en": "Behistun Inscription",
         "ja": "ベヒストゥン碑文",
         "ja_typings": [
-          "behisutunhibun"
+          "behisutwunhibun"
         ]
       },
       {
@@ -124983,7 +126802,8 @@
     "question_text": {
       "en": "Which Babylonian stele inscribed an eye-for-an-eye law code?",
       "ja": "目には目をで知られるバビロニアの法典碑は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125023,7 +126843,8 @@
     "question_text": {
       "en": "On which Mediterranean island was Napoleon Bonaparte born?",
       "ja": "ナポレオン・ボナパルトの生まれた地中海の島は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125031,7 +126852,6 @@
         "en": "Crossbow",
         "ja": "クロスボウ",
         "ja_typings": [
-          "kurosubo",
           "kurosubou"
         ]
       },
@@ -125064,7 +126884,8 @@
     "question_text": {
       "en": "Which medieval ranged weapon was banned by the Church for use against Christians?",
       "ja": "中世に教会が同胞使用を禁じた飛び道具は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125104,7 +126925,8 @@
     "question_text": {
       "en": "Which Central European country split into Czech Republic and Slovakia in 1993?",
       "ja": "1993年にチェコとスロバキアに分かれた中欧の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125144,7 +126966,8 @@
     "question_text": {
       "en": "Who led China's reform and opening-up policy from 1978?",
       "ja": "1978年から中国の改革開放を主導した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125184,7 +127007,8 @@
     "question_text": {
       "en": "Which country existed as the German Democratic Republic until 1990?",
       "ja": "1990年まで存在したドイツ民主共和国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125224,7 +127048,8 @@
     "question_text": {
       "en": "Who was the 12th-century queen consort of both France and England?",
       "ja": "12世紀にフランスとイングランド両国の王妃となった女性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125264,7 +127089,8 @@
     "question_text": {
       "en": "Which Dutch humanist wrote 'In Praise of Folly'?",
       "ja": "『痴愚神礼讃』を書いたオランダの人文主義者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125304,7 +127130,8 @@
     "question_text": {
       "en": "Which country experienced the Revolution of 1789?",
       "ja": "1789年に大革命が起きた国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125344,7 +127171,8 @@
     "question_text": {
       "en": "Who ruled Spain as dictator from 1939 to 1975?",
       "ja": "1939年から1975年までスペインを独裁したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125384,7 +127212,8 @@
     "question_text": {
       "en": "Which Italian astronomer was tried by the Inquisition for heliocentrism?",
       "ja": "地動説で異端審問にかけられたイタリアの天文学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125424,7 +127253,8 @@
     "question_text": {
       "en": "Who was the first president of the United States?",
       "ja": "アメリカ合衆国の初代大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125464,7 +127294,8 @@
     "question_text": {
       "en": "Which European country was reunited in 1990?",
       "ja": "1990年に再統一されたヨーロッパの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125504,7 +127335,8 @@
     "question_text": {
       "en": "Who was the first female Prime Minister of Israel?",
       "ja": "イスラエル初の女性首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125533,7 +127365,7 @@
         "en": "Behistun Inscription",
         "ja": "ベヒストゥン碑文",
         "ja_typings": [
-          "behisutunhibun"
+          "behisutwunhibun"
         ]
       }
     ],
@@ -125544,7 +127376,8 @@
     "question_text": {
       "en": "Which massive fortification stretches across northern China?",
       "ja": "中国北部に延々と続く大要塞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125559,8 +127392,7 @@
         "en": "Malcolm X",
         "ja": "マルコムX",
         "ja_typings": [
-          "marukomux",
-          "marukomuekusu"
+          "marukomux"
         ]
       },
       {
@@ -125585,7 +127417,8 @@
     "question_text": {
       "en": "Who led the Underground Railroad freeing slaves before the Civil War?",
       "ja": "南北戦争以前に地下鉄道で奴隷を救った活動家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125625,7 +127458,8 @@
     "question_text": {
       "en": "Which 1858 treaty opened more Japanese ports to American trade?",
       "ja": "1858年に米国との通商を認めた条約は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125667,7 +127501,8 @@
     "question_text": {
       "en": "Which English king had six wives and broke with Rome?",
       "ja": "6人の妃を持ちローマ教会と決別した英国王は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125707,7 +127542,8 @@
     "question_text": {
       "en": "Which Greek poet wrote 'Works and Days'?",
       "ja": "『労働と日々』を書いたギリシャの詩人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125729,7 +127565,6 @@
         "en": "Thucydides",
         "ja": "トゥキディデス",
         "ja_typings": [
-          "twukidhideesu",
           "twukidhidesu"
         ]
       },
@@ -125748,7 +127583,8 @@
     "question_text": {
       "en": "Which legendary Greek poet wrote the Iliad and Odyssey?",
       "ja": "『イリアス』『オデュッセイア』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125788,7 +127624,8 @@
     "question_text": {
       "en": "Which Swiss reformer led the Reformation in Zurich?",
       "ja": "チューリヒで宗教改革を進めたスイスの改革者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125828,7 +127665,8 @@
     "question_text": {
       "en": "Which 14th-15th century war was fought between England and France?",
       "ja": "14-15世紀のイングランドとフランスの長期戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125868,7 +127706,8 @@
     "question_text": {
       "en": "Which Cold War metaphor did Churchill coin for Europe's divide?",
       "ja": "チャーチルが欧州の分断に用いた冷戦のメタファーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125908,7 +127747,8 @@
     "question_text": {
       "en": "Who formulated the law of universal gravitation?",
       "ja": "万有引力の法則を定式化した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125937,7 +127777,7 @@
         "en": "Mori Terumoto",
         "ja": "毛利輝元",
         "ja_typings": [
-          "moriterumoto"
+          "mouriterumoto"
         ]
       }
     ],
@@ -125948,7 +127788,8 @@
     "question_text": {
       "en": "Who commanded the Western Army at the Battle of Sekigahara?",
       "ja": "関ヶ原で西軍を率いた武将は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125988,7 +127829,8 @@
     "question_text": {
       "en": "Who led the Meiji Restoration government and founded the Liberal Party?",
       "ja": "明治政府の元勲で自由党を結成したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126028,7 +127870,8 @@
     "question_text": {
       "en": "Which ancient province of Japan houses the famous grand shrine?",
       "ja": "出雲大社のある日本の旧国名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126068,7 +127911,8 @@
     "question_text": {
       "en": "Who was the second president of the United States?",
       "ja": "アメリカ合衆国の第2代大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126108,7 +127952,8 @@
     "question_text": {
       "en": "Which French theologian led the Reformation in Geneva?",
       "ja": "ジュネーブで宗教改革を率いたフランス出身の神学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126148,7 +127993,8 @@
     "question_text": {
       "en": "Who was the first American to orbit Earth?",
       "ja": "アメリカ人で初めて地球周回飛行をしたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126188,7 +128034,8 @@
     "question_text": {
       "en": "Who founded the Red Army and was exiled by Stalin?",
       "ja": "赤軍を組織しスターリンに追放された革命家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126228,7 +128075,8 @@
     "question_text": {
       "en": "What was the codename of the atomic bomb dropped on Hiroshima?",
       "ja": "広島に投下された原爆のコードネームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126268,7 +128116,8 @@
     "question_text": {
       "en": "Which French defensive fortification was built before WWII?",
       "ja": "第二次大戦前にフランスが築いた防衛線は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126276,8 +128125,7 @@
         "en": "Malcolm X",
         "ja": "マルコムX",
         "ja_typings": [
-          "marukomux",
-          "marukomuekusu"
+          "marukomux"
         ]
       },
       {
@@ -126309,7 +128157,8 @@
     "question_text": {
       "en": "Who was the Nation of Islam minister assassinated in 1965?",
       "ja": "1965年に暗殺されたネーション・オブ・イスラムの活動家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126349,7 +128198,8 @@
     "question_text": {
       "en": "Who was the queen guillotined during the French Revolution?",
       "ja": "フランス革命で処刑された王妃は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126390,7 +128240,8 @@
     "question_text": {
       "en": "Which French nobleman aided the American Revolution as a general?",
       "ja": "アメリカ独立戦争で将軍として参戦したフランス貴族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126405,8 +128256,7 @@
         "en": "Malcolm X",
         "ja": "マルコムX",
         "ja_typings": [
-          "marukomux",
-          "marukomuekusu"
+          "marukomux"
         ]
       },
       {
@@ -126431,7 +128281,8 @@
     "question_text": {
       "en": "Who led the US civil rights movement and gave the 'I Have a Dream' speech?",
       "ja": "「私には夢がある」演説を行った米公民権運動家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126472,7 +128323,8 @@
     "question_text": {
       "en": "Who led the radical phase of the French Revolution's Reign of Terror?",
       "ja": "フランス革命の恐怖政治を主導した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126512,7 +128364,8 @@
     "question_text": {
       "en": "Which B-17 bomber became famous for completing 25 WWII missions?",
       "ja": "第二次大戦で25回出撃を生き延びた有名なB-17は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126541,7 +128394,6 @@
         "en": "Muhammad Ali Jinnah",
         "ja": "ジンナー",
         "ja_typings": [
-          "jinna-",
           "jinnna-"
         ]
       }
@@ -126553,7 +128405,8 @@
     "question_text": {
       "en": "Who was the Likud Prime Minister of Israel who signed Camp David?",
       "ja": "キャンプ・デービッド合意を結んだイスラエルのリクード首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126593,7 +128446,8 @@
     "question_text": {
       "en": "Who discovered electromagnetic induction in 1831?",
       "ja": "1831年に電磁誘導を発見した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126601,7 +128455,7 @@
         "en": "Mori Terumoto",
         "ja": "毛利輝元",
         "ja_typings": [
-          "moriterumoto"
+          "mouriterumoto"
         ]
       },
       {
@@ -126633,7 +128487,8 @@
     "question_text": {
       "en": "Who was the Mori clan leader and titular head of the Western Army at Sekigahara?",
       "ja": "関ヶ原で西軍総大将を務めた毛利家当主は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126673,7 +128528,8 @@
     "question_text": {
       "en": "Which Islamic empire ruled India from 1526 to the 19th century?",
       "ja": "1526年から19世紀までインドを支配したイスラム王朝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126681,7 +128537,6 @@
         "en": "Muhammad Ali Jinnah",
         "ja": "ジンナー",
         "ja_typings": [
-          "jinna-",
           "jinnna-"
         ]
       },
@@ -126714,7 +128569,8 @@
     "question_text": {
       "en": "Who was the founder of Pakistan?",
       "ja": "パキスタン建国の父と呼ばれる人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126729,7 +128585,7 @@
         "en": "Peace of Westphalia",
         "ja": "ウェストファリア条約",
         "ja_typings": [
-          "uesutofariajouyaku"
+          "wesutofariajouyaku"
         ]
       },
       {
@@ -126754,7 +128610,8 @@
     "question_text": {
       "en": "Which 1938 pact ceded the Sudetenland to Nazi Germany?",
       "ja": "1938年にズデーテン地方をナチスに割譲した協定は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126794,7 +128651,8 @@
     "question_text": {
       "en": "Which chemical element has the symbol Na?",
       "ja": "元素記号Naで表される元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126835,7 +128693,8 @@
     "question_text": {
       "en": "Who was Emperor of France during the Second Empire?",
       "ja": "フランス第二帝政の皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126875,7 +128734,8 @@
     "question_text": {
       "en": "Who proposed the heliocentric model of the solar system in the 16th century?",
       "ja": "16世紀に太陽中心説を唱えた人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126915,7 +128775,8 @@
     "question_text": {
       "en": "Which African river was central to ancient Egyptian civilization?",
       "ja": "古代エジプト文明を育んだアフリカの大河は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126955,7 +128816,8 @@
     "question_text": {
       "en": "Which 1972 detente summit was held in Moscow between US and USSR?",
       "ja": "1972年にモスクワで行われた米ソ緊張緩和の首脳会談は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126995,7 +128857,8 @@
     "question_text": {
       "en": "Who founded Waseda University and served as Prime Minister of Japan?",
       "ja": "早稲田大学を創設し首相も務めた人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127037,7 +128900,8 @@
     "question_text": {
       "en": "Who was crowned the first Holy Roman Emperor in 962?",
       "ja": "962年に神聖ローマ皇帝に戴冠した君主は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127059,7 +128923,7 @@
         "en": "Behistun Inscription",
         "ja": "ベヒストゥン碑文",
         "ja_typings": [
-          "behisutunhibun"
+          "behisutwunhibun"
         ]
       },
       {
@@ -127077,7 +128941,8 @@
     "question_text": {
       "en": "Which ancient Egyptian stone records the early dynasties' kings?",
       "ja": "古代エジプト初期王朝史を刻む石碑は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127085,7 +128950,7 @@
         "en": "Peace of Westphalia",
         "ja": "ウェストファリア条約",
         "ja_typings": [
-          "uesutofariajouyaku"
+          "wesutofariajouyaku"
         ]
       },
       {
@@ -127117,7 +128982,8 @@
     "question_text": {
       "en": "Which 1648 treaty ended the Thirty Years' War?",
       "ja": "1648年に三十年戦争を終結させた条約は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127159,7 +129025,8 @@
     "question_text": {
       "en": "Who founded the Carolingian dynasty by deposing the last Merovingian king?",
       "ja": "メロヴィング朝最後の王を廃しカロリング朝を開いたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127188,7 +129055,6 @@
         "en": "Thucydides",
         "ja": "トゥキディデス",
         "ja_typings": [
-          "twukidhideesu",
           "twukidhidesu"
         ]
       }
@@ -127200,7 +129066,8 @@
     "question_text": {
       "en": "Which Greek philosopher founded the Academy and wrote 'The Republic'?",
       "ja": "アカデメイアを開き『国家』を著したギリシャの哲学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127240,7 +129107,8 @@
     "question_text": {
       "en": "Which 1945 declaration demanded Japan's unconditional surrender?",
       "ja": "1945年に日本に無条件降伏を求めた宣言は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127280,7 +129148,8 @@
     "question_text": {
       "en": "Which Greek mathematician is famous for a theorem about right triangles?",
       "ja": "直角三角形の定理で知られるギリシャの数学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127295,7 +129164,6 @@
         "en": "Muhammad Ali Jinnah",
         "ja": "ジンナー",
         "ja_typings": [
-          "jinna-",
           "jinnna-"
         ]
       },
@@ -127321,7 +129189,8 @@
     "question_text": {
       "en": "Who was the Bengali poet who won the 1913 Nobel Prize in Literature?",
       "ja": "1913年にノーベル文学賞を受けたベンガルの詩人は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127361,7 +129230,8 @@
     "question_text": {
       "en": "Which 1985-88 summit thawed the Cold War between US and USSR?",
       "ja": "1985-88年に冷戦終結に向かった米ソ首脳会談は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127401,7 +129271,8 @@
     "question_text": {
       "en": "Which European river flows through Germany and the Netherlands to the North Sea?",
       "ja": "ドイツからオランダを経て北海に注ぐ欧州の大河は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127441,7 +129312,8 @@
     "question_text": {
       "en": "Which Persian Shia empire rose in 1501 in Iran?",
       "ja": "1501年にイランで興ったシーア派ペルシア王朝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127481,7 +129353,8 @@
     "question_text": {
       "en": "Who ruled Portugal as authoritarian leader during Estado Novo?",
       "ja": "エスタド・ノヴォ体制下でポルトガルを統治したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127521,7 +129394,8 @@
     "question_text": {
       "en": "Which Italian island was a kingdom that united Italy in the 19th century?",
       "ja": "19世紀イタリア統一の核となった島の王国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127561,7 +129435,8 @@
     "question_text": {
       "en": "Which 1856-60 war pitted Britain and France against Qing China?",
       "ja": "1856-60年に英仏が清と戦った戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127601,7 +129476,8 @@
     "question_text": {
       "en": "Which Greek philosopher was tried and executed in Athens?",
       "ja": "アテネで死刑に処されたギリシャの哲学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127641,7 +129517,8 @@
     "question_text": {
       "en": "Who was the king of Wu during the Three Kingdoms period?",
       "ja": "三国志で呉を建てた君主は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127681,7 +129558,8 @@
     "question_text": {
       "en": "Who founded the Republic of China in 1912?",
       "ja": "1912年に中華民国を建てた人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127721,7 +129599,8 @@
     "question_text": {
       "en": "Which mid-19th century Christian-inspired uprising shook the Qing dynasty?",
       "ja": "19世紀半ばに清朝を揺るがしたキリスト教系大反乱は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127761,7 +129640,8 @@
     "question_text": {
       "en": "Who was the Kai daimyo nicknamed 'Tiger of Kai' in Sengoku Japan?",
       "ja": "甲斐の虎と呼ばれた戦国大名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127802,7 +129682,8 @@
     "question_text": {
       "en": "Which French diplomat served Napoleon and represented France at Vienna?",
       "ja": "ナポレオンに仕えウィーン会議でフランス代表となった外交官は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127842,7 +129723,8 @@
     "question_text": {
       "en": "Which 1618-1648 war devastated Central Europe over religion and politics?",
       "ja": "1618-1648年に中欧を荒廃させた宗教戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127882,7 +129764,8 @@
     "question_text": {
       "en": "Who invented the practical incandescent light bulb?",
       "ja": "実用的な白熱電球を発明した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127922,7 +129805,8 @@
     "question_text": {
       "en": "Who authored the US Declaration of Independence and became 3rd president?",
       "ja": "米独立宣言を起草し第3代大統領となったのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127930,7 +129814,6 @@
         "en": "Thucydides",
         "ja": "トゥキディデス",
         "ja_typings": [
-          "twukidhideesu",
           "twukidhidesu"
         ]
       },
@@ -127963,7 +129846,8 @@
     "question_text": {
       "en": "Which Greek historian wrote 'History of the Peloponnesian War'?",
       "ja": "『ペロポネソス戦争史』を書いたギリシャの歴史家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128003,7 +129887,8 @@
     "question_text": {
       "en": "Which river flows through Rome?",
       "ja": "ローマを流れる川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128044,7 +129929,8 @@
     "question_text": {
       "en": "Who was the Turco-Mongol conqueror who founded an empire in 14th-century Central Asia?",
       "ja": "14世紀中央アジアに大帝国を築いたトルコ・モンゴル系の征服者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128084,7 +129970,8 @@
     "question_text": {
       "en": "Who founded the Tokugawa shogunate after Sekigahara?",
       "ja": "関ヶ原の戦い後に江戸幕府を開いた人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128124,7 +130011,8 @@
     "question_text": {
       "en": "Who was the first US consul to Japan in 1856?",
       "ja": "1856年に初代米国総領事として来日した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128164,7 +130052,8 @@
     "question_text": {
       "en": "Who unified Japan as Taiko in the late 16th century?",
       "ja": "16世紀末に太閤として日本を統一した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128204,7 +130093,8 @@
     "question_text": {
       "en": "Which 1951 treaty ended the Allied occupation of Japan?",
       "ja": "1951年に連合国の占領を終わらせた日本の条約は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128219,7 +130109,7 @@
         "en": "Peace of Westphalia",
         "ja": "ウェストファリア条約",
         "ja_typings": [
-          "uesutofariajouyaku"
+          "wesutofariajouyaku"
         ]
       },
       {
@@ -128244,7 +130134,8 @@
     "question_text": {
       "en": "Which 1713 treaty ended the War of the Spanish Succession?",
       "ja": "1713年にスペイン継承戦争を終結させた条約は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128284,7 +130175,8 @@
     "question_text": {
       "en": "Which 1945 Potsdam meeting featured these Allied leaders?",
       "ja": "1945年ポツダム会談で対面した米ソの指導者ペアは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128324,7 +130216,8 @@
     "question_text": {
       "en": "Which 1776 document declared American independence from Britain?",
       "ja": "1776年に英国からの独立を宣した文書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128339,7 +130232,7 @@
         "en": "Mori Terumoto",
         "ja": "毛利輝元",
         "ja_typings": [
-          "moriterumoto"
+          "mouriterumoto"
         ]
       },
       {
@@ -128364,7 +130257,8 @@
     "question_text": {
       "en": "Who was the Uesugi clan head who fought Tokugawa in 1600?",
       "ja": "1600年に徳川と対立した上杉家当主は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128404,7 +130298,8 @@
     "question_text": {
       "en": "Who was the Union general and 18th US President?",
       "ja": "南北戦争の北軍将軍で第18代米大統領は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128444,7 +130339,8 @@
     "question_text": {
       "en": "Which country gained independence on July 4, 1776?",
       "ja": "1776年7月4日に独立を宣した国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128473,7 +130369,7 @@
         "en": "Peace of Westphalia",
         "ja": "ウェストファリア条約",
         "ja_typings": [
-          "uesutofariajouyaku"
+          "wesutofariajouyaku"
         ]
       }
     ],
@@ -128484,7 +130380,8 @@
     "question_text": {
       "en": "Which 1948 UN document outlines fundamental human rights?",
       "ja": "1948年に国連が採択した人権の基本文書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128524,7 +130421,8 @@
     "question_text": {
       "en": "Which 16th-17th century conflicts pitted Catholics against Protestants in France?",
       "ja": "16-17世紀フランスでカトリックとプロテスタントが争った内戦は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128564,7 +130462,8 @@
     "question_text": {
       "en": "Who was the Meiji-era army marshal and twice Prime Minister of Japan?",
       "ja": "明治の元帥陸軍大将で二度首相となった人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128604,7 +130503,8 @@
     "question_text": {
       "en": "Which early Japanese polity centered around the Nara basin in the 4th-7th century?",
       "ja": "4-7世紀に奈良盆地を中心に栄えた日本の政権は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128645,7 +130545,8 @@
     "question_text": {
       "en": "Which Russian admiral arrived in Nagasaki in 1853 seeking trade?",
       "ja": "1853年に長崎に来航した露提督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128674,7 +130575,6 @@
         "en": "Muhammad Ali Jinnah",
         "ja": "ジンナー",
         "ja_typings": [
-          "jinna-",
           "jinnna-"
         ]
       }
@@ -128686,7 +130586,8 @@
     "question_text": {
       "en": "Who was the Israeli PM assassinated in 1995 after signing Oslo Accords?",
       "ja": "オスロ合意後の1995年に暗殺されたイスラエル首相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128726,7 +130627,8 @@
     "question_text": {
       "en": "Which Balkan federation broke apart in the 1990s into multiple states?",
       "ja": "1990年代に複数国家に分裂したバルカンの連邦は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128766,7 +130668,8 @@
     "question_text": {
       "en": "Who was the first human to journey into outer space in 1961?",
       "ja": "1961年に人類初の宇宙飛行を達成したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128806,7 +130709,8 @@
     "question_text": {
       "en": "Who served as the first Premier of the People's Republic of China?",
       "ja": "中華人民共和国の初代国務院総理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128846,7 +130750,8 @@
     "question_text": {
       "en": "Who was the chief strategist of Shu in China's Three Kingdoms period?",
       "ja": "三国志で蜀の軍師として活躍した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128854,31 +130759,28 @@
         "en": "Abel Prize",
         "ja": "アーベル賞",
         "ja_typings": [
-          "a-beruxsiyou",
-          "a-beluxsyou"
+          "a-berushou"
         ]
       },
       {
         "en": "Fields Medal",
         "ja": "フィールズ賞",
         "ja_typings": [
-          "fi-ruzuxsiyou",
-          "fixi-luzusyou"
+          "fi-ruzushou"
         ]
       },
       {
         "en": "Wolf Prize",
         "ja": "ウルフ賞",
         "ja_typings": [
-          "uruhuxsiyou",
-          "uluhusyou"
+          "urufushou"
         ]
       },
       {
         "en": "Turing Award",
         "ja": "チューリング賞",
         "ja_typings": [
-          "chixyu-ringuxsiyou"
+          "chu-ringushou"
         ]
       }
     ],
@@ -128889,7 +130791,8 @@
     "question_text": {
       "en": "Which is a major international mathematics award named after a Norwegian mathematician?",
       "ja": "ノルウェーの数学者にちなんで名づけられた、数学の国際的な賞はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128929,7 +130832,8 @@
     "question_text": {
       "en": "Which branch of mathematics studies geometric objects defined by polynomial equations?",
       "ja": "多項式で定義される図形を扱う数学の分野はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128969,7 +130873,8 @@
     "question_text": {
       "en": "Which branch of mathematics deals with limits, derivatives and integrals?",
       "ja": "極限・微分・積分を扱う数学の分野はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128984,7 +130889,7 @@
         "en": "Euclid",
         "ja": "ユークリッド",
         "ja_typings": [
-          "yu-kuriltudo"
+          "yu-kuriddo"
         ]
       },
       {
@@ -129009,7 +130914,8 @@
     "question_text": {
       "en": "Which ancient Greek mathematician is known for the law of buoyancy?",
       "ja": "浮力の原理で知られる古代ギリシャの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129049,7 +130955,8 @@
     "question_text": {
       "en": "Which ancient Greek philosopher wrote on logic and natural science?",
       "ja": "論理学や自然学の著作を残した古代ギリシャの哲学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129057,7 +130964,6 @@
         "en": "Babbage",
         "ja": "バベッジ",
         "ja_typings": [
-          "bayatuji",
           "babejji"
         ]
       },
@@ -129065,7 +130971,7 @@
         "en": "Turing",
         "ja": "チューリング",
         "ja_typings": [
-          "chixyu-ringu"
+          "chu-ringu"
         ]
       },
       {
@@ -129090,7 +130996,8 @@
     "question_text": {
       "en": "Who designed the Analytical Engine, a forerunner of the computer?",
       "ja": "解析機関を設計した、コンピュータの先駆者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129112,14 +131019,14 @@
         "en": "Central limit theorem",
         "ja": "中心極限定理",
         "ja_typings": [
-          "tixyuusinkyokugenteiri"
+          "chuushinkyokugenteiri"
         ]
       },
       {
         "en": "Chebyshev's inequality",
         "ja": "チェビシェフの不等式",
         "ja_typings": [
-          "chiebisiehunohutousiki"
+          "chebishefunofutoushiki"
         ]
       }
     ],
@@ -129130,7 +131037,8 @@
     "question_text": {
       "en": "Which theorem in probability updates a probability given new evidence?",
       "ja": "新しい情報をもとに確率を更新する確率論の定理はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129170,7 +131078,8 @@
     "question_text": {
       "en": "Which special function in mathematics is denoted B(x,y)?",
       "ja": "B(x,y)で表される数学の特殊関数はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129185,8 +131094,6 @@
         "en": "Fermi",
         "ja": "フェルミ",
         "ja_typings": [
-          "herumi",
-          "felumi",
           "ferumi"
         ]
       },
@@ -129194,8 +131101,6 @@
         "en": "Dirac",
         "ja": "ディラック",
         "ja_typings": [
-          "dexiratuku",
-          "dhilatuku",
           "dhirakku"
         ]
       },
@@ -129214,7 +131119,8 @@
     "question_text": {
       "en": "Which Indian physicist gave his name to particles called bosons?",
       "ja": "ボース粒子（ボソン）に名を残したインドの物理学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129236,7 +131142,6 @@
         "en": "Russell",
         "ja": "ラッセル",
         "ja_typings": [
-          "ratuseru",
           "rasseru"
         ]
       },
@@ -129255,7 +131160,8 @@
     "question_text": {
       "en": "Who founded modern set theory and the theory of transfinite numbers?",
       "ja": "近代集合論と超限数の理論を築いた数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129284,8 +131190,6 @@
         "en": "David Hilbert",
         "ja": "ダフィット・ヒルベルト",
         "ja_typings": [
-          "dahuxituto/hiruberuto",
-          "dafuxitto/hiluberuto",
           "dafitto/hiruberuto"
         ]
       }
@@ -129297,7 +131201,8 @@
     "question_text": {
       "en": "Who is the German mathematician called the prince of mathematicians?",
       "ja": "「数学者の王」と呼ばれたドイツの大数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129305,8 +131210,6 @@
         "en": "Chandrasekhar",
         "ja": "チャンドラセカール",
         "ja_typings": [
-          "chiyandorasekaa-ru",
-          "tyandolasekaa-lu",
           "chandoraseka-ru"
         ]
       },
@@ -129328,7 +131231,7 @@
         "en": "Eddington",
         "ja": "エディントン",
         "ja_typings": [
-          "edexinton"
+          "edhinton"
         ]
       }
     ],
@@ -129339,7 +131242,8 @@
     "question_text": {
       "en": "Which Indian-American astrophysicist's name labels a stellar mass limit?",
       "ja": "恒星の質量限界に名を残したインド系の天体物理学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129347,29 +131251,28 @@
         "en": "Chebyshev's inequality",
         "ja": "チェビシェフの不等式",
         "ja_typings": [
-          "chiebisiehunohutousiki"
+          "chebishefunofutoushiki"
         ]
       },
       {
         "en": "Markov's inequality",
         "ja": "マルコフの不等式",
         "ja_typings": [
-          "marukohunohutousiki"
+          "marukofunofutoushiki"
         ]
       },
       {
         "en": "Jensen's inequality",
         "ja": "イェンセンの不等式",
         "ja_typings": [
-          "ixensennohutousiki",
-          "yensennnohutousiki"
+          "iensennofutoushiki"
         ]
       },
       {
         "en": "Cauchy-Schwarz inequality",
         "ja": "コーシー・シュワルツの不等式",
         "ja_typings": [
-          "ko-shi--/shiyuwarutunohutousiki"
+          "ko-shi-/shuwarutsunofutoushiki"
         ]
       }
     ],
@@ -129380,7 +131283,8 @@
     "question_text": {
       "en": "Which inequality bounds the probability that a random variable deviates from its mean?",
       "ja": "確率変数が平均から外れる確率を抑える不等式はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129420,7 +131324,8 @@
     "question_text": {
       "en": "Which type of polygon has at least one interior angle greater than 180°?",
       "ja": "内角に180°より大きい角がある多角形はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129442,7 +131347,7 @@
         "en": "Star polygon",
         "ja": "星型多角形",
         "ja_typings": [
-          "hosigatatakakukei"
+          "hoshigatatakakukei"
         ]
       },
       {
@@ -129460,7 +131365,8 @@
     "question_text": {
       "en": "Which type of polygon has all interior angles less than 180°?",
       "ja": "全ての内角が180°未満である多角形はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129482,15 +131388,13 @@
         "en": "Nabla",
         "ja": "ナブラ",
         "ja_typings": [
-          "nabura",
-          "nabula"
+          "nabura"
         ]
       },
       {
         "en": "Hessian",
         "ja": "ヘッシアン",
         "ja_typings": [
-          "hetusian",
           "hesshian"
         ]
       }
@@ -129502,7 +131406,8 @@
     "question_text": {
       "en": "Which operator, used in relativity, is the wave operator in 4-dimensional spacetime?",
       "ja": "相対論で4次元時空の波動を表す微分作用素はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129510,8 +131415,7 @@
         "en": "Delta",
         "ja": "デルタ",
         "ja_typings": [
-          "deruta",
-          "deluta"
+          "deruta"
         ]
       },
       {
@@ -129532,8 +131436,7 @@
         "en": "Lambda",
         "ja": "ラムダ",
         "ja_typings": [
-          "ramuda",
-          "lamuda"
+          "ramuda"
         ]
       }
     ],
@@ -129544,7 +131447,8 @@
     "question_text": {
       "en": "Which Greek letter is often used to denote a small change in mathematics?",
       "ja": "数学で微小な変化を表すのによく使うギリシャ文字はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129584,7 +131488,8 @@
     "question_text": {
       "en": "Which generalized function, introduced by Dirac, equals zero except at one point?",
       "ja": "ディラックが導入した、1点以外でゼロとなる超関数はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129592,16 +131497,14 @@
         "en": "Descartes",
         "ja": "デカルト",
         "ja_typings": [
-          "dekaruto",
-          "dekaluto"
+          "dekaruto"
         ]
       },
       {
         "en": "Pascal",
         "ja": "パスカル",
         "ja_typings": [
-          "pasukaru",
-          "pasukalu"
+          "pasukaru"
         ]
       },
       {
@@ -129615,8 +131518,6 @@
         "en": "Leibniz",
         "ja": "ライプニッツ",
         "ja_typings": [
-          "raipunitutu",
-          "laipunittu",
           "raipunittsu"
         ]
       }
@@ -129628,7 +131529,8 @@
     "question_text": {
       "en": "Which 17th-century French philosopher introduced analytic geometry?",
       "ja": "解析幾何学を創始した17世紀フランスの哲学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129636,7 +131538,7 @@
         "en": "Euclid",
         "ja": "ユークリッド",
         "ja_typings": [
-          "yu-kuriltudo"
+          "yu-kuriddo"
         ]
       },
       {
@@ -129657,8 +131559,7 @@
         "en": "Apollonius",
         "ja": "アポロニウス",
         "ja_typings": [
-          "aporoniusu",
-          "apoloniusu"
+          "aporoniusu"
         ]
       }
     ],
@@ -129669,7 +131570,8 @@
     "question_text": {
       "en": "Who wrote the Elements, the foundational text of geometry?",
       "ja": "幾何学の基礎となる『原論』を著したのは誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129684,8 +131586,7 @@
         "en": "Bernoulli",
         "ja": "ベルヌーイ",
         "ja_typings": [
-          "berunu-i",
-          "belunu-i"
+          "berunu-i"
         ]
       },
       {
@@ -129699,8 +131600,6 @@
         "en": "Lagrange",
         "ja": "ラグランジュ",
         "ja_typings": [
-          "raguranjixu",
-          "lagulanju",
           "raguranju"
         ]
       }
@@ -129712,7 +131611,8 @@
     "question_text": {
       "en": "Which Swiss mathematician introduced the constant e and much modern notation?",
       "ja": "定数 e を導入し、近代数学記法を整備したスイスの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129752,7 +131652,8 @@
     "question_text": {
       "en": "Which operation breaks a number into a product of primes?",
       "ja": "ある数を素数の積に分ける操作はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129781,8 +131682,7 @@
         "en": "Galois",
         "ja": "ガロア",
         "ja_typings": [
-          "garoa",
-          "galoa"
+          "garoa"
         ]
       }
     ],
@@ -129793,7 +131693,8 @@
     "question_text": {
       "en": "Whose Last Theorem about x^n+y^n=z^n was proved by Andrew Wiles?",
       "ja": "ワイルズが証明した「最終定理」を残した数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129808,7 +131709,6 @@
         "en": "Russell",
         "ja": "ラッセル",
         "ja_typings": [
-          "ratuseru",
           "rasseru"
         ]
       },
@@ -129816,8 +131716,6 @@
         "en": "Wittgenstein",
         "ja": "ウィトゲンシュタイン",
         "ja_typings": [
-          "uxitogensiyutain",
-          "wxitogenshutain",
           "witogenshutain"
         ]
       },
@@ -129825,8 +131723,7 @@
         "en": "Gödel",
         "ja": "ゲーデル",
         "ja_typings": [
-          "ge-deru",
-          "ge-delu"
+          "ge-deru"
         ]
       }
     ],
@@ -129837,7 +131734,8 @@
     "question_text": {
       "en": "Which German logician founded modern logic with his Begriffsschrift?",
       "ja": "『概念記法』で近代論理学を築いたドイツの論理学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129859,8 +131757,7 @@
         "en": "Mapping",
         "ja": "写像",
         "ja_typings": [
-          "siyazou",
-          "syazou"
+          "shazou"
         ]
       },
       {
@@ -129878,7 +131775,8 @@
     "question_text": {
       "en": "Which mathematical concept assigns each input exactly one output?",
       "ja": "各入力にちょうど1つの出力を対応させる概念はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129886,23 +131784,20 @@
         "en": "Galois",
         "ja": "ガロア",
         "ja_typings": [
-          "garoa",
-          "galoa"
+          "garoa"
         ]
       },
       {
         "en": "Abel",
         "ja": "アーベル",
         "ja_typings": [
-          "a-beru",
-          "a-belu"
+          "a-beru"
         ]
       },
       {
         "en": "Cauchy",
         "ja": "コーシー",
         "ja_typings": [
-          "ko-shi--",
           "ko-shi-"
         ]
       },
@@ -129921,7 +131816,8 @@
     "question_text": {
       "en": "Which young French mathematician founded group theory before dying in a duel?",
       "ja": "決闘で若くして亡くなり、群論を築いたフランスの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129961,7 +131857,8 @@
     "question_text": {
       "en": "Which function, denoted Γ(x), generalizes the factorial to real numbers?",
       "ja": "階乗を実数に拡張した Γ(x) で表される関数はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129983,16 +131880,14 @@
         "en": "Laplace",
         "ja": "ラプラス",
         "ja_typings": [
-          "rapurasu",
-          "lapulasu"
+          "rapurasu"
         ]
       },
       {
         "en": "Bernoulli",
         "ja": "ベルヌーイ",
         "ja_typings": [
-          "berunu-i",
-          "belunu-i"
+          "berunu-i"
         ]
       }
     ],
@@ -130003,7 +131898,8 @@
     "question_text": {
       "en": "Which mathematician's name labels the normal distribution's bell curve?",
       "ja": "正規分布の釣鐘型曲線に名を残した数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130011,16 +131907,13 @@
         "en": "Georg Cantor",
         "ja": "ゲオルク・カントール",
         "ja_typings": [
-          "georuku/kanto-ru",
-          "geoluku/kanto-lu"
+          "georuku/kanto-ru"
         ]
       },
       {
         "en": "Richard Dedekind",
         "ja": "リヒャルト・デデキント",
         "ja_typings": [
-          "rihiyaruto/dedekinto",
-          "lihyaluto/dedekinto",
           "rihyaruto/dedekinto"
         ]
       },
@@ -130028,7 +131921,6 @@
         "en": "David Hilbert",
         "ja": "ダフィット・ヒルベルト",
         "ja_typings": [
-          "dahuxituto/hiruberuto",
           "dafitto/hiruberuto"
         ]
       },
@@ -130036,8 +131928,7 @@
         "en": "Henri Poincaré",
         "ja": "アンリ・ポアンカレ",
         "ja_typings": [
-          "anri/poankare",
-          "anli/poankale"
+          "anri/poankare"
         ]
       }
     ],
@@ -130048,7 +131939,8 @@
     "question_text": {
       "en": "Who founded set theory and proved different sizes of infinity?",
       "ja": "集合論を創り、無限に大小があることを示した数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130088,7 +131980,8 @@
     "question_text": {
       "en": "Which famous ratio is approximately 1.618?",
       "ja": "約1.618の値を持つ有名な比はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130129,7 +132022,8 @@
     "question_text": {
       "en": "Which symbol denotes the golden ratio?",
       "ja": "黄金比を表す記号はどれ?"
-    }
+    },
+    "ja_reviewed": false
   },
   {
     "choices": [
@@ -130151,7 +132045,6 @@
         "en": "John Nash",
         "ja": "ジョン・ナッシュ",
         "ja_typings": [
-          "jiyon/natusiyu",
           "jon/nasshu"
         ]
       },
@@ -130159,7 +132052,6 @@
         "en": "Andrew Wiles",
         "ja": "アンドリュー・ワイルズ",
         "ja_typings": [
-          "andoriyu-/wairuzu",
           "andoryu-/wairuzu"
         ]
       }
@@ -130171,7 +132063,8 @@
     "question_text": {
       "en": "Who proved the Poincaré conjecture and declined the Fields Medal?",
       "ja": "ポアンカレ予想を証明しフィールズ賞を辞退した数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130179,16 +132072,14 @@
         "en": "Gödel",
         "ja": "ゲーデル",
         "ja_typings": [
-          "ge-deru",
-          "ge-delu"
+          "ge-deru"
         ]
       },
       {
         "en": "Tarski",
         "ja": "タルスキ",
         "ja_typings": [
-          "tarusuki",
-          "talusuki"
+          "tarusuki"
         ]
       },
       {
@@ -130202,7 +132093,6 @@
         "en": "Russell",
         "ja": "ラッセル",
         "ja_typings": [
-          "ratuseru",
           "rasseru"
         ]
       }
@@ -130214,7 +132104,8 @@
     "question_text": {
       "en": "Who proved the incompleteness theorems of formal arithmetic?",
       "ja": "形式的算術の不完全性定理を証明した数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130222,15 +132113,13 @@
         "en": "Hardy",
         "ja": "ハーディ",
         "ja_typings": [
-          "ha-dexi"
+          "ha-dhi"
         ]
       },
       {
         "en": "Littlewood",
         "ja": "リトルウッド",
         "ja_typings": [
-          "riturouxtudo",
-          "litoluuxtudo",
           "ritoruuddo"
         ]
       },
@@ -130238,7 +132127,6 @@
         "en": "Russell",
         "ja": "ラッセル",
         "ja_typings": [
-          "ratuseru",
           "rasseru"
         ]
       },
@@ -130246,7 +132134,7 @@
         "en": "Turing",
         "ja": "チューリング",
         "ja_typings": [
-          "chixyu-ringu"
+          "chu-ringu"
         ]
       }
     ],
@@ -130257,7 +132145,8 @@
     "question_text": {
       "en": "Which English mathematician collaborated extensively with Ramanujan?",
       "ja": "ラマヌジャンと長く共同研究したイギリスの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130272,7 +132161,7 @@
         "en": "Parabola",
         "ja": "放物線",
         "ja_typings": [
-          "houbutusen"
+          "houbutsusen"
         ]
       },
       {
@@ -130297,7 +132186,8 @@
     "question_text": {
       "en": "Which conic section is the graph of y = 1/x?",
       "ja": "y = 1/x のグラフが描く円錐曲線はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130338,7 +132228,8 @@
     "question_text": {
       "en": "Which calculus operation finds the area under a curve?",
       "ja": "曲線の下の面積を求める微積分の操作はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130346,7 +132237,6 @@
         "en": "John Nash",
         "ja": "ジョン・ナッシュ",
         "ja_typings": [
-          "jiyon/natusiyu",
           "jon/nasshu"
         ]
       },
@@ -130354,8 +132244,6 @@
         "en": "John von Neumann",
         "ja": "ジョン・フォン・ノイマン",
         "ja_typings": [
-          "jiyon/fuxon/noiman",
-          "jon/foxn/noiman",
           "jon/fon/noiman"
         ]
       },
@@ -130363,8 +132251,6 @@
         "en": "Lloyd Shapley",
         "ja": "ロイド・シャプレー",
         "ja_typings": [
-          "roido/shiyapure-",
-          "loido/shaple-",
           "roido/shapure-"
         ]
       },
@@ -130372,8 +132258,7 @@
         "en": "Reinhard Selten",
         "ja": "ラインハルト・ゼルテン",
         "ja_typings": [
-          "rainharuto/zeruten",
-          "lainhaluto/zeluten"
+          "rainharuto/zeruten"
         ]
       }
     ],
@@ -130384,7 +132269,8 @@
     "question_text": {
       "en": "Which American mathematician won a Nobel Prize for game theory?",
       "ja": "ゲーム理論でノーベル経済学賞を受けたアメリカの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130392,14 +132278,13 @@
         "en": "Kolmogorov",
         "ja": "コルモゴロフ",
         "ja_typings": [
-          "korumogorohu"
+          "korumogorofu"
         ]
       },
       {
         "en": "Chebyshev",
         "ja": "チェビシェフ",
         "ja_typings": [
-          "chiebisiehu",
           "chebishefu"
         ]
       },
@@ -130407,8 +132292,6 @@
         "en": "Lobachevsky",
         "ja": "ロバチェフスキー",
         "ja_typings": [
-          "robatiehusuki-",
-          "lobatiehusuki-",
           "robachefusuki-"
         ]
       },
@@ -130416,7 +132299,7 @@
         "en": "Markov",
         "ja": "マルコフ",
         "ja_typings": [
-          "marukohu"
+          "marukofu"
         ]
       }
     ],
@@ -130427,7 +132310,8 @@
     "question_text": {
       "en": "Which Russian mathematician axiomatized probability theory in 1933?",
       "ja": "1933年に確率論を公理化したロシアの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130435,15 +132319,13 @@
         "en": "Lambda",
         "ja": "ラムダ",
         "ja_typings": [
-          "ramuda",
-          "lamuda"
+          "ramuda"
         ]
       },
       {
         "en": "Mu",
         "ja": "ミュー",
         "ja_typings": [
-          "miyu-",
           "myu-"
         ]
       },
@@ -130451,7 +132333,6 @@
         "en": "Nu",
         "ja": "ニュー",
         "ja_typings": [
-          "niyu-",
           "nyu-"
         ]
       },
@@ -130459,7 +132340,6 @@
         "en": "Kappa",
         "ja": "カッパ",
         "ja_typings": [
-          "katupa",
           "kappa"
         ]
       }
@@ -130471,7 +132351,8 @@
     "question_text": {
       "en": "Which Greek letter is the 11th and often denotes wavelength or eigenvalue?",
       "ja": "波長や固有値を表すのによく使うギリシャ文字（第11字）はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130493,15 +132374,13 @@
         "en": "Nabla",
         "ja": "ナブラ",
         "ja_typings": [
-          "nabura",
-          "nabula"
+          "nabura"
         ]
       },
       {
         "en": "Hessian",
         "ja": "ヘッシアン",
         "ja_typings": [
-          "hetusian",
           "hesshian"
         ]
       }
@@ -130513,7 +132392,8 @@
     "question_text": {
       "en": "Which differential operator is the divergence of the gradient?",
       "ja": "勾配の発散として定義される微分作用素はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130528,7 +132408,7 @@
         "en": "Central limit theorem",
         "ja": "中心極限定理",
         "ja_typings": [
-          "tixyuusinkyokugenteiri"
+          "chuushinkyokugenteiri"
         ]
       },
       {
@@ -130542,7 +132422,7 @@
         "en": "Chebyshev's inequality",
         "ja": "チェビシェフの不等式",
         "ja_typings": [
-          "chiebisiehunohutousiki"
+          "chebishefunofutoushiki"
         ]
       }
     ],
@@ -130553,7 +132433,8 @@
     "question_text": {
       "en": "Which theorem says sample averages converge to the expected value?",
       "ja": "標本平均が期待値に収束することを述べる定理はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130561,8 +132442,6 @@
         "en": "Leibniz",
         "ja": "ライプニッツ",
         "ja_typings": [
-          "raipunitutu",
-          "laipunittu",
           "raipunittsu"
         ]
       },
@@ -130570,7 +132449,6 @@
         "en": "Newton",
         "ja": "ニュートン",
         "ja_typings": [
-          "niyu-ton",
           "nyu-ton"
         ]
       },
@@ -130585,8 +132463,7 @@
         "en": "Bernoulli",
         "ja": "ベルヌーイ",
         "ja_typings": [
-          "berunu-i",
-          "belunu-i"
+          "berunu-i"
         ]
       }
     ],
@@ -130597,7 +132474,8 @@
     "question_text": {
       "en": "Which German philosopher-mathematician independently invented calculus?",
       "ja": "微積分を独立に発見したドイツの哲学者・数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130626,8 +132504,7 @@
         "en": "Series",
         "ja": "級数",
         "ja_typings": [
-          "kiyuusuu",
-          "kyusuu"
+          "kyuusuu"
         ]
       }
     ],
@@ -130638,7 +132515,8 @@
     "question_text": {
       "en": "Which calculus concept is the value a function approaches near a point?",
       "ja": "ある点に近づけたときの値を表す微積分の概念はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130646,8 +132524,6 @@
         "en": "Lobachevsky",
         "ja": "ロバチェフスキー",
         "ja_typings": [
-          "robatiehusuki-",
-          "lobatiehusuki-",
           "robachefusuki-"
         ]
       },
@@ -130680,7 +132556,8 @@
     "question_text": {
       "en": "Which Russian mathematician developed non-Euclidean hyperbolic geometry?",
       "ja": "双曲幾何学を生んだロシアの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130695,7 +132572,7 @@
         "en": "Exponential curve",
         "ja": "指数曲線",
         "ja_typings": [
-          "sisuukyokusen"
+          "shisuukyokusen"
         ]
       },
       {
@@ -130720,7 +132597,8 @@
     "question_text": {
       "en": "Which curve is the graph of y = log x?",
       "ja": "y = log x のグラフが描く曲線はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130728,8 +132606,7 @@
         "en": "Mapping",
         "ja": "写像",
         "ja_typings": [
-          "siyazou",
-          "syazou"
+          "shazou"
         ]
       },
       {
@@ -130761,7 +132638,8 @@
     "question_text": {
       "en": "Which concept assigns each element of one set to an element of another?",
       "ja": "ある集合の各要素を別の集合の要素に対応させる概念はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130769,16 +132647,14 @@
         "en": "Nabla",
         "ja": "ナブラ",
         "ja_typings": [
-          "nabura",
-          "nabula"
+          "nabura"
         ]
       },
       {
         "en": "Delta",
         "ja": "デルタ",
         "ja_typings": [
-          "deruta",
-          "deluta"
+          "deruta"
         ]
       },
       {
@@ -130803,7 +132679,8 @@
     "question_text": {
       "en": "Which symbol ∇ is used for the gradient operator?",
       "ja": "勾配を表す記号 ∇ の名前はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130843,7 +132720,8 @@
     "question_text": {
       "en": "Which branch of mathematics studies properties of integers?",
       "ja": "整数の性質を研究する数学の分野はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130858,8 +132736,6 @@
         "en": "Alpha",
         "ja": "アルファ",
         "ja_typings": [
-          "aruhua",
-          "alufa",
           "arufa"
         ]
       },
@@ -130885,7 +132761,8 @@
     "question_text": {
       "en": "Which is the last letter of the Greek alphabet?",
       "ja": "ギリシャ文字の最後の文字はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130914,8 +132791,7 @@
         "en": "Mapping",
         "ja": "写像",
         "ja_typings": [
-          "siyazou",
-          "syazou"
+          "shazou"
         ]
       }
     ],
@@ -130926,7 +132802,8 @@
     "question_text": {
       "en": "Which mathematical concept combines elements like +, ×, ∘?",
       "ja": "+ や × のように要素を組み合わせる数学的概念はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130966,7 +132843,8 @@
     "question_text": {
       "en": "Which famous constant gives the ratio of a circle's circumference to its diameter?",
       "ja": "円周と直径の比を表す有名な定数はどれ?"
-    }
+    },
+    "ja_reviewed": false
   },
   {
     "choices": [
@@ -130974,16 +132852,14 @@
         "en": "Poincaré",
         "ja": "ポアンカレ",
         "ja_typings": [
-          "poankare",
-          "poankale"
+          "poankare"
         ]
       },
       {
         "en": "Galois",
         "ja": "ガロア",
         "ja_typings": [
-          "garoa",
-          "galoa"
+          "garoa"
         ]
       },
       {
@@ -130997,7 +132873,6 @@
         "en": "Cauchy",
         "ja": "コーシー",
         "ja_typings": [
-          "ko-shi--",
           "ko-shi-"
         ]
       }
@@ -131009,7 +132884,8 @@
     "question_text": {
       "en": "Which French polymath stated a famous topology conjecture about 3-spheres?",
       "ja": "3次元球面に関する有名な位相幾何の予想を残したフランスの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131031,7 +132907,7 @@
         "en": "Euclidean theorem",
         "ja": "ユークリッドの定理",
         "ja_typings": [
-          "yu-kuriltudonoteiri"
+          "yu-kuriddonoteiri"
         ]
       },
       {
@@ -131049,7 +132925,8 @@
     "question_text": {
       "en": "Which theorem states a² + b² = c² for right triangles?",
       "ja": "直角三角形で a² + b² = c² が成り立つ定理はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131057,8 +132934,6 @@
         "en": "Ramanujan",
         "ja": "ラマヌジャン",
         "ja_typings": [
-          "ramanujiyan",
-          "lamanujan",
           "ramanujan"
         ]
       },
@@ -131073,8 +132948,6 @@
         "en": "Chandrasekhar",
         "ja": "チャンドラセカール",
         "ja_typings": [
-          "chiyandorasekaa-ru",
-          "tyandolasekaa-lu",
           "chandoraseka-ru"
         ]
       },
@@ -131082,8 +132955,7 @@
         "en": "Aryabhata",
         "ja": "アーリヤバタ",
         "ja_typings": [
-          "a-riyabata",
-          "a-liyabata"
+          "a-riyabata"
         ]
       }
     ],
@@ -131094,7 +132966,8 @@
     "question_text": {
       "en": "Which Indian mathematician was famous for self-taught genius and infinite series?",
       "ja": "独学の天才で無限級数の研究で知られるインドの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131116,8 +132989,7 @@
         "en": "Mapping",
         "ja": "写像",
         "ja_typings": [
-          "siyazou",
-          "syazou"
+          "shazou"
         ]
       },
       {
@@ -131135,7 +133007,8 @@
     "question_text": {
       "en": "Which mathematical concept connects elements without requiring a unique image?",
       "ja": "1対多も許す、要素同士の対応を表す数学概念はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131143,7 +133016,6 @@
         "en": "Russell",
         "ja": "ラッセル",
         "ja_typings": [
-          "ratuseru",
           "rasseru"
         ]
       },
@@ -131158,7 +133030,6 @@
         "en": "Wittgenstein",
         "ja": "ウィトゲンシュタイン",
         "ja_typings": [
-          "uxitogensiyutain",
           "witogenshutain"
         ]
       },
@@ -131166,7 +133037,6 @@
         "en": "Moore",
         "ja": "ムーア",
         "ja_typings": [
-          "mu--a",
           "mu-a"
         ]
       }
@@ -131178,7 +133048,8 @@
     "question_text": {
       "en": "Which British philosopher co-wrote Principia Mathematica with Whitehead?",
       "ja": "ホワイトヘッドと『プリンキピア・マテマティカ』を著した英国の哲学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131193,7 +133064,7 @@
         "en": "Turing",
         "ja": "チューリング",
         "ja_typings": [
-          "chixyu-ringu"
+          "chu-ringu"
         ]
       },
       {
@@ -131207,7 +133078,7 @@
         "en": "Wiener",
         "ja": "ウィーナー",
         "ja_typings": [
-          "uxi-na-"
+          "wi-na-"
         ]
       }
     ],
@@ -131218,7 +133089,8 @@
     "question_text": {
       "en": "Which American mathematician founded information theory?",
       "ja": "情報理論を創始したアメリカの数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131240,16 +133112,14 @@
         "en": "Delta",
         "ja": "デルタ",
         "ja_typings": [
-          "deruta",
-          "deluta"
+          "deruta"
         ]
       },
       {
         "en": "Lambda",
         "ja": "ラムダ",
         "ja_typings": [
-          "ramuda",
-          "lamuda"
+          "ramuda"
         ]
       }
     ],
@@ -131260,7 +133130,8 @@
     "question_text": {
       "en": "Which Greek letter Σ denotes summation in mathematics?",
       "ja": "総和を表すギリシャ文字Σはどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131282,7 +133153,7 @@
         "en": "Exponential curve",
         "ja": "指数曲線",
         "ja_typings": [
-          "sisuukyokusen"
+          "shisuukyokusen"
         ]
       },
       {
@@ -131300,7 +133171,8 @@
     "question_text": {
       "en": "Which S-shaped curve is widely used in neural network activations?",
       "ja": "ニューラルネットの活性化関数で使われるS字曲線はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131329,7 +133201,7 @@
         "en": "Convex polygon",
         "ja": "凸多角形",
         "ja_typings": [
-          "totutakakukei"
+          "totsutakakukei"
         ]
       }
     ],
@@ -131340,7 +133212,8 @@
     "question_text": {
       "en": "Which type of polygon has the same shape but different size as another?",
       "ja": "形が同じで大きさが異なる多角形を何という?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131348,16 +133221,14 @@
         "en": "Tarski",
         "ja": "タルスキ",
         "ja_typings": [
-          "tarusuki",
-          "talusuki"
+          "tarusuki"
         ]
       },
       {
         "en": "Gödel",
         "ja": "ゲーデル",
         "ja_typings": [
-          "ge-deru",
-          "ge-delu"
+          "ge-deru"
         ]
       },
       {
@@ -131371,8 +133242,7 @@
         "en": "Kleene",
         "ja": "クリーネ",
         "ja_typings": [
-          "kuri-ne",
-          "kuli-ne"
+          "kuri-ne"
         ]
       }
     ],
@@ -131383,7 +133253,8 @@
     "question_text": {
       "en": "Which Polish-American logician is known for the definition of truth in formal languages?",
       "ja": "形式言語における真理の定義で知られるポーランド系米国の論理学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131423,7 +133294,8 @@
     "question_text": {
       "en": "Which Australian-American mathematician received the Fields Medal in 2006?",
       "ja": "2006年にフィールズ賞を受賞した豪州系米国の数学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131431,28 +133303,28 @@
         "en": "Turing Award",
         "ja": "チューリング賞",
         "ja_typings": [
-          "chixyu-ringuxsiyou"
+          "chu-ringushou"
         ]
       },
       {
         "en": "Fields Medal",
         "ja": "フィールズ賞",
         "ja_typings": [
-          "fi-ruzuxsiyou"
+          "fi-ruzushou"
         ]
       },
       {
         "en": "Abel Prize",
         "ja": "アーベル賞",
         "ja_typings": [
-          "a-beruxsiyou"
+          "a-berushou"
         ]
       },
       {
         "en": "Wolf Prize",
         "ja": "ウルフ賞",
         "ja_typings": [
-          "uruhuxsiyou"
+          "urufushou"
         ]
       }
     ],
@@ -131463,7 +133335,8 @@
     "question_text": {
       "en": "Which prize is the highest honor in computer science, given by the ACM?",
       "ja": "ACM が授与する計算機科学最高の賞はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131471,16 +133344,13 @@
         "en": "Vector",
         "ja": "ベクトル",
         "ja_typings": [
-          "bekutoru",
-          "bekutolu"
+          "bekutoru"
         ]
       },
       {
         "en": "Scalar",
         "ja": "スカラー",
         "ja_typings": [
-          "sukara--",
-          "sukalaa-",
           "sukara-"
         ]
       },
@@ -131488,16 +133358,14 @@
         "en": "Tensor",
         "ja": "テンソル",
         "ja_typings": [
-          "tensoru",
-          "tensolu"
+          "tensoru"
         ]
       },
       {
         "en": "Matrix",
         "ja": "行列",
         "ja_typings": [
-          "gyouretu",
-          "gyouletu"
+          "gyouretsu"
         ]
       }
     ],
@@ -131508,7 +133376,8 @@
     "question_text": {
       "en": "Which mathematical object has both magnitude and direction?",
       "ja": "大きさと向きを持つ数学的対象はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131523,14 +133392,13 @@
         "en": "Turing",
         "ja": "チューリング",
         "ja_typings": [
-          "chixyu-ringu"
+          "chu-ringu"
         ]
       },
       {
         "en": "Babbage",
         "ja": "バベッジ",
         "ja_typings": [
-          "bayatuji",
           "babejji"
         ]
       },
@@ -131549,7 +133417,8 @@
     "question_text": {
       "en": "Who is the Hungarian-American polymath who pioneered modern computer architecture?",
       "ja": "現代コンピュータ・アーキテクチャを築いたハンガリー系米国の万能学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131557,29 +133426,28 @@
         "en": "Wolf Prize",
         "ja": "ウルフ賞",
         "ja_typings": [
-          "uruhuxsiyou",
-          "uluhusyou"
+          "urufushou"
         ]
       },
       {
         "en": "Abel Prize",
         "ja": "アーベル賞",
         "ja_typings": [
-          "a-beruxsiyou"
+          "a-berushou"
         ]
       },
       {
         "en": "Fields Medal",
         "ja": "フィールズ賞",
         "ja_typings": [
-          "fi-ruzuxsiyou"
+          "fi-ruzushou"
         ]
       },
       {
         "en": "Turing Award",
         "ja": "チューリング賞",
         "ja_typings": [
-          "chixyu-ringuxsiyou"
+          "chu-ringushou"
         ]
       }
     ],
@@ -131590,7 +133458,8 @@
     "question_text": {
       "en": "Which Israeli prize is given for outstanding achievements in mathematics and the arts?",
       "ja": "数学や芸術での業績に贈られるイスラエルの賞はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131634,7 +133503,8 @@
     "question_text": {
       "en": "How many wheels does a unicycle have?",
       "ja": "一輪車のタイヤは何輪?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131674,7 +133544,8 @@
     "question_text": {
       "en": "How many months are in a year?",
       "ja": "1年は何か月?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131718,7 +133589,8 @@
     "question_text": {
       "en": "How many wheels does a bicycle have?",
       "ja": "自転車のタイヤは何輪?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131762,7 +133634,8 @@
     "question_text": {
       "en": "How many fingers does a typical human have in total?",
       "ja": "人の指は両手で何本?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131804,7 +133677,8 @@
     "question_text": {
       "en": "About how long is a full marathon?",
       "ja": "フルマラソンの距離はおよそ何km?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131844,7 +133718,8 @@
     "question_text": {
       "en": "How many days does April have?",
       "ja": "4月は何日まで?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131888,7 +133763,8 @@
     "question_text": {
       "en": "About how long is a half marathon?",
       "ja": "ハーフマラソンの距離はおよそ何km?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131921,10 +133797,7 @@
         "en": "12 minutes",
         "ja": "12分",
         "ja_typings": [
-          "12hun",
-          "12pun",
-          "12bun",
-          "juunihun"
+          "12fun"
         ]
       }
     ],
@@ -131935,7 +133808,8 @@
     "question_text": {
       "en": "How long is one period in a high school basketball game?",
       "ja": "高校バスケのクォーター1ピリオドは何分?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131950,7 +133824,6 @@
         "en": "2",
         "ja": "2つ",
         "ja_typings": [
-          "futatsu",
           "2tsu"
         ]
       },
@@ -131976,7 +133849,8 @@
     "question_text": {
       "en": "How many seasons are there in a year?",
       "ja": "1年の季節はいくつ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132012,9 +133886,7 @@
         "en": "45 minutes",
         "ja": "45分",
         "ja_typings": [
-          "45hun",
-          "45pun",
-          "45bun"
+          "45fun"
         ]
       }
     ],
@@ -132025,7 +133897,8 @@
     "question_text": {
       "en": "How long is one half in a college basketball game (NCAA men)?",
       "ja": "NCAA男子バスケのハーフは何分?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132069,7 +133942,8 @@
     "question_text": {
       "en": "About how fast does a 100m sprinter run in km/h?",
       "ja": "100m走の世界トップ選手のおよその速度は時速何km?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132114,7 +133988,8 @@
     "question_text": {
       "en": "How long is one half of a soccer match?",
       "ja": "サッカーの前半・後半は何分?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132122,8 +133997,7 @@
         "en": "Alexander Graham Bell",
         "ja": "アレクサンダー・グラハム・ベル",
         "ja_typings": [
-          "arekusanda-/gurahamu/beru",
-          "alekusanda-/gulahamu/belu"
+          "arekusanda-/gurahamu/beru"
         ]
       },
       {
@@ -132137,8 +134011,6 @@
         "en": "Samuel Morse",
         "ja": "サミュエル・モールス",
         "ja_typings": [
-          "samiyueru/mo-rusu",
-          "samyueru/mo-lusu",
           "samyueru/mo-rusu"
         ]
       },
@@ -132146,8 +134018,7 @@
         "en": "Nikola Tesla",
         "ja": "ニコラ・テスラ",
         "ja_typings": [
-          "nikora/tesura",
-          "nikola/tesula"
+          "nikora/tesura"
         ]
       }
     ],
@@ -132158,7 +134029,8 @@
     "question_text": {
       "en": "Who is credited with inventing the telephone in 1876?",
       "ja": "1876年に電話を発明したとされる人物は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132166,7 +134038,6 @@
         "en": "Anton Chekhov",
         "ja": "アントン・チェーホフ",
         "ja_typings": [
-          "anton/chie-hohu",
           "anton/che-hofu"
         ]
       },
@@ -132188,7 +134059,7 @@
         "en": "Fyodor Dostoevsky",
         "ja": "ドストエフスキー",
         "ja_typings": [
-          "dosutoehusuki-"
+          "dosutoefusuki-"
         ]
       }
     ],
@@ -132199,7 +134070,8 @@
     "question_text": {
       "en": "Who is the Russian playwright that wrote The Cherry Orchard?",
       "ja": "『桜の園』を書いたロシアの劇作家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132207,24 +134079,20 @@
         "en": "Belle",
         "ja": "ベル",
         "ja_typings": [
-          "beru",
-          "belu"
+          "beru"
         ]
       },
       {
         "en": "Ariel",
         "ja": "アリエル",
         "ja_typings": [
-          "arieru",
-          "alielu"
+          "arieru"
         ]
       },
       {
         "en": "Cinderella",
         "ja": "シンデレラ",
         "ja_typings": [
-          "shindererera",
-          "shindelelela",
           "shinderera"
         ]
       },
@@ -132232,7 +134100,6 @@
         "en": "Jasmine",
         "ja": "ジャスミン",
         "ja_typings": [
-          "jiyasumin",
           "jasumin"
         ]
       }
@@ -132244,7 +134111,8 @@
     "question_text": {
       "en": "Who is the heroine of Disney's Beauty and the Beast?",
       "ja": "ディズニー『美女と野獣』のヒロインは誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132259,7 +134127,6 @@
         "en": "Steve Jobs",
         "ja": "スティーブ・ジョブズ",
         "ja_typings": [
-          "sutexi-bu/jiyobuzu",
           "suthi-bu/jobuzu"
         ]
       },
@@ -132267,7 +134134,6 @@
         "en": "Steve Wozniak",
         "ja": "スティーブ・ウォズニアック",
         "ja_typings": [
-          "sutexi-bu/uxozuniatuku",
           "suthi-bu/wozuniakku"
         ]
       },
@@ -132275,8 +134141,7 @@
         "en": "Larry Page",
         "ja": "ラリー・ペイジ",
         "ja_typings": [
-          "rari-/peiji",
-          "lali-/peiji"
+          "rari-/peiji"
         ]
       }
     ],
@@ -132287,7 +134152,8 @@
     "question_text": {
       "en": "Who co-founded Microsoft with Paul Allen?",
       "ja": "ポール・アレンとマイクロソフトを共同創業したのは誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132295,8 +134161,7 @@
         "en": "Brazil",
         "ja": "ブラジル",
         "ja_typings": [
-          "burajiru",
-          "bulajiru"
+          "burajiru"
         ]
       },
       {
@@ -132317,8 +134182,7 @@
         "en": "Colombia",
         "ja": "コロンビア",
         "ja_typings": [
-          "koronbia",
-          "kolonbia"
+          "koronbia"
         ]
       }
     ],
@@ -132329,7 +134193,8 @@
     "question_text": {
       "en": "Which country's flag features a yellow lozenge on a green field?",
       "ja": "緑地に黄色のひし形がある国旗はどこの国?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132337,24 +134202,20 @@
         "en": "C. S. Lewis",
         "ja": "C.S.ルイス",
         "ja_typings": [
-          "c.s.ruisu",
-          "shi-esuruisu"
+          "c.s.ruisu"
         ]
       },
       {
         "en": "J. R. R. Tolkien",
         "ja": "J.R.R.トールキン",
         "ja_typings": [
-          "j.r.r.to-rukin",
-          "jeia-rua-ruto-rukin"
+          "j.r.r.to-rukin"
         ]
       },
       {
         "en": "Roald Dahl",
         "ja": "ロアルド・ダール",
         "ja_typings": [
-          "roarudo/da--ru",
-          "loaludo/daa-lu",
           "roarudo/da-ru"
         ]
       },
@@ -132362,8 +134223,6 @@
         "en": "Lewis Carroll",
         "ja": "ルイス・キャロル",
         "ja_typings": [
-          "ruisu/kiyaroru",
-          "luisu/kyalolu",
           "ruisu/kyaroru"
         ]
       }
@@ -132375,7 +134234,8 @@
     "question_text": {
       "en": "Who wrote The Chronicles of Narnia?",
       "ja": "『ナルニア国物語』を書いた作家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132383,8 +134243,6 @@
         "en": "Charles Dickens",
         "ja": "チャールズ・ディケンズ",
         "ja_typings": [
-          "chiya-ruzu/dexikenzu",
-          "cha-luzu/dhikenzu",
           "cha-ruzu/dhikenzu"
         ]
       },
@@ -132392,7 +134250,6 @@
         "en": "Mark Twain",
         "ja": "マーク・トウェイン",
         "ja_typings": [
-          "ma--ku/touxein",
           "ma-ku/towein"
         ]
       },
@@ -132400,8 +134257,6 @@
         "en": "Oscar Wilde",
         "ja": "オスカー・ワイルド",
         "ja_typings": [
-          "osuka--/wairudo",
-          "osuka--/wailudo",
           "osuka-/wairudo"
         ]
       },
@@ -132409,7 +134264,6 @@
         "en": "Jane Austen",
         "ja": "ジェーン・オースティン",
         "ja_typings": [
-          "jixe-n/oo-sutexin",
           "je-n/o-suthin"
         ]
       }
@@ -132421,7 +134275,8 @@
     "question_text": {
       "en": "Who wrote A Christmas Carol and Oliver Twist?",
       "ja": "『クリスマス・キャロル』『オリバー・ツイスト』を書いた英国の作家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132429,14 +134284,14 @@
         "en": "China",
         "ja": "中国",
         "ja_typings": [
-          "tixyuugoku"
+          "chuugoku"
         ]
       },
       {
         "en": "United States",
         "ja": "アメリカ合衆国",
         "ja_typings": [
-          "amerikagatusiyuukoku"
+          "amerikagasshuukoku"
         ]
       },
       {
@@ -132461,7 +134316,8 @@
     "question_text": {
       "en": "Which country has the world's largest population alongside India?",
       "ja": "インドと並んで世界最大級の人口を持つ国はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132476,7 +134332,6 @@
         "en": "Bessie",
         "ja": "ベッシー",
         "ja_typings": [
-          "betusi-",
           "besshi-"
         ]
       },
@@ -132484,8 +134339,6 @@
         "en": "Buttercup",
         "ja": "バターカップ",
         "ja_typings": [
-          "bata--katupu",
-          "bata--kappu",
           "bata-kappu"
         ]
       },
@@ -132493,8 +134346,6 @@
         "en": "Clover",
         "ja": "クローバー",
         "ja_typings": [
-          "kuro--ba--",
-          "kuloo-baa-",
           "kuro-ba-"
         ]
       }
@@ -132506,7 +134357,8 @@
     "question_text": {
       "en": "Which is a common pet name often associated with cows in English?",
       "ja": "英語圏で乳牛によく付けられる名前はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132548,7 +134400,8 @@
     "question_text": {
       "en": "What is the official language of the Netherlands?",
       "ja": "オランダの公用語はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132563,7 +134416,6 @@
         "en": "Sudan",
         "ja": "スーダン",
         "ja_typings": [
-          "su--dan",
           "su-dan"
         ]
       },
@@ -132571,16 +134423,14 @@
         "en": "Libya",
         "ja": "リビア",
         "ja_typings": [
-          "ribia",
-          "libia"
+          "ribia"
         ]
       },
       {
         "en": "Iraq",
         "ja": "イラク",
         "ja_typings": [
-          "iraku",
-          "ilaku"
+          "iraku"
         ]
       }
     ],
@@ -132591,7 +134441,8 @@
     "question_text": {
       "en": "In which country are the Pyramids of Giza located?",
       "ja": "ギザのピラミッドがある国はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132633,7 +134484,8 @@
     "question_text": {
       "en": "Which plant family includes peas and beans?",
       "ja": "エンドウやマメを含む植物の科はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132641,8 +134493,6 @@
         "en": "Florence",
         "ja": "フィレンツェ",
         "ja_typings": [
-          "fuxirentue",
-          "filentse",
           "firentse"
         ]
       },
@@ -132650,16 +134500,13 @@
         "en": "Milan",
         "ja": "ミラノ",
         "ja_typings": [
-          "mirano",
-          "milano"
+          "mirano"
         ]
       },
       {
         "en": "Rome",
         "ja": "ローマ",
         "ja_typings": [
-          "ro--ma",
-          "loo-ma",
           "ro-ma"
         ]
       },
@@ -132667,7 +134514,6 @@
         "en": "Venice",
         "ja": "ヴェネツィア",
         "ja_typings": [
-          "venetsuxia",
           "venetsia"
         ]
       }
@@ -132679,7 +134525,8 @@
     "question_text": {
       "en": "Which Italian city is famous as the cradle of the Renaissance?",
       "ja": "ルネサンス発祥の地として知られるイタリアの都市はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132687,7 +134534,6 @@
         "en": "Frances Hodgson Burnett",
         "ja": "バーネット",
         "ja_typings": [
-          "ba--netuto",
           "ba-netto"
         ]
       },
@@ -132695,8 +134541,6 @@
         "en": "Louisa May Alcott",
         "ja": "オルコット",
         "ja_typings": [
-          "orukotuto",
-          "olukotto",
           "orukotto"
         ]
       },
@@ -132704,7 +134548,6 @@
         "en": "Beatrix Potter",
         "ja": "ポター",
         "ja_typings": [
-          "pota--",
           "pota-"
         ]
       },
@@ -132712,8 +134555,7 @@
         "en": "Lucy Maud Montgomery",
         "ja": "モンゴメリ",
         "ja_typings": [
-          "mongomeri",
-          "mongomeli"
+          "mongomeri"
         ]
       }
     ],
@@ -132724,7 +134566,8 @@
     "question_text": {
       "en": "Who wrote The Secret Garden and A Little Princess?",
       "ja": "『秘密の花園』『小公女』を書いた英米の作家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132732,7 +134575,7 @@
         "en": "Fyodor Dostoevsky",
         "ja": "ドストエフスキー",
         "ja_typings": [
-          "dosutoehusuki-"
+          "dosutoefusuki-"
         ]
       },
       {
@@ -132746,7 +134589,6 @@
         "en": "Anton Chekhov",
         "ja": "アントン・チェーホフ",
         "ja_typings": [
-          "anton/chie-hohu",
           "anton/che-hofu"
         ]
       },
@@ -132765,7 +134607,8 @@
     "question_text": {
       "en": "Who wrote Crime and Punishment and The Brothers Karamazov?",
       "ja": "『罪と罰』『カラマーゾフの兄弟』を書いた作家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132780,8 +134623,6 @@
         "en": "Austria",
         "ja": "オーストリア",
         "ja_typings": [
-          "o--sutoria",
-          "o--sutolia",
           "o-sutoria"
         ]
       },
@@ -132796,8 +134637,7 @@
         "en": "Netherlands",
         "ja": "オランダ",
         "ja_typings": [
-          "oranda",
-          "olanda"
+          "oranda"
         ]
       }
     ],
@@ -132808,7 +134648,8 @@
     "question_text": {
       "en": "In which country is the city Munich located?",
       "ja": "ミュンヘンがある国はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132850,7 +134691,8 @@
     "question_text": {
       "en": "Which Japanese bacteriologist appears on the 1000-yen note?",
       "ja": "1000円札の肖像となった日本の細菌学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132872,7 +134714,6 @@
         "en": "George R. R. Martin",
         "ja": "ジョージ・R.R.マーティン",
         "ja_typings": [
-          "jiyo-ji/r.r.maa-texin",
           "jo-ji/r.r.ma-thin"
         ]
       },
@@ -132880,8 +134721,6 @@
         "en": "Terry Pratchett",
         "ja": "テリー・プラチェット",
         "ja_typings": [
-          "teri-/puratietuto",
-          "teli-/pulachetto",
           "teri-/purachetto"
         ]
       }
@@ -132893,7 +134732,8 @@
     "question_text": {
       "en": "Who wrote The Lord of the Rings?",
       "ja": "『指輪物語』を書いた英国の作家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132935,7 +134775,8 @@
     "question_text": {
       "en": "Which Japanese chemist first isolated adrenaline?",
       "ja": "アドレナリンを世界で初めて結晶化した日本の化学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132958,7 +134799,7 @@
         "en": "Shibasaburo Kitasato",
         "ja": "北里柴三郎",
         "ja_typings": [
-          "kitasatosibasaburou"
+          "kitasatoshibasaburou"
         ]
       },
       {
@@ -132976,7 +134817,8 @@
     "question_text": {
       "en": "Which Japanese bacteriologist discovered the dysentery bacillus?",
       "ja": "赤痢菌を発見した日本の細菌学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132984,16 +134826,13 @@
         "en": "Los Angeles",
         "ja": "ロサンゼルス",
         "ja_typings": [
-          "rosanzerusu",
-          "losanzelusu"
+          "rosanzerusu"
         ]
       },
       {
         "en": "New York",
         "ja": "ニューヨーク",
         "ja_typings": [
-          "niyuu-yoo-ku",
-          "nyu--yo--ku",
           "nyu-yo-ku"
         ]
       },
@@ -133019,7 +134858,8 @@
     "question_text": {
       "en": "Which American city is the heart of the U.S. film industry (Hollywood)?",
       "ja": "ハリウッドがある、米国映画産業の中心都市はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133061,7 +134901,8 @@
     "question_text": {
       "en": "Which plant family includes magnolias?",
       "ja": "モクレンやコブシを含む植物の科はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133069,16 +134910,13 @@
         "en": "Melanie",
         "ja": "メラニー",
         "ja_typings": [
-          "merani-",
-          "melani-"
+          "merani-"
         ]
       },
       {
         "en": "Scarlett",
         "ja": "スカーレット",
         "ja_typings": [
-          "suka--retuto",
-          "suka--letto",
           "suka-retto"
         ]
       },
@@ -133086,8 +134924,6 @@
         "en": "Suellen",
         "ja": "スーエレン",
         "ja_typings": [
-          "su--eren",
-          "su--elen",
           "su-eren"
         ]
       },
@@ -133106,7 +134942,8 @@
     "question_text": {
       "en": "Which character is the antagonist's sister in Gone with the Wind?",
       "ja": "『風と共に去りぬ』に登場するアシュレーの妻の名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133114,16 +134951,13 @@
         "en": "Milan",
         "ja": "ミラノ",
         "ja_typings": [
-          "mirano",
-          "milano"
+          "mirano"
         ]
       },
       {
         "en": "Rome",
         "ja": "ローマ",
         "ja_typings": [
-          "ro--ma",
-          "loo-ma",
           "ro-ma"
         ]
       },
@@ -133131,7 +134965,6 @@
         "en": "Florence",
         "ja": "フィレンツェ",
         "ja_typings": [
-          "fuxirentue",
           "firentse"
         ]
       },
@@ -133139,8 +134972,7 @@
         "en": "Naples",
         "ja": "ナポリ",
         "ja_typings": [
-          "napori",
-          "napoli"
+          "napori"
         ]
       }
     ],
@@ -133151,7 +134983,8 @@
     "question_text": {
       "en": "Which Italian city is famous for fashion and the La Scala opera house?",
       "ja": "ファッションとスカラ座で有名なイタリアの都市はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133159,8 +134992,6 @@
         "en": "New York",
         "ja": "ニューヨーク",
         "ja_typings": [
-          "niyuu-yoo-ku",
-          "nyu--yo--ku",
           "nyu-yo-ku"
         ]
       },
@@ -133193,7 +135024,8 @@
     "question_text": {
       "en": "Which American city is home to the Statue of Liberty?",
       "ja": "自由の女神像があるアメリカの都市はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133201,15 +135033,13 @@
         "en": "Nikolai Gogol",
         "ja": "ニコライ・ゴーゴリ",
         "ja_typings": [
-          "nikorai/go-gori",
-          "nikolai/go-goli"
+          "nikorai/go-gori"
         ]
       },
       {
         "en": "Anton Chekhov",
         "ja": "アントン・チェーホフ",
         "ja_typings": [
-          "anton/chie-hohu",
           "anton/che-hofu"
         ]
       },
@@ -133217,7 +135047,7 @@
         "en": "Fyodor Dostoevsky",
         "ja": "ドストエフスキー",
         "ja_typings": [
-          "dosutoehusuki-"
+          "dosutoefusuki-"
         ]
       },
       {
@@ -133235,7 +135065,8 @@
     "question_text": {
       "en": "Who wrote the Russian short story The Overcoat?",
       "ja": "『外套』を書いたロシアの作家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133243,8 +135074,6 @@
         "en": "Oscar Wilde",
         "ja": "オスカー・ワイルド",
         "ja_typings": [
-          "osuka--/wairudo",
-          "osuka--/wailudo",
           "osuka-/wairudo"
         ]
       },
@@ -133252,7 +135081,6 @@
         "en": "Charles Dickens",
         "ja": "チャールズ・ディケンズ",
         "ja_typings": [
-          "chiya-ruzu/dexikenzu",
           "cha-ruzu/dhikenzu"
         ]
       },
@@ -133260,8 +135088,6 @@
         "en": "Bram Stoker",
         "ja": "ブラム・ストーカー",
         "ja_typings": [
-          "buramu/suto--ka--",
-          "bulamu/sutoo-kaa-",
           "buramu/suto-ka-"
         ]
       },
@@ -133280,7 +135106,8 @@
     "question_text": {
       "en": "Who wrote The Picture of Dorian Gray?",
       "ja": "『ドリアン・グレイの肖像』を書いた作家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133296,8 +135123,6 @@
         "en": "Red radish",
         "ja": "ラディッシュ",
         "ja_typings": [
-          "radexitusiyu",
-          "radhixisshu",
           "radhisshu"
         ]
       },
@@ -133312,7 +135137,6 @@
         "en": "Beetroot",
         "ja": "ビーツ",
         "ja_typings": [
-          "bi--tsu",
           "bi-tsu"
         ]
       }
@@ -133324,7 +135148,8 @@
     "question_text": {
       "en": "Which vegetable is purple-leaved and used in coleslaw and salads?",
       "ja": "紫色の葉でサラダやコールスローに使う野菜はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133332,8 +135157,6 @@
         "en": "Red radish",
         "ja": "ラディッシュ",
         "ja_typings": [
-          "radexitusiyu",
-          "radhixisshu",
           "radhisshu"
         ]
       },
@@ -133341,7 +135164,7 @@
         "en": "Red cabbage",
         "ja": "紫キャベツ",
         "ja_typings": [
-          "murasakikiyabetu"
+          "murasakikyabetsu"
         ]
       },
       {
@@ -133355,7 +135178,6 @@
         "en": "Beetroot",
         "ja": "ビーツ",
         "ja_typings": [
-          "bi--tsu",
           "bi-tsu"
         ]
       }
@@ -133367,7 +135189,8 @@
     "question_text": {
       "en": "Which small red root vegetable is often called the salad radish?",
       "ja": "サラダによく使う小さな赤い根菜はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133375,8 +135198,6 @@
         "en": "Roald Dahl",
         "ja": "ロアルド・ダール",
         "ja_typings": [
-          "roarudo/da--ru",
-          "loaludo/daa-lu",
           "roarudo/da-ru"
         ]
       },
@@ -133384,7 +135205,6 @@
         "en": "J. K. Rowling",
         "ja": "J.K.ローリング",
         "ja_typings": [
-          "j.k.ro--ringu",
           "j.k.ro-ringu"
         ]
       },
@@ -133399,7 +135219,6 @@
         "en": "Lewis Carroll",
         "ja": "ルイス・キャロル",
         "ja_typings": [
-          "ruisu/kiyaroru",
           "ruisu/kyaroru"
         ]
       }
@@ -133411,7 +135230,8 @@
     "question_text": {
       "en": "Who wrote Charlie and the Chocolate Factory?",
       "ja": "『チョコレート工場の秘密』を書いた作家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133419,8 +135239,6 @@
         "en": "Rome",
         "ja": "ローマ",
         "ja_typings": [
-          "ro--ma",
-          "loo-ma",
           "ro-ma"
         ]
       },
@@ -133428,15 +135246,13 @@
         "en": "Milan",
         "ja": "ミラノ",
         "ja_typings": [
-          "mirano",
-          "milano"
+          "mirano"
         ]
       },
       {
         "en": "Florence",
         "ja": "フィレンツェ",
         "ja_typings": [
-          "fuxirentue",
           "firentse"
         ]
       },
@@ -133444,7 +135260,6 @@
         "en": "Venice",
         "ja": "ヴェネツィア",
         "ja_typings": [
-          "vuxenetuxia",
           "venetsia"
         ]
       }
@@ -133456,7 +135271,8 @@
     "question_text": {
       "en": "Which is the capital of Italy?",
       "ja": "イタリアの首都はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133464,8 +135280,6 @@
         "en": "Samuel Morse",
         "ja": "サミュエル・モールス",
         "ja_typings": [
-          "samiyueru/mo-rusu",
-          "samyueru/mo-lusu",
           "samyueru/mo-rusu"
         ]
       },
@@ -133498,7 +135312,8 @@
     "question_text": {
       "en": "Who invented the famous telegraph code of dots and dashes?",
       "ja": "点と線の電信符号を発明した米国の発明家は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133520,15 +135335,14 @@
         "en": "San Diego",
         "ja": "サンディエゴ",
         "ja_typings": [
-          "sandexiego"
+          "sandhiego"
         ]
       },
       {
         "en": "Sacramento",
         "ja": "サクラメント",
         "ja_typings": [
-          "sakuramento",
-          "sakulamento"
+          "sakuramento"
         ]
       }
     ],
@@ -133539,7 +135353,8 @@
     "question_text": {
       "en": "Which Californian city is famous for the Golden Gate Bridge?",
       "ja": "ゴールデンゲートブリッジで有名なカリフォルニアの都市はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133547,7 +135362,6 @@
         "en": "Steve Wozniak",
         "ja": "スティーブ・ウォズニアック",
         "ja_typings": [
-          "sutexi-bu/uxozuniatuku",
           "suthi-bu/wozuniakku"
         ]
       },
@@ -133562,7 +135376,6 @@
         "en": "Tim Cook",
         "ja": "ティム・クック",
         "ja_typings": [
-          "teximu/kutuku",
           "thimu/kukku"
         ]
       },
@@ -133581,7 +135394,8 @@
     "question_text": {
       "en": "Who co-founded Apple Computer with Steve Jobs in 1976?",
       "ja": "1976年にスティーブ・ジョブズとアップルを共同創業したのは誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133604,7 +135418,7 @@
         "en": "Danish",
         "ja": "デンマーク語",
         "ja_typings": [
-          "denma--kugo"
+          "denma-kugo"
         ]
       },
       {
@@ -133623,7 +135437,8 @@
     "question_text": {
       "en": "What is the official language of Sweden?",
       "ja": "スウェーデンの公用語はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133652,8 +135467,7 @@
         "en": "Laos",
         "ja": "ラオス",
         "ja_typings": [
-          "raosu",
-          "laosu"
+          "raosu"
         ]
       }
     ],
@@ -133664,7 +135478,8 @@
     "question_text": {
       "en": "In which country is Bangkok the capital?",
       "ja": "首都がバンコクの国はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133704,7 +135519,8 @@
     "question_text": {
       "en": "Which plant family includes tea and camellia?",
       "ja": "ツバキやチャを含む植物の科はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133712,7 +135528,6 @@
         "en": "Tim Cook",
         "ja": "ティム・クック",
         "ja_typings": [
-          "teximu/kutuku",
           "thimu/kukku"
         ]
       },
@@ -133720,7 +135535,6 @@
         "en": "Jonathan Ive",
         "ja": "ジョナサン・アイブ",
         "ja_typings": [
-          "jiyonasan/aibu",
           "jonasan/aibu"
         ]
       },
@@ -133728,8 +135542,6 @@
         "en": "Eddy Cue",
         "ja": "エディ・キュー",
         "ja_typings": [
-          "edexi-/kiyuu-",
-          "edhii-/kyu--",
           "edhi/kyu-"
         ]
       },
@@ -133737,8 +135549,6 @@
         "en": "Craig Federighi",
         "ja": "クレイグ・フェデリギ",
         "ja_typings": [
-          "kureigu/fuederigi",
-          "kuleigu/federigi",
           "kureigu/federigi"
         ]
       }
@@ -133750,7 +135560,8 @@
     "question_text": {
       "en": "Who succeeded Steve Jobs as CEO of Apple?",
       "ja": "スティーブ・ジョブズの後を継ぎアップルCEOになったのは誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133758,16 +135569,13 @@
         "en": "Turkey",
         "ja": "トルコ",
         "ja_typings": [
-          "toruko",
-          "toluko"
+          "toruko"
         ]
       },
       {
         "en": "Greece",
         "ja": "ギリシャ",
         "ja_typings": [
-          "girisiya",
-          "gilisya",
           "girisha"
         ]
       },
@@ -133775,8 +135583,7 @@
         "en": "Bulgaria",
         "ja": "ブルガリア",
         "ja_typings": [
-          "burugaria",
-          "bulugalia"
+          "burugaria"
         ]
       },
       {
@@ -133794,7 +135601,8 @@
     "question_text": {
       "en": "In which country is the city Istanbul located?",
       "ja": "イスタンブールがある国はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133802,7 +135610,7 @@
         "en": "United States",
         "ja": "アメリカ合衆国",
         "ja_typings": [
-          "amerikagatusiyuukoku"
+          "amerikagasshuukoku"
         ]
       },
       {
@@ -133823,8 +135631,7 @@
         "en": "United Kingdom",
         "ja": "イギリス",
         "ja_typings": [
-          "igirisu",
-          "igilisu"
+          "igirisu"
         ]
       }
     ],
@@ -133835,7 +135642,8 @@
     "question_text": {
       "en": "Which country has its capital at Washington, D.C.?",
       "ja": "首都がワシントンD.C.の国はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133850,7 +135658,6 @@
         "en": "Oman",
         "ja": "オマーン",
         "ja_typings": [
-          "oma--n",
           "oma-n"
         ]
       },
@@ -133858,8 +135665,6 @@
         "en": "Qatar",
         "ja": "カタール",
         "ja_typings": [
-          "kata--ru",
-          "kata--lu",
           "kata-ru"
         ]
       },
@@ -133867,8 +135672,6 @@
         "en": "Bahrain",
         "ja": "バーレーン",
         "ja_typings": [
-          "ba--re-n",
-          "ba--le-n",
           "ba-re-n"
         ]
       }
@@ -133880,7 +135683,8 @@
     "question_text": {
       "en": "Which country's capital is Sana'a in the Arabian Peninsula?",
       "ja": "首都がサヌアであるアラビア半島の国はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133923,7 +135727,8 @@
     "question_text": {
       "en": "Frogs and salamanders belong to which class of animals?",
       "ja": "カエルやサンショウウオが属する動物の綱はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133963,7 +135768,8 @@
     "question_text": {
       "en": "How often are the Summer Olympics normally held?",
       "ja": "夏季オリンピックは通常何年ごとに開催される?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134003,7 +135809,8 @@
     "question_text": {
       "en": "How often is the World Athletics Championships held in odd years (recently)?",
       "ja": "近年、世界陸上は何年ごとに開催される?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134018,7 +135825,6 @@
         "en": "flash of a camera",
         "ja": "カメラのフラッシュ",
         "ja_typings": [
-          "kameranohuratusiyu",
           "kameranofurasshu"
         ]
       },
@@ -134033,7 +135839,7 @@
         "en": "torch flame",
         "ja": "松明の炎",
         "ja_typings": [
-          "taimatunohonoo"
+          "taimatsunohonoo"
         ]
       }
     ],
@@ -134044,7 +135850,8 @@
     "question_text": {
       "en": "What does the kanji 電 (as in 電光) literally depict?",
       "ja": "「電光石火」の「電光」が指すのはどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134067,14 +135874,14 @@
         "en": "temple guardian",
         "ja": "寺院の守護神",
         "ja_typings": [
-          "jiinnosiyugosin"
+          "jiinnoshugoshin"
         ]
       },
       {
         "en": "running deer",
         "ja": "走る鹿",
         "ja_typings": [
-          "hasiruxsika"
+          "hashirushika"
         ]
       }
     ],
@@ -134085,7 +135892,8 @@
     "question_text": {
       "en": "What does the kanji 韋 in 韋駄天 originally evoke as an image?",
       "ja": "「韋駄天走り」のもとになるイメージはどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134100,8 +135908,6 @@
         "en": "cycle hit",
         "ja": "サイクルヒット",
         "ja_typings": [
-          "saikuruhitututo",
-          "saikuluhitto",
           "saikuruhitto"
         ]
       },
@@ -134116,7 +135922,6 @@
         "en": "perfect day",
         "ja": "パーフェクトデー",
         "ja_typings": [
-          "pa--fuxekutode-",
           "pa-fekutode-"
         ]
       }
@@ -134128,7 +135933,8 @@
     "question_text": {
       "en": "In baseball, hitting four doubles in a single game is colloquially what?",
       "ja": "野球で1試合に二塁打を4本打つことを何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134157,7 +135963,6 @@
         "en": "cycle hit",
         "ja": "サイクルヒット",
         "ja_typings": [
-          "saikuruhitututo",
           "saikuruhitto"
         ]
       }
@@ -134169,7 +135974,8 @@
     "question_text": {
       "en": "In baseball, what do you call hitting four home runs in one game?",
       "ja": "野球で1試合に本塁打を4本打つことを何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134177,25 +135983,21 @@
         "en": "frog",
         "ja": "カエル",
         "ja_typings": [
-          "kaeru",
-          "kaelu"
+          "kaeru"
         ]
       },
       {
         "en": "salamander",
         "ja": "サンショウウオ",
         "ja_typings": [
-          "sansiyouuo",
-          "sanshouuo",
-          "sanshouo"
+          "sanshouuo"
         ]
       },
       {
         "en": "newt",
         "ja": "イモリ",
         "ja_typings": [
-          "imori",
-          "imoli"
+          "imori"
         ]
       },
       {
@@ -134213,7 +136015,8 @@
     "question_text": {
       "en": "Which amphibian is known for metamorphosing from a tadpole?",
       "ja": "オタマジャクシから変態することで知られる両生類はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134253,7 +136056,8 @@
     "question_text": {
       "en": "What part of a plant typically develops from a fertilized flower and contains seeds?",
       "ja": "受粉した花が成熟してできる、種子を含む部分はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134296,7 +136100,8 @@
     "question_text": {
       "en": "Which sense allows some animals to navigate using Earth's field?",
       "ja": "地磁気を使ってナビゲーションする動物が持つ感覚はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134336,7 +136141,8 @@
     "question_text": {
       "en": "Which food group is the primary source of animal protein in many diets?",
       "ja": "多くの食生活で動物性たんぱく質の主な供給源はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134359,7 +136165,7 @@
         "en": "echolocation",
         "ja": "反響定位",
         "ja_typings": [
-          "hankiyouteii"
+          "hankyouteii"
         ]
       },
       {
@@ -134377,7 +136183,8 @@
     "question_text": {
       "en": "Which ability lets owls and cats hunt in very low light?",
       "ja": "フクロウやネコが暗所で狩りができる視覚能力はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134392,8 +136199,7 @@
         "en": "crow",
         "ja": "カラス",
         "ja_typings": [
-          "karasu",
-          "kalasu"
+          "karasu"
         ]
       },
       {
@@ -134418,7 +136224,8 @@
     "question_text": {
       "en": "Which bird is famous for its homing ability and is often white in symbolism?",
       "ja": "帰巣本能で知られ、平和の象徴とされる鳥はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134433,24 +136240,20 @@
         "en": "hare",
         "ja": "ノウサギ",
         "ja_typings": [
-          "nousagi",
-          "nosagi"
+          "nousagi"
         ]
       },
       {
         "en": "squirrel",
         "ja": "リス",
         "ja_typings": [
-          "risu",
-          "lisu"
+          "risu"
         ]
       },
       {
         "en": "guinea pig",
         "ja": "モルモット",
         "ja_typings": [
-          "morumotutoto",
-          "molumotto",
           "morumotto"
         ]
       }
@@ -134462,7 +136265,8 @@
     "question_text": {
       "en": "Which mammal is famous for long ears and rapid reproduction?",
       "ja": "長い耳と繁殖力で知られる哺乳類はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134478,14 +136282,14 @@
         "en": "amphibians",
         "ja": "両生類",
         "ja_typings": [
-          "riyouseirui"
+          "ryouseirui"
         ]
       },
       {
         "en": "mammals",
         "ja": "哺乳類",
         "ja_typings": [
-          "honiyuurui"
+          "honyuurui"
         ]
       },
       {
@@ -134504,7 +136308,8 @@
     "question_text": {
       "en": "Snakes, turtles and lizards belong to which class of animals?",
       "ja": "ヘビ・カメ・トカゲが属する動物の綱はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134527,7 +136332,7 @@
         "en": "night vision",
         "ja": "夜視力",
         "ja_typings": [
-          "yasiriyoku"
+          "yashiryoku"
         ]
       },
       {
@@ -134546,7 +136351,8 @@
     "question_text": {
       "en": "Which sense do dogs use exceptionally well to track prey or people?",
       "ja": "犬が獲物や人を追跡するときに特に優れている感覚はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134561,14 +136367,13 @@
         "en": "perfect inning",
         "ja": "完全イニング",
         "ja_typings": [
-          "kanzeniningu"
+          "kanzenniningu"
         ]
       },
       {
         "en": "immaculate inning",
         "ja": "イマキュレートイニング",
         "ja_typings": [
-          "imakiyure-toiningu",
           "imakyure-toiningu"
         ]
       },
@@ -134576,8 +136381,6 @@
         "en": "no-hitter",
         "ja": "ノーヒッター",
         "ja_typings": [
-          "no--hituta--",
-          "no--hitta--",
           "no-hitta-"
         ]
       }
@@ -134589,7 +136392,8 @@
     "question_text": {
       "en": "In baseball, getting three strikeouts in one inning is called what?",
       "ja": "野球で1イニングに3つ三振を取ることを何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134629,7 +136433,8 @@
     "question_text": {
       "en": "What does an arrow leave behind in flight, often used as an idiom?",
       "ja": "矢が飛んだ後に残るとされる、慣用句にもなるものはどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134669,7 +136474,8 @@
     "question_text": {
       "en": "Which bit width can represent IPv6 addresses?",
       "ja": "IPv6アドレスを表現できるビット幅は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134709,7 +136515,8 @@
     "question_text": {
       "en": "Which bit width can represent only two values, 0 and 1?",
       "ja": "0と1の2値しか表現できないビット幅は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134749,7 +136556,8 @@
     "question_text": {
       "en": "Which bit width is called a nibble?",
       "ja": "ニブルと呼ばれるビット幅は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134789,7 +136597,8 @@
     "question_text": {
       "en": "Which bit width equals one byte?",
       "ja": "1バイトに相当するビット幅は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134829,7 +136638,8 @@
     "question_text": {
       "en": "Which is the famous early microcomputer kit released in 1975?",
       "ja": "1975年に発売された有名な初期マイコンキットは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134869,7 +136679,8 @@
     "question_text": {
       "en": "Which CPU architecture is widely used in smartphones?",
       "ja": "スマートフォンで広く使われているCPUアーキテクチャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134909,7 +136720,8 @@
     "question_text": {
       "en": "Which company makes the iPhone?",
       "ja": "iPhoneを製造している企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134949,7 +136761,8 @@
     "question_text": {
       "en": "Which firmware initializes hardware at PC boot?",
       "ja": "PC起動時にハードウェアを初期化するファームウェアは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134989,7 +136802,8 @@
     "question_text": {
       "en": "Which short-range wireless standard is used for headsets?",
       "ja": "ヘッドセットなどで使われる近距離無線規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135029,7 +136843,8 @@
     "question_text": {
       "en": "Which temporary storage smooths the speed gap between devices?",
       "ja": "機器間の速度差を吸収する一時記憶領域は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135069,7 +136884,8 @@
     "question_text": {
       "en": "Which component is the brain of a computer?",
       "ja": "コンピュータの頭脳に相当する部品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135109,7 +136925,8 @@
     "question_text": {
       "en": "Which 32-bit cyclic redundancy check is widely used for error detection?",
       "ja": "エラー検出に広く使われる32ビットの巡回冗長検査は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135149,7 +136966,8 @@
     "question_text": {
       "en": "Which high-speed memory sits between the CPU and main memory?",
       "ja": "CPUと主記憶の間にある高速メモリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135189,7 +137007,8 @@
     "question_text": {
       "en": "Which company is a major networking equipment vendor?",
       "ja": "大手ネットワーク機器ベンダーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135229,7 +137048,8 @@
     "question_text": {
       "en": "Which memory standard is commonly used in modern PCs?",
       "ja": "現代のPCで広く使われるメモリ規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135269,7 +137089,8 @@
     "question_text": {
       "en": "Which protocol automatically assigns IP addresses to hosts?",
       "ja": "ホストにIPアドレスを自動配布するプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135309,7 +137130,8 @@
     "question_text": {
       "en": "Which system resolves domain names to IP addresses?",
       "ja": "ドメイン名をIPアドレスに解決する仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135349,7 +137171,8 @@
     "question_text": {
       "en": "Which non-volatile memory can be electrically erased and rewritten?",
       "ja": "電気的に消去・書き換え可能な不揮発性メモリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135389,7 +137212,8 @@
     "question_text": {
       "en": "Which file system was widely used in older Windows versions?",
       "ja": "古いWindowsで広く使われたファイルシステムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135429,7 +137253,8 @@
     "question_text": {
       "en": "Which type of non-volatile memory is used in USB drives?",
       "ja": "USBメモリに使われる不揮発性メモリの種類は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135469,7 +137294,8 @@
     "question_text": {
       "en": "Which Unix-like OS evolved from the Berkeley Software Distribution?",
       "ja": "BSDから派生したUnix系OSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135509,7 +137335,8 @@
     "question_text": {
       "en": "Which processor specializes in parallel graphics computation?",
       "ja": "並列グラフィクス演算に特化したプロセッサは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135549,7 +137376,8 @@
     "question_text": {
       "en": "Which company developed the Android operating system?",
       "ja": "Android OSを開発した企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135589,7 +137417,8 @@
     "question_text": {
       "en": "Which magnetic storage device uses spinning platters?",
       "ja": "回転するプラッタを使う磁気記憶装置は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135629,7 +137458,8 @@
     "question_text": {
       "en": "Which digital audio-video interface is common on TVs?",
       "ja": "テレビで広く使われるデジタル映像音声端子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135669,7 +137499,8 @@
     "question_text": {
       "en": "Which file system was developed by Apple?",
       "ja": "Appleが開発したファイルシステムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135709,7 +137540,8 @@
     "question_text": {
       "en": "Which protocol is the foundation of the World Wide Web?",
       "ja": "World Wide Webの基礎となるプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135731,7 +137563,7 @@
         "en": "Search function",
         "ja": "検索関数",
         "ja_typings": [
-          "kennsakukansuu"
+          "kensakukansuu"
         ]
       },
       {
@@ -135749,7 +137581,8 @@
     "question_text": {
       "en": "Which function maps arbitrary data to a fixed-size value?",
       "ja": "任意のデータを固定長の値に変換する関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135789,7 +137622,8 @@
     "question_text": {
       "en": "Which company built the System/360 mainframe family?",
       "ja": "System/360メインフレームを生み出した企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135829,7 +137663,8 @@
     "question_text": {
       "en": "Which parallel interface was once common for connecting hard drives?",
       "ja": "かつてHDD接続に広く使われたパラレル規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135869,7 +137704,8 @@
     "question_text": {
       "en": "Which core part of an operating system manages resources?",
       "ja": "OSの中核としてリソースを管理する部分は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135909,7 +137745,8 @@
     "question_text": {
       "en": "Which 4G mobile communication standard succeeded 3G?",
       "ja": "3Gの次世代となった4G移動通信規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135949,7 +137786,8 @@
     "question_text": {
       "en": "Which Linux disk management abstraction allows flexible volumes?",
       "ja": "柔軟なボリューム管理を行うLinuxの仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135989,7 +137827,8 @@
     "question_text": {
       "en": "Which device distributes traffic across multiple servers?",
       "ja": "複数サーバへ通信を分散する装置は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136029,7 +137868,8 @@
     "question_text": {
       "en": "Which early Harvard relay-based computer was completed in 1944?",
       "ja": "1944年に完成したハーバードのリレー式初期コンピュータは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136069,7 +137909,8 @@
     "question_text": {
       "en": "Which memory directly accessed by the CPU during execution?",
       "ja": "CPUが実行中に直接アクセスする記憶領域は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136109,7 +137950,8 @@
     "question_text": {
       "en": "Which company owns Facebook and Instagram?",
       "ja": "FacebookとInstagramを保有する企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136149,7 +137991,8 @@
     "question_text": {
       "en": "Which company developed the Windows operating system?",
       "ja": "Windows OSを開発した企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136189,7 +138032,8 @@
     "question_text": {
       "en": "Which storage device is dedicated to file sharing over a network?",
       "ja": "ネットワーク経由でファイル共有する専用ストレージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136229,7 +138073,8 @@
     "question_text": {
       "en": "Which technology translates private and public IP addresses?",
       "ja": "プライベートとグローバルIPを変換する技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136269,7 +138114,8 @@
     "question_text": {
       "en": "Which very short range wireless tech is used for contactless payment?",
       "ja": "非接触決済で使われるごく短距離無線技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136309,7 +138155,8 @@
     "question_text": {
       "en": "Which file system is the default for modern Windows?",
       "ja": "現代のWindowsで標準のファイルシステムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136349,7 +138196,8 @@
     "question_text": {
       "en": "Which company is famous for enterprise database products?",
       "ja": "企業向けデータベースで知られる企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136389,7 +138237,8 @@
     "question_text": {
       "en": "Which high-speed serial expansion bus is used inside modern PCs?",
       "ja": "現代PC内部の高速シリアル拡張バスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136429,7 +138278,8 @@
     "question_text": {
       "en": "Which old round connector was used for keyboards and mice?",
       "ja": "キーボードやマウスに使われた古い丸型コネクタは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136469,7 +138319,8 @@
     "question_text": {
       "en": "Which OS abstraction represents a running program?",
       "ja": "実行中のプログラムを表すOSの抽象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136509,7 +138360,8 @@
     "question_text": {
       "en": "Which server relays client requests to other servers?",
       "ja": "クライアントの要求を他サーバへ中継するサーバは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136549,7 +138401,8 @@
     "question_text": {
       "en": "Which company is known for the Snapdragon mobile SoC?",
       "ja": "Snapdragonモバイル向けSoCで知られる企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136589,7 +138442,8 @@
     "question_text": {
       "en": "Which volatile memory holds data while a computer is running?",
       "ja": "稼働中のPCでデータを保持する揮発性メモリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136629,7 +138483,8 @@
     "question_text": {
       "en": "Which 8-pin modular connector is standard for Ethernet?",
       "ja": "イーサネットで標準的な8ピンモジュラ端子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136669,7 +138524,8 @@
     "question_text": {
       "en": "Which simple cipher shifts letters by 13 positions?",
       "ja": "アルファベットを13文字ずらす単純な暗号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136709,7 +138565,8 @@
     "question_text": {
       "en": "Which serial interface standard was once common on PCs?",
       "ja": "かつてPCで一般的だったシリアル通信規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136749,7 +138606,8 @@
     "question_text": {
       "en": "Which public-key cryptosystem is named after its three inventors?",
       "ja": "発明者3人の頭文字を取った公開鍵暗号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136789,7 +138647,8 @@
     "question_text": {
       "en": "Which CPU component holds small, fast data for immediate use?",
       "ja": "CPU内部で即時利用される小さく高速な記憶領域は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136829,7 +138688,8 @@
     "question_text": {
       "en": "Which attack makes a victim host connect back to the attacker?",
       "ja": "被害ホストから攻撃者へ接続させる攻撃手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136869,7 +138729,8 @@
     "question_text": {
       "en": "Which network is dedicated to high-speed block storage access?",
       "ja": "高速ブロックストレージ専用のネットワークは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136909,7 +138770,8 @@
     "question_text": {
       "en": "Which type of RAM uses flip-flops and needs no refresh?",
       "ja": "フリップフロップで構成しリフレッシュ不要なRAMは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136949,7 +138811,8 @@
     "question_text": {
       "en": "Which storage uses flash memory and has no moving parts?",
       "ja": "フラッシュメモリを使い可動部品が無いストレージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136989,7 +138852,8 @@
     "question_text": {
       "en": "Which encrypted protocol is used for secure remote shell?",
       "ja": "暗号化された遠隔シェルで使うプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137029,7 +138893,8 @@
     "question_text": {
       "en": "Which Korean conglomerate is a major smartphone maker?",
       "ja": "大手スマートフォンメーカーの韓国系コングロマリットは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137069,7 +138934,8 @@
     "question_text": {
       "en": "Which mechanism moves memory pages between RAM and disk?",
       "ja": "RAMとディスク間でメモリページを退避する仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137109,7 +138975,8 @@
     "question_text": {
       "en": "Which protocol provides reliable, ordered data delivery on the Internet?",
       "ja": "信頼性のある順序付き配送を提供するインターネットプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137149,7 +139016,8 @@
     "question_text": {
       "en": "Which old plaintext protocol is used for remote terminal access?",
       "ja": "古い平文の遠隔端末アクセスプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137189,7 +139057,8 @@
     "question_text": {
       "en": "Which connectionless protocol prioritizes speed over reliability?",
       "ja": "信頼性より速度を優先するコネクションレスプロトコルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137229,7 +139098,8 @@
     "question_text": {
       "en": "Which 1951 commercial computer succeeded the ENIAC line?",
       "ja": "ENIAC系を継いだ1951年の商用コンピュータは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137269,7 +139139,8 @@
     "question_text": {
       "en": "Which serial bus is most common for connecting peripherals?",
       "ja": "周辺機器接続で最も一般的なシリアルバスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137309,7 +139180,8 @@
     "question_text": {
       "en": "Which OS technique uses disk to extend addressable memory?",
       "ja": "ディスクを使って利用可能なメモリを拡張するOSの仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137317,7 +139189,6 @@
         "en": "Windows",
         "ja": "ウィンドウズ",
         "ja_typings": [
-          "windozu",
           "windouzu"
         ]
       },
@@ -137350,7 +139221,8 @@
     "question_text": {
       "en": "Which OS is developed by Microsoft for personal computers?",
       "ja": "Microsoftが開発するPC向けOSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137390,7 +139262,8 @@
     "question_text": {
       "en": "Which low-power mesh wireless standard is used in IoT?",
       "ja": "IoTで使われる低消費電力のメッシュ無線規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137430,7 +139303,8 @@
     "question_text": {
       "en": "Which is a modern default journaling file system on Linux?",
       "ja": "現代のLinuxで標準的なジャーナリングファイルシステムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137445,7 +139319,6 @@
         "en": "Windows",
         "ja": "ウィンドウズ",
         "ja_typings": [
-          "windozu",
           "windouzu"
         ]
       },
@@ -137471,7 +139344,8 @@
     "question_text": {
       "en": "Which OS is developed by Apple for Macintosh computers?",
       "ja": "AppleがMacintosh向けに開発するOSは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137511,7 +139385,8 @@
     "question_text": {
       "en": "Which is roughly the average winter temperature at the South Pole?",
       "ja": "南極の冬の平均気温に近いのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137551,7 +139426,8 @@
     "question_text": {
       "en": "Which temperature is physically impossible since absolute zero is -273 degrees?",
       "ja": "絶対零度がマイナス273度であるため物理的にあり得ない温度は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137591,7 +139467,8 @@
     "question_text": {
       "en": "At which Celsius temperature does pure water freeze at 1 atm?",
       "ja": "1気圧で純水が凍る摂氏温度は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137631,7 +139508,8 @@
     "question_text": {
       "en": "Which Celsius temperature is typical for a comfortable room?",
       "ja": "快適な室温として典型的な摂氏温度は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137671,7 +139549,8 @@
     "question_text": {
       "en": "Which Celsius temperature is considered a hot summer day in Japan?",
       "ja": "日本で真夏日の目安となる摂氏温度は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137711,7 +139590,8 @@
     "question_text": {
       "en": "Which Celsius temperature is classified as an extremely hot day in Japan?",
       "ja": "日本で猛暑日と分類される摂氏温度の目安は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137751,7 +139631,8 @@
     "question_text": {
       "en": "Which ABO blood type has antigen A on red blood cells?",
       "ja": "赤血球にA抗原を持つABO式血液型は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137791,7 +139672,8 @@
     "question_text": {
       "en": "Which lightweight metal has atomic number 13?",
       "ja": "原子番号13番の軽い金属は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137831,7 +139713,8 @@
     "question_text": {
       "en": "Which ancient Greek scholar discovered the principle of buoyancy?",
       "ja": "浮力の原理を発見した古代ギリシアの学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137871,7 +139754,8 @@
     "question_text": {
       "en": "Which element symbol represents gold?",
       "ja": "金を表す元素記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137911,7 +139795,8 @@
     "question_text": {
       "en": "Which polar atmospheric phenomenon shows colorful curtains of light?",
       "ja": "極地で色とりどりの光のカーテンが見える大気現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137951,7 +139836,8 @@
     "question_text": {
       "en": "Which ABO blood type has antigen B on red blood cells?",
       "ja": "赤血球にB抗原を持つABO式血液型は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -137991,7 +139877,8 @@
     "question_text": {
       "en": "Which index combines weight and height to estimate body fat?",
       "ja": "体重と身長から肥満度を推定する指数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138031,7 +139918,8 @@
     "question_text": {
       "en": "Which French physicist discovered natural radioactivity in 1896?",
       "ja": "1896年に天然放射能を発見したフランスの物理学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138039,14 +139927,14 @@
         "en": "Carbon",
         "ja": "炭素",
         "ja_typings": [
-          "tannso"
+          "tanso"
         ]
       },
       {
         "en": "Oxygen",
         "ja": "酸素",
         "ja_typings": [
-          "sannso"
+          "sanso"
         ]
       },
       {
@@ -138072,7 +139960,8 @@
     "question_text": {
       "en": "Which element with symbol C is the basis of organic chemistry?",
       "ja": "有機化学の基盤となる元素記号Cの元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138094,7 +139983,7 @@
         "en": "Natural gas",
         "ja": "天然ガス",
         "ja_typings": [
-          "tennenngasu"
+          "tennnengasu"
         ]
       },
       {
@@ -138112,7 +140001,8 @@
     "question_text": {
       "en": "Which fossil fuel is a black sedimentary rock burned for energy?",
       "ja": "黒い堆積岩でエネルギー源として燃やされる化石燃料は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138120,28 +140010,28 @@
         "en": "Combustion",
         "ja": "燃焼",
         "ja_typings": [
-          "nennshou"
+          "nenshou"
         ]
       },
       {
         "en": "Oxidation",
         "ja": "酸化",
         "ja_typings": [
-          "sannka"
+          "sanka"
         ]
       },
       {
         "en": "Reduction",
         "ja": "還元",
         "ja_typings": [
-          "kanngen"
+          "kangen"
         ]
       },
       {
         "en": "Electrolysis",
         "ja": "電気分解",
         "ja_typings": [
-          "dennkibunnkai"
+          "denkibunkai"
         ]
       }
     ],
@@ -138152,7 +140042,8 @@
     "question_text": {
       "en": "Which chemical reaction with oxygen produces heat and light?",
       "ja": "酸素と反応して熱と光を出す化学反応は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138192,7 +140083,8 @@
     "question_text": {
       "en": "Which French physicist gave his name to the SI unit of electric charge?",
       "ja": "電荷のSI単位に名を残すフランスの物理学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138232,7 +140124,8 @@
     "question_text": {
       "en": "Which logarithmic unit expresses sound pressure level?",
       "ja": "音圧レベルを対数で表す単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138272,7 +140165,8 @@
     "question_text": {
       "en": "Which physicist published the theory of relativity in 1905 and 1915?",
       "ja": "1905年と1915年に相対性理論を発表した物理学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138280,7 +140174,7 @@
         "en": "Electromagnetic force",
         "ja": "電磁気力",
         "ja_typings": [
-          "dennjikiryoku"
+          "denjikiryoku"
         ]
       },
       {
@@ -138312,7 +140206,8 @@
     "question_text": {
       "en": "Which fundamental force acts between electrically charged particles?",
       "ja": "電荷を持つ粒子の間に働く基本相互作用は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138352,7 +140247,8 @@
     "question_text": {
       "en": "Which element symbol represents iron?",
       "ja": "鉄を表す元素記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138392,7 +140288,8 @@
     "question_text": {
       "en": "Which British scientist formulated rules for the direction of induced current?",
       "ja": "誘導電流の向きに関する法則を定めた英国の科学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138432,7 +140329,8 @@
     "question_text": {
       "en": "Which force resists motion between surfaces in contact?",
       "ja": "接触する面の運動を妨げる力は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138472,7 +140370,8 @@
     "question_text": {
       "en": "Which Italian astronomer first observed Jupiter's four largest moons?",
       "ja": "木星の四大衛星を最初に観測したイタリアの天文学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138512,7 +140411,8 @@
     "question_text": {
       "en": "Which attractive force pulls objects toward the Earth?",
       "ja": "地球が物体を引き寄せる力は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138553,7 +140453,8 @@
     "question_text": {
       "en": "Which Japanese bacteriologist studied yellow fever and is on the 1000 yen note?",
       "ja": "黄熱病を研究し千円札の肖像にもなった日本の細菌学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138593,7 +140494,8 @@
     "question_text": {
       "en": "Which English scientist formulated the law of elasticity for springs?",
       "ja": "ばねの弾性に関する法則を定めた英国の科学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138633,7 +140535,8 @@
     "question_text": {
       "en": "Which American astronomer found that distant galaxies are receding?",
       "ja": "遠方銀河が後退していることを発見した米国の天文学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138655,7 +140558,7 @@
         "en": "Oxygen",
         "ja": "酸素",
         "ja_typings": [
-          "sannso"
+          "sanso"
         ]
       },
       {
@@ -138674,7 +140577,8 @@
     "question_text": {
       "en": "Which element has atomic number 1 and symbol H?",
       "ja": "原子番号1番で記号Hの元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138714,7 +140618,8 @@
     "question_text": {
       "en": "Which score is a numerical estimate of intelligence?",
       "ja": "知能を数値化した指標は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138722,7 +140627,7 @@
         "en": "Interference",
         "ja": "干渉",
         "ja_typings": [
-          "kannshou"
+          "kanshou"
         ]
       },
       {
@@ -138736,7 +140641,7 @@
         "en": "Reflection",
         "ja": "反射",
         "ja_typings": [
-          "hannsha"
+          "hansha"
         ]
       },
       {
@@ -138754,7 +140659,8 @@
     "question_text": {
       "en": "Which wave phenomenon results from superposition producing reinforcement and cancellation?",
       "ja": "波の重ね合わせで強め合いや打ち消しが起きる現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138794,7 +140700,8 @@
     "question_text": {
       "en": "Which English doctor developed the first smallpox vaccine?",
       "ja": "天然痘の世界初のワクチンを開発した英国の医師は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138809,7 +140716,7 @@
         "en": "Triassic",
         "ja": "三畳紀",
         "ja_typings": [
-          "sannjouki"
+          "sanjouki"
         ]
       },
       {
@@ -138823,7 +140730,7 @@
         "en": "Cambrian",
         "ja": "カンブリア紀",
         "ja_typings": [
-          "kannburiaki"
+          "kanburiaki"
         ]
       }
     ],
@@ -138834,7 +140741,8 @@
     "question_text": {
       "en": "Which Mesozoic geological period is famous for large dinosaurs?",
       "ja": "大型恐竜で有名な中生代の地質時代は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138874,7 +140782,8 @@
     "question_text": {
       "en": "Which Dutch pioneer first observed microorganisms with a microscope?",
       "ja": "顕微鏡で初めて微生物を観察したオランダの先駆者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138914,7 +140823,8 @@
     "question_text": {
       "en": "Which disturbance of Earth's magnetic field is caused by solar wind?",
       "ja": "太陽風によって生じる地球磁場の擾乱は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138954,7 +140864,8 @@
     "question_text": {
       "en": "Which optical phenomenon makes distant objects appear distorted over hot ground?",
       "ja": "熱い地面の上で遠くの物体が歪んで見える光学現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138994,7 +140905,8 @@
     "question_text": {
       "en": "Which chemical formula represents sodium hydroxide?",
       "ja": "水酸化ナトリウムを表す化学式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139002,7 +140914,7 @@
         "en": "Natural gas",
         "ja": "天然ガス",
         "ja_typings": [
-          "tennenngasu"
+          "tennnengasu"
         ]
       },
       {
@@ -139034,7 +140946,8 @@
     "question_text": {
       "en": "Which fossil fuel is primarily composed of methane?",
       "ja": "主にメタンからなる化石燃料は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139074,7 +140987,8 @@
     "question_text": {
       "en": "Which electrically neutral subatomic particle is found in atomic nuclei?",
       "ja": "原子核に含まれる電気的に中性の粒子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139098,14 +141012,14 @@
         "en": "Combustion",
         "ja": "燃焼",
         "ja_typings": [
-          "nennshou"
+          "nenshou"
         ]
       },
       {
         "en": "Electrolysis",
         "ja": "電気分解",
         "ja_typings": [
-          "dennkibunnkai"
+          "denkibunkai"
         ]
       }
     ],
@@ -139116,7 +141030,8 @@
     "question_text": {
       "en": "Which type of reaction occurs in the Sun's core?",
       "ja": "太陽の中心で起きている反応の種類は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139156,7 +141071,8 @@
     "question_text": {
       "en": "Which ABO blood type has neither A nor B antigen?",
       "ja": "A抗原もB抗原も持たないABO式血液型は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139196,7 +141112,8 @@
     "question_text": {
       "en": "Which German physicist gave his name to the unit of electrical resistance?",
       "ja": "電気抵抗の単位に名を残すドイツの物理学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139218,7 +141135,7 @@
         "en": "Natural gas",
         "ja": "天然ガス",
         "ja_typings": [
-          "tennenngasu"
+          "tennnengasu"
         ]
       },
       {
@@ -139236,7 +141153,8 @@
     "question_text": {
       "en": "Which fossil fuel is refined into gasoline and diesel?",
       "ja": "ガソリンや軽油に精製される化石燃料は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139244,7 +141162,7 @@
         "en": "Oxygen",
         "ja": "酸素",
         "ja_typings": [
-          "sannso"
+          "sanso"
         ]
       },
       {
@@ -139258,7 +141176,7 @@
         "en": "Carbon",
         "ja": "炭素",
         "ja_typings": [
-          "tannso"
+          "tanso"
         ]
       },
       {
@@ -139277,7 +141195,8 @@
     "question_text": {
       "en": "Which element with symbol O is essential for respiration?",
       "ja": "呼吸に不可欠な記号Oの元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139285,14 +141204,14 @@
         "en": "Paleogene",
         "ja": "古第三紀",
         "ja_typings": [
-          "kodaisannki"
+          "kodaisanki"
         ]
       },
       {
         "en": "Neogene",
         "ja": "新第三紀",
         "ja_typings": [
-          "shinndaisannki"
+          "shindaisanki"
         ]
       },
       {
@@ -139317,7 +141236,8 @@
     "question_text": {
       "en": "Which Cenozoic geological period followed the Cretaceous?",
       "ja": "白亜紀のあとに続く新生代の地質時代は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139357,7 +141277,8 @@
     "question_text": {
       "en": "Which French scientist developed pasteurization and a rabies vaccine?",
       "ja": "低温殺菌法と狂犬病ワクチンを開発したフランスの科学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139397,7 +141318,8 @@
     "question_text": {
       "en": "Which elementary particle is the quantum of light?",
       "ja": "光の量子に相当する素粒子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139437,7 +141359,8 @@
     "question_text": {
       "en": "Which positively charged particle is found in atomic nuclei?",
       "ja": "原子核に含まれる正電荷の粒子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139477,7 +141400,8 @@
     "question_text": {
       "en": "Which ancient Greek astronomer is known for a geocentric model?",
       "ja": "天動説で知られる古代ギリシアの天文学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139517,7 +141441,8 @@
     "question_text": {
       "en": "Which color is produced by mixing red and blue light?",
       "ja": "赤い光と青い光を混ぜると見える色は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139557,7 +141482,8 @@
     "question_text": {
       "en": "Which optical phenomenon appears as a colored arc after rain?",
       "ja": "雨上がりに見える色の弧の光学現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139597,7 +141523,8 @@
     "question_text": {
       "en": "Which German physicist discovered X-rays in 1895?",
       "ja": "1895年にX線を発見したドイツの物理学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139619,7 +141546,6 @@
         "en": "Virchow",
         "ja": "ウィルヒョウ",
         "ja_typings": [
-          "wiruhyo",
           "wiruhyou"
         ]
       },
@@ -139638,7 +141564,8 @@
     "question_text": {
       "en": "Which German botanist co-founded the cell theory for plants?",
       "ja": "植物の細胞説を共同で提唱したドイツの植物学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139646,7 +141573,7 @@
         "en": "Seismic intensity",
         "ja": "震度",
         "ja_typings": [
-          "shinndo"
+          "shindo"
         ]
       },
       {
@@ -139678,7 +141605,8 @@
     "question_text": {
       "en": "Which Japanese scale measures the strength of shaking at a location?",
       "ja": "ある地点での揺れの強さを表す日本の尺度は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139693,7 +141621,7 @@
         "en": "Carbon",
         "ja": "炭素",
         "ja_typings": [
-          "tannso"
+          "tanso"
         ]
       },
       {
@@ -139718,7 +141646,8 @@
     "question_text": {
       "en": "Which element with symbol Si is the main material of semiconductors?",
       "ja": "半導体の主材料となる記号Siの元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139758,7 +141687,8 @@
     "question_text": {
       "en": "Which is the brightest star in Earth's night sky?",
       "ja": "地球の夜空で最も明るく見える恒星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139773,7 +141703,7 @@
         "en": "Carbon",
         "ja": "炭素",
         "ja_typings": [
-          "tannso"
+          "tanso"
         ]
       },
       {
@@ -139787,7 +141717,7 @@
         "en": "Phosphorus",
         "ja": "リン",
         "ja_typings": [
-          "rinn"
+          "rin"
         ]
       }
     ],
@@ -139798,7 +141728,8 @@
     "question_text": {
       "en": "Which yellow element with symbol S is found near volcanoes?",
       "ja": "火山周辺で見られる記号Sの黄色い元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139806,7 +141737,7 @@
         "en": "Triassic",
         "ja": "三畳紀",
         "ja_typings": [
-          "sannjouki"
+          "sanjouki"
         ]
       },
       {
@@ -139838,7 +141769,8 @@
     "question_text": {
       "en": "Which Mesozoic period came right before the Jurassic?",
       "ja": "ジュラ紀の直前に位置する中生代の地質時代は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139878,7 +141810,8 @@
     "question_text": {
       "en": "Which color is the result of mixing all visible wavelengths of light equally?",
       "ja": "可視光のすべての波長を均等に混ぜたときに見える色は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139918,7 +141851,8 @@
     "question_text": {
       "en": "Which is the color of a ripe lemon?",
       "ja": "熟したレモンの色は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139958,7 +141892,8 @@
     "question_text": {
       "en": "Which unit expresses concentration as parts per million?",
       "ja": "100万分のいくつかで濃度を表す単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139966,7 +141901,6 @@
         "en": "AZKi",
         "ja": "AZKi",
         "ja_typings": [
-          "azuki",
           "azki"
         ]
       },
@@ -139999,7 +141933,8 @@
     "question_text": {
       "en": "Which hololive VTuber is known for music activities and is sometimes called the goddess of music?",
       "ja": "ホロライブで音楽活動を中心にする「ソング・フォー・ユー」を歌うVTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140039,7 +141974,8 @@
     "question_text": {
       "en": "What is the net-slang term for an avatar or anonymous online persona?",
       "ja": "ネットスラングで匿名のあだ名や仮の名前を指す言葉は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140079,7 +142015,8 @@
     "question_text": {
       "en": "Which English word is often used in net slang to express frustration?",
       "ja": "ネットで怒りを表す英単語スラングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140119,7 +142056,8 @@
     "question_text": {
       "en": "Which Japanese word means 'storm' and is also a famous idol group name?",
       "ja": "「嵐」を意味し有名アイドルグループ名でもある言葉は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140127,7 +142065,6 @@
         "en": "BTW",
         "ja": "ところで",
         "ja_typings": [
-          "btw",
           "tokorode"
         ]
       },
@@ -140160,7 +142097,8 @@
     "question_text": {
       "en": "What does the net abbreviation 'BTW' stand for?",
       "ja": "ネット略語「BTW」の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140201,7 +142139,8 @@
     "question_text": {
       "en": "Which Japanese word means 'subtle' or 'so-so'?",
       "ja": "「微妙」を意味する日本語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140241,7 +142180,8 @@
     "question_text": {
       "en": "What is the name of the virtual currency used to cheer on Twitch?",
       "ja": "Twitchで配信者を応援するために使う仮想通貨は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140270,8 +142210,7 @@
         "en": "DeNA",
         "ja": "DeNA",
         "ja_typings": [
-          "dena",
-          "deiienue-"
+          "dena"
         ]
       }
     ],
@@ -140282,7 +142221,8 @@
     "question_text": {
       "en": "Which Japanese company produces Bang Dream and Revue Starlight, and runs many TCGs?",
       "ja": "バンドリやヴァイスシュヴァルツを運営する日本企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140322,7 +142262,8 @@
     "question_text": {
       "en": "Which English word is commonly used as a parting greeting?",
       "ja": "英語で別れの挨拶として使われる短い単語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140363,7 +142304,8 @@
     "question_text": {
       "en": "What is a streaming format where multiple VTubers appear together called?",
       "ja": "複数のVTuberが一緒に出演する配信形式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140403,7 +142345,8 @@
     "question_text": {
       "en": "Which company runs the Hololive Production VTuber agency?",
       "ja": "ホロライブプロダクションを運営する会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140443,7 +142386,8 @@
     "question_text": {
       "en": "What is a group of regular fans of a specific streamer or VTuber called in English?",
       "ja": "特定の配信者の常連ファン集団を英語で何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140451,8 +142395,7 @@
         "en": "DeNA",
         "ja": "DeNA",
         "ja_typings": [
-          "dena",
-          "deiienue-"
+          "dena"
         ]
       },
       {
@@ -140484,7 +142427,8 @@
     "question_text": {
       "en": "Which company is known for the mobile games Pokemon Masters and Mobage platform?",
       "ja": "モバゲーやポケモンマスターズで知られる日本企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140524,7 +142468,8 @@
     "question_text": {
       "en": "What net slang refers to the English language or being in English?",
       "ja": "英語であることを指すネットスラングは?"
-    }
+    },
+    "ja_reviewed": false
   },
   {
     "choices": [
@@ -140539,7 +142484,6 @@
         "en": "BTW",
         "ja": "ところで",
         "ja_typings": [
-          "btw",
           "tokorode"
         ]
       },
@@ -140565,7 +142509,8 @@
     "question_text": {
       "en": "What does the net abbreviation 'FYI' stand for?",
       "ja": "ネット略語「FYI」の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140605,7 +142550,8 @@
     "question_text": {
       "en": "Which net slang word refers to character traits in Japanese?",
       "ja": "ネットスラングで「キャラ性」「性格」を指す日本語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140645,7 +142591,8 @@
     "question_text": {
       "en": "What is the top-tier paid YouTube channel membership called?",
       "ja": "YouTubeチャンネルメンバーシップの最上位プランは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140685,7 +142632,8 @@
     "question_text": {
       "en": "Which Japanese word means 'trash' and is used as net slang?",
       "ja": "ネットスラングで「ゴミ」を意味する言葉は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140725,7 +142673,8 @@
     "question_text": {
       "en": "What is a typical morning greeting in English?",
       "ja": "英語で朝の挨拶として使われる定型句は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140765,7 +142714,8 @@
     "question_text": {
       "en": "Which is the largest Japanese VTuber agency featuring Pekora and Fubuki?",
       "ja": "兎田ぺこらや白上フブキが所属するVTuber事務所は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140805,7 +142755,8 @@
     "question_text": {
       "en": "Which Southeast Asian country has its own Hololive branch?",
       "ja": "ホロライブの支部があった東南アジアの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140845,7 +142796,8 @@
     "question_text": {
       "en": "Which Nijisanji VTuber is the leader of the 'Iwagumi' generation and has cat ears?",
       "ja": "にじさんじの「岩組」のリーダーで猫耳のVTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140889,7 +142841,8 @@
     "question_text": {
       "en": "Which country is the headquarters of Hololive based in?",
       "ja": "ホロライブの本社がある国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140929,7 +142882,8 @@
     "question_text": {
       "en": "Which Japanese publisher owns Dwango and is famous for light novels?",
       "ja": "ドワンゴを子会社に持ち、ライトノベルでも有名な日本の出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140970,7 +142924,8 @@
     "question_text": {
       "en": "Which East Asian country borders Japan and has its own VTuber scene?",
       "ja": "日本の隣にあり独自のVTuber文化を持つ東アジアの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141010,7 +142965,8 @@
     "question_text": {
       "en": "Which Japanese word means 'mastermind' behind the scenes?",
       "ja": "陰で操る黒幕を意味する日本語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141050,7 +143006,8 @@
     "question_text": {
       "en": "Which Nijisanji male duo became hugely popular as the 'ChroNoiR' unit?",
       "ja": "にじさんじでChroNoiRとして活動する男性デュオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141090,7 +143047,8 @@
     "question_text": {
       "en": "What is the slang term for a stream of paid YouTube Super Chat messages?",
       "ja": "YouTubeのスーパーチャットの俗称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141130,7 +143088,8 @@
     "question_text": {
       "en": "What do you call a viewer who watches and comments on streams?",
       "ja": "配信を見ながらコメントする視聴者を指す言葉は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141170,7 +143129,8 @@
     "question_text": {
       "en": "What is a paid YouTube channel supporter called?",
       "ja": "有料のチャンネル登録者をなんと呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141210,7 +143170,8 @@
     "question_text": {
       "en": "Which English word borrowed into Japanese means 'message'?",
       "ja": "「メッセージ」を意味するドイツ語由来の言葉で、見本市の意味もある語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141250,7 +143211,8 @@
     "question_text": {
       "en": "Which Hololive VTuber has blue twintails and is famous for the 'Aqua Crew'?",
       "ja": "ホロライブで青いツインテールが特徴のVTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141272,7 +143234,7 @@
         "en": "Reaction douga",
         "ja": "リアクション動画",
         "ja_typings": [
-          "riakushondo-ga"
+          "riakushondouga"
         ]
       },
       {
@@ -141290,7 +143252,8 @@
     "question_text": {
       "en": "What do you call replaying another streamer's broadcast on your own channel?",
       "ja": "他人の配信を自分の画面で同時に映す配信形式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141330,7 +143293,8 @@
     "question_text": {
       "en": "Which Hololive VTuber has purple hair and is the younger sister of Yozora Mel?",
       "ja": "ホロライブの紫髪のVTuberで、夜空メルの妹分とされるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141370,7 +143334,8 @@
     "question_text": {
       "en": "Which Hololive VTuber has red oni horns and is part of 'Yo-rappers'?",
       "ja": "赤い鬼の角が特徴のホロライブVTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141411,7 +143376,8 @@
     "question_text": {
       "en": "What was the name of NHK's traditional New Year's Eve singing contest, parodied on Niconico?",
       "ja": "NHK紅白歌合戦をパロディしたニコニコ動画の年末イベントは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141452,7 +143418,8 @@
     "question_text": {
       "en": "What is the slang term for a die-hard Niconico Douga fan?",
       "ja": "ニコニコ動画に熱中する人を指すスラングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141492,7 +143459,8 @@
     "question_text": {
       "en": "What is the annual Niconico user festival held in Makuhari called?",
       "ja": "幕張メッセで行われるニコニコ動画のリアルイベントは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141532,7 +143500,8 @@
     "question_text": {
       "en": "Which Atlus RPG series features Shadows and the Velvet Room?",
       "ja": "アトラスのRPGで「ベルベットルーム」が登場するシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141572,7 +143541,8 @@
     "question_text": {
       "en": "What is a mid-tier YouTube channel membership plan often called?",
       "ja": "YouTubeメンバーシップで中位のプラン名としてよく使われるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141613,7 +143583,8 @@
     "question_text": {
       "en": "What kind of video shows a streamer's responses to other content?",
       "ja": "他の動画や配信に対する反応を撮った動画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141653,7 +143624,8 @@
     "question_text": {
       "en": "What is the slang term for spamming the same comment repeatedly?",
       "ja": "同じコメントを何度も連投することを指すスラングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141693,7 +143665,8 @@
     "question_text": {
       "en": "Which Hololive VTuber is a robot girl voiced as a tinkerer who builds Robohouse?",
       "ja": "ホロライブのロボット娘で工作好きなVTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141733,7 +143706,8 @@
     "question_text": {
       "en": "Which Hololive VTuber is a white fox-girl and 'gamers' group member?",
       "ja": "ホロライブGAMERSの白い狐のVTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141773,7 +143747,8 @@
     "question_text": {
       "en": "Which Japanese global electronics and entertainment giant owns PlayStation?",
       "ja": "PlayStationを展開する日本の大手電機・エンタメ企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141813,7 +143788,8 @@
     "question_text": {
       "en": "Which English word is used to apologize politely?",
       "ja": "英語で丁寧に謝罪する一語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141853,7 +143829,8 @@
     "question_text": {
       "en": "What do you call unsolicited junk messages on the internet?",
       "ja": "ネット上の迷惑な大量メッセージのことを何という?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141893,7 +143870,8 @@
     "question_text": {
       "en": "What do you call the production team behind the scenes of a stream?",
       "ja": "配信を支える裏方のスタッフを英語で何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141933,7 +143911,8 @@
     "question_text": {
       "en": "What is the slang term for a paid Twitch chat similar to Supacha?",
       "ja": "Twitchの有料コメント機能を指す俗称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141948,7 +143927,6 @@
         "en": "BTW",
         "ja": "ところで",
         "ja_typings": [
-          "btw",
           "tokorode"
         ]
       },
@@ -141974,7 +143952,8 @@
     "question_text": {
       "en": "What does the net abbreviation 'TBH' stand for?",
       "ja": "ネット略語「TBH」の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142014,7 +143993,8 @@
     "question_text": {
       "en": "Which Japanese word refers to the 'soul' inside a VTuber avatar?",
       "ja": "VTuberのアバターの中の人(魂)を指す日本語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142054,7 +144034,8 @@
     "question_text": {
       "en": "Which male VTuber is known as the leader of 'Tasokare Hotel' and 774 inc?",
       "ja": "774inc.に所属し「黄昏ホテル」で知られる男性VTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142094,7 +144075,8 @@
     "question_text": {
       "en": "Which English word is used to express gratitude?",
       "ja": "英語で感謝を伝える短い単語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142134,7 +144116,8 @@
     "question_text": {
       "en": "What term refers to the main personality being broadcast in a stream?",
       "ja": "配信のメインとなる配信者を英語で何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142149,7 +144132,6 @@
         "en": "Twitch",
         "ja": "ツイッチ",
         "ja_typings": [
-          "tsuicchi",
           "tsuitchi"
         ]
       },
@@ -142164,7 +144146,7 @@
         "en": "Nicochu",
         "ja": "ニコ厨",
         "ja_typings": [
-          "nikochu"
+          "nikochuu"
         ]
       }
     ],
@@ -142175,7 +144157,8 @@
     "question_text": {
       "en": "Which short-form video app is owned by ByteDance and popular for dance trends?",
       "ja": "ByteDanceが運営するショート動画アプリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142215,7 +144198,8 @@
     "question_text": {
       "en": "What is the annual Niconico gaming festival called?",
       "ja": "ニコニコが主催するゲームのリアルイベントは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142223,7 +144207,6 @@
         "en": "Twitch",
         "ja": "ツイッチ",
         "ja_typings": [
-          "tsuicchi",
           "tsuitchi"
         ]
       },
@@ -142245,7 +144228,7 @@
         "en": "Nicochu",
         "ja": "ニコ厨",
         "ja_typings": [
-          "nikochu"
+          "nikochuu"
         ]
       }
     ],
@@ -142256,7 +144239,8 @@
     "question_text": {
       "en": "Which Amazon-owned live streaming platform is centered on gaming?",
       "ja": "Amazon傘下のゲーム配信に強いストリーミングサービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142296,7 +144280,8 @@
     "question_text": {
       "en": "Which Hololive VTuber is a bunny girl famous for 'peko peko peko'?",
       "ja": "「ぺこぺこぺこ」で有名なホロライブのバニーVTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142318,7 +144303,7 @@
         "en": "Reaction douga",
         "ja": "リアクション動画",
         "ja_typings": [
-          "riakushondo-ga"
+          "riakushondouga"
         ]
       },
       {
@@ -142336,7 +144321,8 @@
     "question_text": {
       "en": "What kind of software changes the pitch or tone of a streamer's voice?",
       "ja": "配信者の声を加工するソフトウェアの一般名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142376,7 +144362,8 @@
     "question_text": {
       "en": "Which early .LIVE VTuber is known as a quiet aesthetic singer with long hair?",
       "ja": "アイドル部の長髪で物静かな歌姫VTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142391,7 +144378,6 @@
         "en": "Twitch",
         "ja": "ツイッチ",
         "ja_typings": [
-          "tsuicchi",
           "tsuitchi"
         ]
       },
@@ -142406,7 +144392,7 @@
         "en": "Nicochu",
         "ja": "ニコ厨",
         "ja_typings": [
-          "nikochu"
+          "nikochuu"
         ]
       }
     ],
@@ -142417,7 +144403,8 @@
     "question_text": {
       "en": "Which Google-owned video platform is the largest in the world?",
       "ja": "Googleが運営する世界最大の動画共有サイトは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142457,7 +144444,8 @@
     "question_text": {
       "en": "Which Japanese word means 'weakling' and is often shouted by streamers?",
       "ja": "「雑魚」を意味し配信者がよく叫ぶスラングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142497,7 +144485,8 @@
     "question_text": {
       "en": "What is the traditional long Vietnamese silk tunic dress called?",
       "ja": "ベトナムの伝統的な長い絹のチュニック衣装は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142537,7 +144526,8 @@
     "question_text": {
       "en": "Which Italian pasta sauce is made with garlic, chili and tomato, and means 'angry'?",
       "ja": "ニンニクと唐辛子のトマトソースで「怒り」を意味するイタリア料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142577,7 +144567,8 @@
     "question_text": {
       "en": "Which ancient Mesoamerican civilization built Tenochtitlan?",
       "ja": "テノチティトランを築いた古代メソアメリカ文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142617,7 +144608,8 @@
     "question_text": {
       "en": "What is the central sacred book of Christianity called?",
       "ja": "キリスト教の聖典は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142657,7 +144649,8 @@
     "question_text": {
       "en": "Which Italian pasta sauce comes from a city in Emilia-Romagna and uses ground meat?",
       "ja": "エミリア=ロマーニャ州の都市発祥のひき肉トマトソースは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142697,7 +144690,8 @@
     "question_text": {
       "en": "Which Brazilian music genre is closely associated with 'The Girl from Ipanema'?",
       "ja": "「イパネマの娘」で有名なブラジル発祥の音楽ジャンルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142737,7 +144731,8 @@
     "question_text": {
       "en": "Which major river flows through Tibet, India and Bangladesh?",
       "ja": "チベット、インド、バングラデシュを流れる大河は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142777,7 +144772,8 @@
     "question_text": {
       "en": "Which planned city, designed by Oscar Niemeyer, is the capital of Brazil?",
       "ja": "オスカー・ニーマイヤー設計のブラジルの計画都市の首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142817,7 +144813,8 @@
     "question_text": {
       "en": "Which Mexican wrap consists of fillings inside a wheat flour tortilla?",
       "ja": "小麦粉トルティーヤで具を包んだメキシコ料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142832,7 +144829,6 @@
         "en": "Focaccia",
         "ja": "フォカッチャ",
         "ja_typings": [
-          "fokaccha",
           "fokatcha"
         ]
       },
@@ -142858,7 +144854,8 @@
     "question_text": {
       "en": "Which Italian dish is a folded pizza, baked or fried?",
       "ja": "二つ折りにして焼くイタリアのピザは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142898,7 +144895,8 @@
     "question_text": {
       "en": "Which Parisian iron landmark was built for the 1889 World's Fair?",
       "ja": "1889年パリ万博のために建てられた鉄の塔は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142938,7 +144936,8 @@
     "question_text": {
       "en": "Which Mexican dish involves corn tortillas filled, rolled and covered in chili sauce?",
       "ja": "トウモロコシのトルティーヤを巻きチリソースをかけたメキシコ料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142978,7 +144977,8 @@
     "question_text": {
       "en": "Which passionate Spanish dance is associated with Andalusia?",
       "ja": "アンダルシア地方発祥の情熱的なスペインの舞踊は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142986,7 +144986,6 @@
         "en": "Focaccia",
         "ja": "フォカッチャ",
         "ja_typings": [
-          "fokaccha",
           "fokatcha"
         ]
       },
@@ -143019,7 +145018,8 @@
     "question_text": {
       "en": "Which Italian flatbread is topped with olive oil and herbs?",
       "ja": "オリーブオイルとハーブを使ったイタリアの平焼きパンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143027,7 +145027,6 @@
         "en": "Frank Lloyd Wright",
         "ja": "フランク・ロイド・ライト",
         "ja_typings": [
-          "furankuroidoraito",
           "furanku/roido/raito"
         ]
       },
@@ -143035,7 +145034,6 @@
         "en": "Le Corbusier",
         "ja": "ル・コルビュジエ",
         "ja_typings": [
-          "rukorubyujie",
           "ru/korubyujie"
         ]
       },
@@ -143043,7 +145041,6 @@
         "en": "Zaha Hadid",
         "ja": "ザハ・ハディド",
         "ja_typings": [
-          "zahahadeido",
           "zaha/hadhido"
         ]
       },
@@ -143062,7 +145059,8 @@
     "question_text": {
       "en": "Which American architect designed Fallingwater and the Guggenheim Museum?",
       "ja": "落水荘やグッゲンハイム美術館を設計したアメリカの建築家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143102,7 +145100,8 @@
     "question_text": {
       "en": "Which traditional Japanese wooden footwear has a raised platform on two 'teeth'?",
       "ja": "二本歯の台がある日本の伝統的な木の履物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143142,7 +145141,8 @@
     "question_text": {
       "en": "What is the traditional Korean dress, worn during festivals and ceremonies?",
       "ja": "祝祭で着用される韓国の伝統衣装は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143182,7 +145182,8 @@
     "question_text": {
       "en": "Which Middle Eastern dip is made from chickpeas, tahini and lemon?",
       "ja": "ひよこ豆とタヒニで作る中東の料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143222,7 +145223,8 @@
     "question_text": {
       "en": "Which major South Asian river gave its name to an ancient civilization in Pakistan?",
       "ja": "パキスタンを流れ古代文明の名にもなった大河は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143262,7 +145264,8 @@
     "question_text": {
       "en": "Which Middle Eastern grilled meat dish is often served on skewers or in wraps?",
       "ja": "串焼きや包み焼きにする中東発祥の肉料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143302,7 +145305,8 @@
     "question_text": {
       "en": "Which patterned headscarf is associated with traditional Arab dress?",
       "ja": "アラブ圏で頭に巻く格子模様の伝統的なスカーフは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143343,7 +145347,8 @@
     "question_text": {
       "en": "Which sumo rank is the fourth-highest, ranked just below Sekiwake?",
       "ja": "大相撲の番付で関脇のすぐ下の地位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143383,7 +145388,8 @@
     "question_text": {
       "en": "Which Israeli self-defense martial art was developed for military use?",
       "ja": "イスラエル軍で生まれた自己防衛のための格闘術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143391,7 +145397,6 @@
         "en": "Le Corbusier",
         "ja": "ル・コルビュジエ",
         "ja_typings": [
-          "rukorubyujie",
           "ru/korubyujie"
         ]
       },
@@ -143399,7 +145404,6 @@
         "en": "Frank Lloyd Wright",
         "ja": "フランク・ロイド・ライト",
         "ja_typings": [
-          "furankuroidoraito",
           "furanku/roido/raito"
         ]
       },
@@ -143407,7 +145411,6 @@
         "en": "Zaha Hadid",
         "ja": "ザハ・ハディド",
         "ja_typings": [
-          "zahahadeido",
           "zaha/hadhido"
         ]
       },
@@ -143426,7 +145429,8 @@
     "question_text": {
       "en": "Which Swiss-French architect designed the Villa Savoye and Unite d'Habitation?",
       "ja": "サヴォア邸とユニテ・ダビタシオンを設計した建築家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143466,7 +145470,8 @@
     "question_text": {
       "en": "Which famous Paris museum houses the Mona Lisa?",
       "ja": "モナ・リザを所蔵するパリの美術館は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143506,7 +145511,8 @@
     "question_text": {
       "en": "Which ancient Mesoamerican civilization is known for Chichen Itza and the Long Count calendar?",
       "ja": "チチェン・イッツァや長期暦で知られる古代メソアメリカ文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143546,7 +145552,8 @@
     "question_text": {
       "en": "Which soft leather shoe is associated with Native American tradition?",
       "ja": "ネイティブアメリカンの伝統的な柔らかい革靴は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143586,7 +145593,8 @@
     "question_text": {
       "en": "Which is considered the earliest known major civilization of Mesoamerica, predating the Maya?",
       "ja": "マヤ文明より古い、メソアメリカ最古とされる文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143627,7 +145635,8 @@
     "question_text": {
       "en": "Which sumo rank is the second-highest, just below Yokozuna?",
       "ja": "大相撲の番付で横綱のすぐ下の地位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143667,7 +145676,8 @@
     "question_text": {
       "en": "Which ancient Roman temple in Rome has a famous dome and oculus?",
       "ja": "ローマにあるドームと天窓で有名な古代神殿は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143707,7 +145717,8 @@
     "question_text": {
       "en": "Which Jewish holiday commemorates the Exodus from Egypt?",
       "ja": "ユダヤ教でエジプト脱出を記念する祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143747,7 +145758,8 @@
     "question_text": {
       "en": "Which Italian seafood pasta sauce features shellfish and tomato?",
       "ja": "魚介とトマトで作るイタリアのパスタソースは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143762,7 +145774,6 @@
         "en": "Focaccia",
         "ja": "フォカッチャ",
         "ja_typings": [
-          "fokaccha",
           "fokatcha"
         ]
       },
@@ -143788,7 +145799,8 @@
     "question_text": {
       "en": "Which flatbread from Emilia-Romagna is similar to a tortilla?",
       "ja": "エミリア=ロマーニャ州のトルティーヤに似た平焼きパンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143828,7 +145840,8 @@
     "question_text": {
       "en": "Which South American garment is a single piece of cloth with a hole for the head?",
       "ja": "頭を通す穴があいた一枚布の南米の衣服は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143868,7 +145881,8 @@
     "question_text": {
       "en": "Which traditional wooden shoe is associated with France and the Netherlands?",
       "ja": "フランスやオランダの木製の伝統的な靴は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143908,7 +145922,8 @@
     "question_text": {
       "en": "Which sumo rank is the third-highest, just below Ozeki?",
       "ja": "大相撲の番付で大関のすぐ下の地位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143948,7 +145963,8 @@
     "question_text": {
       "en": "Which Levantine salad is made of bulgur, parsley, tomato and mint?",
       "ja": "ブルグル、パセリ、トマト、ミントで作る中東のサラダは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143988,7 +146004,8 @@
     "question_text": {
       "en": "Which Mexican dish uses a folded corn tortilla with various fillings?",
       "ja": "コーントルティーヤに具を挟んだメキシコ料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144028,7 +146045,8 @@
     "question_text": {
       "en": "Which Korean martial art is known for its powerful kicks and is an Olympic sport?",
       "ja": "強力な蹴りで知られ五輪競技にもなった韓国発祥の格闘技は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144068,7 +146086,8 @@
     "question_text": {
       "en": "Which checkered woven pattern is associated with Scottish kilts?",
       "ja": "スコットランドのキルトに使われる格子模様は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144108,7 +146127,8 @@
     "question_text": {
       "en": "Which ancient Roman garment was a draped piece of cloth worn by citizens?",
       "ja": "古代ローマの市民が身につけた、布をまとう衣服は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144148,7 +146168,8 @@
     "question_text": {
       "en": "Which sacred Jewish scripture corresponds to the first five books of the Hebrew Bible?",
       "ja": "ヘブライ語聖書の最初の五書に当たるユダヤ教の聖典は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144188,7 +146209,8 @@
     "question_text": {
       "en": "Which wrapped headgear is traditionally worn by Sikh men and others across South Asia?",
       "ja": "南アジアでシーク教徒の男性などが頭に巻く布は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144228,7 +146250,8 @@
     "question_text": {
       "en": "Which ancient Indian sacred texts form the foundation of Hindu scripture?",
       "ja": "ヒンドゥー教の聖典の基礎となる古代インドの聖典は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144268,7 +146291,8 @@
     "question_text": {
       "en": "Which thin fabric covering is worn over the face, often in religious or wedding contexts?",
       "ja": "宗教儀礼や結婚式で顔を覆う薄い布は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144308,7 +146332,8 @@
     "question_text": {
       "en": "Which sacred river of India flows through Delhi and joins the Ganges at Prayagraj?",
       "ja": "デリーを流れプラヤーグラージでガンジス川と合流するインドの聖なる川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144316,7 +146341,6 @@
         "en": "Zaha Hadid",
         "ja": "ザハ・ハディド",
         "ja_typings": [
-          "zahahadeido",
           "zaha/hadhido"
         ]
       },
@@ -144324,7 +146348,6 @@
         "en": "Frank Lloyd Wright",
         "ja": "フランク・ロイド・ライト",
         "ja_typings": [
-          "furankuroidoraito",
           "furanku/roido/raito"
         ]
       },
@@ -144332,7 +146355,6 @@
         "en": "Le Corbusier",
         "ja": "ル・コルビュジエ",
         "ja_typings": [
-          "rukorubyujie",
           "ru/korubyujie"
         ]
       },
@@ -144351,7 +146373,8 @@
     "question_text": {
       "en": "Which Iraqi-British architect designed the Heydar Aliyev Center and the London Aquatics Centre?",
       "ja": "ヘイダル・アリエフ・センターを設計したイラク出身の建築家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144391,7 +146414,8 @@
     "question_text": {
       "en": "Which copyleft license requires source disclosure even for network-served software?",
       "ja": "ネットワーク経由で提供されるソフトウェアにもソース開示を求めるコピーレフトライセンスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144431,7 +146455,8 @@
     "question_text": {
       "en": "Which AWS service acts as a managed front door for APIs with routing, auth, and throttling?",
       "ja": "API のルーティングや認証、スロットリングを担う AWS のマネージドサービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144471,7 +146496,8 @@
     "question_text": {
       "en": "What is the term for an early pre-release version used for internal or limited testing?",
       "ja": "限定的な内部テスト向けに公開される初期段階の試験版を何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144511,7 +146537,8 @@
     "question_text": {
       "en": "Which AWS service auto-scales relational database capacity on demand?",
       "ja": "需要に応じてリレーショナルDBの容量を自動スケールする AWS サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144551,7 +146578,8 @@
     "question_text": {
       "en": "What is a feature-complete pre-release version offered to wider testers before release?",
       "ja": "リリース前に広範な利用者に提供される機能ほぼ完成版の試験版は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144591,7 +146619,8 @@
     "question_text": {
       "en": "Which deployment switches traffic between two identical environments to minimize downtime?",
       "ja": "二つの同一環境を切り替えてダウンタイムを最小化するデプロイ手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144631,7 +146660,8 @@
     "question_text": {
       "en": "Which foundation hosts Kubernetes and other cloud native projects?",
       "ja": "Kubernetes 等のクラウドネイティブ系プロジェクトをホストする財団は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144671,7 +146701,8 @@
     "question_text": {
       "en": "In GitLab, what is the abbreviation for a request to review and integrate code (similar to GitHub PR)?",
       "ja": "GitLab で GitHub の PR に相当する変更取り込み要求の略称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144711,7 +146742,8 @@
     "question_text": {
       "en": "Which AWS service is a global content delivery network (CDN)?",
       "ja": "AWS のグローバル CDN サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144751,7 +146783,8 @@
     "question_text": {
       "en": "Which protocol translates human-readable domain names into IP addresses?",
       "ja": "ドメイン名を IP アドレスに変換する仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144791,7 +146824,8 @@
     "question_text": {
       "en": "Which Kubernetes resource manages a replicated set of stateless Pods?",
       "ja": "ステートレスな Pod のレプリカを管理する Kubernetes リソースは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144831,7 +146865,8 @@
     "question_text": {
       "en": "Which AWS service provides a dedicated private network connection to AWS?",
       "ja": "オンプレと AWS を専用線で接続する AWS サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144871,7 +146906,8 @@
     "question_text": {
       "en": "In agile, what is a large body of work that is broken down into multiple stories?",
       "ja": "アジャイルで複数のストーリーに分割される大きな作業単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144911,7 +146947,8 @@
     "question_text": {
       "en": "Which architecture style produces and consumes events asynchronously between components?",
       "ja": "コンポーネント間でイベントを非同期にやり取りするアーキテクチャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144951,7 +146988,8 @@
     "question_text": {
       "en": "Which US government standard specifies security requirements for cryptographic modules?",
       "ja": "暗号モジュールのセキュリティ要件を定めた米国政府の規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144991,7 +147029,8 @@
     "question_text": {
       "en": "Which 1985 document by Richard Stallman declared the philosophy of free software?",
       "ja": "1985 年にストールマンがフリーソフトウェアの理念を宣言した文書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145031,7 +147070,8 @@
     "question_text": {
       "en": "Which version of the GNU General Public License was released in 2007 with patent provisions?",
       "ja": "2007 年にリリースされ特許条項を含む GPL のバージョンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145071,7 +147111,8 @@
     "question_text": {
       "en": "Which 1986 essay by The Mentor became iconic in hacker culture?",
       "ja": "ハッカー文化の象徴となった 1986 年のメンターによる文書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145111,7 +147152,8 @@
     "question_text": {
       "en": "Which organization develops and promotes voluntary Internet standards like TCP/IP and HTTP?",
       "ja": "TCP/IP や HTTP 等のインターネット標準を策定する組織は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145151,7 +147193,8 @@
     "question_text": {
       "en": "In compilers, what is the abbreviation for the intermediate representation of code?",
       "ja": "コンパイラで中間表現を指す略称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145191,7 +147234,8 @@
     "question_text": {
       "en": "Which international standard specifies requirements for an information security management system (ISMS)?",
       "ja": "情報セキュリティマネジメントシステム(ISMS)の要件を定めた国際規格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145231,7 +147275,8 @@
     "question_text": {
       "en": "Which GNU license allows linking with proprietary software, often used for libraries?",
       "ja": "ライブラリ向けで、プロプライエタリと動的リンク可能な GNU 系ライセンスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145271,7 +147316,8 @@
     "question_text": {
       "en": "In GitLab terminology, what is the abbreviation for a Merge Request?",
       "ja": "GitLab でマージリクエストを意味する略称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145311,7 +147357,8 @@
     "question_text": {
       "en": "Which architecture deploys an application as a single, tightly coupled unit?",
       "ja": "アプリ全体を単一の密結合な単位として配備するアーキテクチャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145351,7 +147398,8 @@
     "question_text": {
       "en": "Which technique remaps IP addresses by translating them between private and public networks?",
       "ja": "プライベートとパブリックネットワーク間で IP を変換する技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145391,7 +147439,8 @@
     "question_text": {
       "en": "What is a build automatically produced every night from the latest source code called?",
       "ja": "毎晩最新ソースから自動生成されるビルドを何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145431,7 +147480,8 @@
     "question_text": {
       "en": "In Kubernetes, what term refers to a worker machine (VM or physical) that runs Pods?",
       "ja": "Kubernetes で Pod を実行するワーカーマシンを何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145471,7 +147521,8 @@
     "question_text": {
       "en": "Which non-profit publishes the Top 10 list of web application security risks?",
       "ja": "Web アプリのセキュリティリスク Top 10 を公開している非営利団体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145511,7 +147562,8 @@
     "question_text": {
       "en": "Which document published by OSI defines the criteria a license must meet to be \"open source\"?",
       "ja": "OSI が公開する、オープンソースライセンスの定義文書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145551,7 +147603,8 @@
     "question_text": {
       "en": "On GitHub, what is the abbreviation for a request to merge a branch's changes?",
       "ja": "GitHub でブランチの変更をマージ要求する仕組みの略称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145591,7 +147644,8 @@
     "question_text": {
       "en": "Which cloud service model provides a managed runtime and platform for deploying apps?",
       "ja": "アプリ実行用のマネージドなプラットフォームを提供するクラウド形態は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145631,7 +147685,8 @@
     "question_text": {
       "en": "Which agile estimation technique uses cards with Fibonacci-like numbers?",
       "ja": "フィボナッチ風の数字カードで規模見積りを行うアジャイル手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145671,7 +147726,8 @@
     "question_text": {
       "en": "Which AWS service provides a managed relational database?",
       "ja": "リレーショナルDBをマネージドで提供する AWS サービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145711,7 +147767,8 @@
     "question_text": {
       "en": "Which deployment gradually replaces instances of the old version with the new one?",
       "ja": "旧版のインスタンスを順次新版へ置き換えていくデプロイ手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145751,7 +147808,8 @@
     "question_text": {
       "en": "Which AICPA audit report focuses on service organizations' security and availability controls?",
       "ja": "サービス事業者のセキュリティ・可用性統制を評価する AICPA の監査報告書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145791,7 +147849,8 @@
     "question_text": {
       "en": "In Kubernetes, which resource provides stable network access to a set of Pods?",
       "ja": "Kubernetes で Pod 群への安定したネットワークアクセスを提供するリソースは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145831,7 +147890,8 @@
     "question_text": {
       "en": "Which architecture organizes functionality as reusable services communicating over a network?",
       "ja": "機能をネットワーク経由で再利用可能なサービス群として組むアーキテクチャは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145871,7 +147931,8 @@
     "question_text": {
       "en": "Which deployment sends a copy of live traffic to a new version without affecting users?",
       "ja": "本番トラフィックを複製して新版に流し、利用者に影響を与えない検証手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145911,7 +147972,8 @@
     "question_text": {
       "en": "In agile, what is the smallest unit of work assigned to a developer?",
       "ja": "アジャイルで開発者にアサインされる最小の作業単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145951,7 +148013,8 @@
     "question_text": {
       "en": "In requirements engineering, what describes a sequence of interactions between user and system?",
       "ja": "要件定義で利用者とシステムのやり取りの流れを記述するものは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145991,7 +148054,8 @@
     "question_text": {
       "en": "Which technology creates an encrypted tunnel over a public network to access a private one?",
       "ja": "公衆網上に暗号化トンネルを張りプライベート網へアクセスする技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146031,7 +148095,8 @@
     "question_text": {
       "en": "What is the linguistic term for a bound morpheme attached to a word stem (prefix, suffix, infix)?",
       "ja": "語幹に付加される接頭辞・接尾辞などの拘束形態素を指す言語学用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146071,7 +148136,8 @@
     "question_text": {
       "en": "Which language family includes Arabic, Hebrew, and ancient Egyptian?",
       "ja": "アラビア語・ヘブライ語・古代エジプト語を含む語族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146111,7 +148177,8 @@
     "question_text": {
       "en": "Which part of speech in English includes \"can,\" \"will,\" \"must,\" and \"may\"?",
       "ja": "英語で can / will / must / may を含む品詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146151,7 +148218,8 @@
     "question_text": {
       "en": "In Japanese kanji learning order, which direction is sometimes used in stroke order references?",
       "ja": "漢字の筆順の説明で、下から上へ書く方向性を指す表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146191,7 +148259,8 @@
     "question_text": {
       "en": "Which voice expresses that the subject causes someone or something else to perform an action?",
       "ja": "主語が他者に動作を行わせることを表す態(ヴォイス)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146231,7 +148300,8 @@
     "question_text": {
       "en": "What are the logographic characters borrowed from China and used in Japanese called in English?",
       "ja": "日本語で中国由来の表意文字である漢字を英語で何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146239,21 +148309,21 @@
         "en": "Customary reading",
         "ja": "慣用読み",
         "ja_typings": [
-          "kanyouyomi"
+          "kannyouyomi"
         ]
       },
       {
         "en": "On reading",
         "ja": "音読み",
         "ja_typings": [
-          "onyomi"
+          "onnyomi"
         ]
       },
       {
         "en": "Kun reading",
         "ja": "訓読み",
         "ja_typings": [
-          "kunyomi"
+          "kunnyomi"
         ]
       },
       {
@@ -146271,7 +148341,8 @@
     "question_text": {
       "en": "Which kanji reading is based on traditional convention rather than standard on/kun readings?",
       "ja": "音読み・訓読みの標準的な規則ではなく慣習に基づく漢字の読み方は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146311,7 +148382,8 @@
     "question_text": {
       "en": "Which alphabet is used for Russian, Bulgarian, and Serbian?",
       "ja": "ロシア語・ブルガリア語・セルビア語で用いられる文字体系は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146319,32 +148391,28 @@
         "en": "Eight",
         "ja": "8",
         "ja_typings": [
-          "8",
-          "hachi"
+          "8"
         ]
       },
       {
         "en": "Six",
         "ja": "6",
         "ja_typings": [
-          "6",
-          "roku"
+          "6"
         ]
       },
       {
         "en": "Two",
         "ja": "2",
         "ja_typings": [
-          "2",
-          "ni"
+          "2"
         ]
       },
       {
         "en": "Ten",
         "ja": "10",
         "ja_typings": [
-          "10",
-          "juu"
+          "10"
         ]
       }
     ],
@@ -146355,7 +148423,8 @@
     "question_text": {
       "en": "Which number is \"eight\" in English?",
       "ja": "英語で eight が表す数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146384,7 +148453,7 @@
         "en": "Metaphor",
         "ja": "隠喩",
         "ja_typings": [
-          "inyu"
+          "innyu"
         ]
       }
     ],
@@ -146395,7 +148464,8 @@
     "question_text": {
       "en": "What is the rhetorical device of omitting words that are understood from context?",
       "ja": "文脈から自明な語を省略する修辞技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146435,7 +148505,8 @@
     "question_text": {
       "en": "What is the final part of a Japanese conjugated word called?",
       "ja": "日本語の活用語の末尾(活用語尾)を指す語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146475,7 +148546,8 @@
     "question_text": {
       "en": "Which romanization system for Japanese was popularized by an American missionary's dictionary?",
       "ja": "米国人宣教師の辞典で普及した日本語のローマ字表記法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146515,7 +148587,8 @@
     "question_text": {
       "en": "Which language family includes English, Hindi, Russian, and Greek?",
       "ja": "英語・ヒンディー語・ロシア語・ギリシャ語を含む語族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146555,7 +148628,8 @@
     "question_text": {
       "en": "What is the rhetorical device of reversing the usual word order for emphasis?",
       "ja": "強調のために通常の語順を入れ替える修辞技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146595,7 +148669,8 @@
     "question_text": {
       "en": "Which script is used to write the Khmer language of Cambodia?",
       "ja": "カンボジアのクメール語を書き表す文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146635,7 +148710,8 @@
     "question_text": {
       "en": "Which alphabet is used for English, French, Spanish, and most European languages?",
       "ja": "英語・フランス語・スペイン語など多くの欧州言語で使われる文字体系は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146643,7 +148719,7 @@
         "en": "Metaphor",
         "ja": "隠喩",
         "ja_typings": [
-          "inyu"
+          "innyu"
         ]
       },
       {
@@ -146657,7 +148733,7 @@
         "en": "Metonymy",
         "ja": "換喩",
         "ja_typings": [
-          "kanyu"
+          "kannyu"
         ]
       },
       {
@@ -146675,7 +148751,8 @@
     "question_text": {
       "en": "What is the rhetorical device of describing one thing as if it were another (e.g., \"Time is money\")?",
       "ja": "あるものを別のものに見立てて表現する修辞技法(例: 時は金なり)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146683,14 +148760,14 @@
         "en": "Metonymy",
         "ja": "換喩",
         "ja_typings": [
-          "kanyu"
+          "kannyu"
         ]
       },
       {
         "en": "Metaphor",
         "ja": "隠喩",
         "ja_typings": [
-          "inyu"
+          "innyu"
         ]
       },
       {
@@ -146715,7 +148792,8 @@
     "question_text": {
       "en": "Which rhetorical device substitutes a related concept for the name of a thing (e.g., \"the crown\" for monarchy)?",
       "ja": "事物の名を関連概念で置き換える修辞技法(例: 王冠が王権を指す)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146755,7 +148833,8 @@
     "question_text": {
       "en": "What is the final part of a Japanese noun's conjugational form called?",
       "ja": "日本語で名詞活用の語尾部分を指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146795,7 +148874,8 @@
     "question_text": {
       "en": "Which Japanese part of speech marks grammatical relations like subject, object, and topic?",
       "ja": "主語・目的語・主題などの文法関係を示す日本語の品詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146835,7 +148915,8 @@
     "question_text": {
       "en": "Which voice expresses that the subject receives the action of the verb?",
       "ja": "主語が動作の受け手であることを表す態(ヴォイス)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146850,14 +148931,14 @@
         "en": "Metaphor",
         "ja": "隠喩",
         "ja_typings": [
-          "inyu"
+          "innyu"
         ]
       },
       {
         "en": "Metonymy",
         "ja": "換喩",
         "ja_typings": [
-          "kanyu"
+          "kannyu"
         ]
       },
       {
@@ -146875,7 +148956,8 @@
     "question_text": {
       "en": "What rhetorical device gives human qualities to non-human things?",
       "ja": "人ではないものに人間的性質を与える修辞技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146915,7 +148997,8 @@
     "question_text": {
       "en": "What is the polite style of Japanese using forms like \"desu\" and \"masu\" called?",
       "ja": "「です」「ます」を用いる日本語の丁寧な文体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146955,7 +149038,8 @@
     "question_text": {
       "en": "Which Romance language is the official language of Portugal and Brazil?",
       "ja": "ポルトガルとブラジルの公用語であるロマンス諸語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146995,7 +149079,8 @@
     "question_text": {
       "en": "Which subfield of linguistics studies how context contributes to meaning?",
       "ja": "文脈が意味に与える影響を研究する言語学の下位分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147035,7 +149120,8 @@
     "question_text": {
       "en": "Which interdisciplinary field studies the mental processes involved in language use?",
       "ja": "言語使用に関わる心的過程を研究する学際分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147075,7 +149161,8 @@
     "question_text": {
       "en": "What is the Japanese phonological phenomenon where a voiceless consonant becomes voiced in compounds (e.g., hito + hito = hitobito)?",
       "ja": "複合語で清音が濁音化する日本語の音韻現象(例: ひと+ひと=ひとびと)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147104,7 +149191,7 @@
         "en": "Metaphor",
         "ja": "隠喩",
         "ja_typings": [
-          "inyu"
+          "innyu"
         ]
       }
     ],
@@ -147115,7 +149202,8 @@
     "question_text": {
       "en": "Which rhetorical device repeats words or phrases for emphasis?",
       "ja": "強調のために語句を繰り返す修辞技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147155,7 +149243,8 @@
     "question_text": {
       "en": "What is the Japanese honorific style used to elevate the listener or referent called?",
       "ja": "聞き手や話題の人物を高める日本語の敬語スタイルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147163,32 +149252,28 @@
         "en": "Six",
         "ja": "6",
         "ja_typings": [
-          "6",
-          "roku"
+          "6"
         ]
       },
       {
         "en": "Eight",
         "ja": "8",
         "ja_typings": [
-          "8",
-          "hachi"
+          "8"
         ]
       },
       {
         "en": "Two",
         "ja": "2",
         "ja_typings": [
-          "2",
-          "ni"
+          "2"
         ]
       },
       {
         "en": "Nine",
         "ja": "9",
         "ja_typings": [
-          "9",
-          "kyuu"
+          "9"
         ]
       }
     ],
@@ -147199,7 +149284,8 @@
     "question_text": {
       "en": "Which number is \"six\" in English?",
       "ja": "英語で six が表す数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147239,7 +149325,8 @@
     "question_text": {
       "en": "Which subfield of linguistics studies the relationship between language and society?",
       "ja": "言語と社会の関係を研究する言語学の下位分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147279,7 +149366,8 @@
     "question_text": {
       "en": "Which Romance language is the official language of Spain and most of Latin America?",
       "ja": "スペインおよびラテンアメリカの多くの国の公用語であるロマンス諸語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147319,7 +149407,8 @@
     "question_text": {
       "en": "What is the unchanging core part of a Japanese conjugated word called?",
       "ja": "日本語の活用語で変化しない中心部分を指す語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147334,7 +149423,7 @@
         "en": "Metonymy",
         "ja": "換喩",
         "ja_typings": [
-          "kanyu"
+          "kannyu"
         ]
       },
       {
@@ -147359,7 +149448,8 @@
     "question_text": {
       "en": "Which rhetorical device uses a part to represent the whole, or vice versa (e.g., \"all hands on deck\")?",
       "ja": "部分で全体を、あるいは全体で部分を表す修辞技法(例: \"all hands\" が船員を指す)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147399,7 +149489,8 @@
     "question_text": {
       "en": "Which subfield of linguistics studies the rules governing sentence structure?",
       "ja": "文の構造を規定する規則を研究する言語学の下位分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147439,7 +149530,8 @@
     "question_text": {
       "en": "Which script is used to write the Thai language?",
       "ja": "タイ語を書き表す文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147447,32 +149539,28 @@
         "en": "Two",
         "ja": "2",
         "ja_typings": [
-          "2",
-          "ni"
+          "2"
         ]
       },
       {
         "en": "Six",
         "ja": "6",
         "ja_typings": [
-          "6",
-          "roku"
+          "6"
         ]
       },
       {
         "en": "Eight",
         "ja": "8",
         "ja_typings": [
-          "8",
-          "hachi"
+          "8"
         ]
       },
       {
         "en": "Three",
         "ja": "3",
         "ja_typings": [
-          "3",
-          "san"
+          "3"
         ]
       }
     ],
@@ -147483,7 +149571,8 @@
     "question_text": {
       "en": "Which number is \"two\" in English?",
       "ja": "英語で two が表す数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147523,7 +149612,8 @@
     "question_text": {
       "en": "Who created the manga \"Dragon Ball\"?",
       "ja": "漫画『ドラゴンボール』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147563,7 +149653,8 @@
     "question_text": {
       "en": "Who created the manga \"One Piece\"?",
       "ja": "漫画『ONE PIECE』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147571,14 +149662,14 @@
         "en": "Fujiko F. Fujio",
         "ja": "藤子・F・不二雄",
         "ja_typings": [
-          "fujikoffujio"
+          "fujiko/f/fujio"
         ]
       },
       {
         "en": "Fujiko Fujio A",
         "ja": "藤子不二雄A",
         "ja_typings": [
-          "fujikofujioa"
+          "fujikofujioe-"
         ]
       },
       {
@@ -147603,7 +149694,8 @@
     "question_text": {
       "en": "Which pen name was used by the duo behind \"Doraemon\"?",
       "ja": "『ドラえもん』を生んだコンビが用いたペンネームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147618,7 +149710,7 @@
         "en": "Shueisha",
         "ja": "集英社",
         "ja_typings": [
-          "shueisha"
+          "shuueisha"
         ]
       },
       {
@@ -147643,7 +149735,8 @@
     "question_text": {
       "en": "Which Japanese publisher issues \"Weekly Manga Action\" and \"Manga Town\"?",
       "ja": "『漫画アクション』『漫画タウン』を発行する日本の出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147658,7 +149751,7 @@
         "en": "Shueisha",
         "ja": "集英社",
         "ja_typings": [
-          "shueisha"
+          "shuueisha"
         ]
       },
       {
@@ -147683,7 +149776,8 @@
     "question_text": {
       "en": "Which Japanese publisher issues \"Hana to Yume\" and \"LaLa\"?",
       "ja": "『花とゆめ』『LaLa』を発行する日本の出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147698,7 +149792,7 @@
         "en": "Shueisha",
         "ja": "集英社",
         "ja_typings": [
-          "shueisha"
+          "shuueisha"
         ]
       },
       {
@@ -147723,7 +149817,8 @@
     "question_text": {
       "en": "Which publisher issues \"Monthly Shonen Ace\" and is a major light novel publisher?",
       "ja": "『月刊少年エース』を発行しライトノベルでも大手の出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147763,7 +149858,8 @@
     "question_text": {
       "en": "Who created \"Akira\"?",
       "ja": "漫画『AKIRA』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147803,7 +149899,8 @@
     "question_text": {
       "en": "Who created \"Berserk\"?",
       "ja": "漫画『ベルセルク』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147843,7 +149940,8 @@
     "question_text": {
       "en": "Who created \"Ghost in the Shell\"?",
       "ja": "『攻殻機動隊』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147883,7 +149981,8 @@
     "question_text": {
       "en": "Who is the protagonist artist character of \"Glass Mask\" (Garasu no Kamen)?",
       "ja": "『ガラスの仮面』に登場する天才舞台女優のライバルの名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147923,7 +150022,8 @@
     "question_text": {
       "en": "Which Japanese newspaper company is known for its economic and business news?",
       "ja": "経済・ビジネスニュースで知られる日本の新聞社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147963,7 +150063,8 @@
     "question_text": {
       "en": "Who is the illustrator of \"Death Note\" and \"Bakuman\"?",
       "ja": "『DEATH NOTE』『バクマン。』の作画担当は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148003,7 +150104,8 @@
     "question_text": {
       "en": "Who created \"Chainsaw Man\"?",
       "ja": "『チェンソーマン』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148043,7 +150145,8 @@
     "question_text": {
       "en": "Who created \"Fist of the North Star\" as the artist?",
       "ja": "『北斗の拳』の作画担当は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148083,7 +150186,8 @@
     "question_text": {
       "en": "Which national daily Japanese newspaper is published by Mainichi Shimbun Holdings?",
       "ja": "毎日新聞社が発行する日本の全国紙は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148123,7 +150227,8 @@
     "question_text": {
       "en": "Which Japanese daily newspaper has the largest circulation, published by The Yomiuri Shimbun Holdings?",
       "ja": "発行部数が日本最大級の、読売新聞社が発行する全国紙は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148163,7 +150268,8 @@
     "question_text": {
       "en": "Who is the writer of \"Death Note\" and \"Bakuman\"?",
       "ja": "『DEATH NOTE』『バクマン。』の原作担当は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148203,7 +150309,8 @@
     "question_text": {
       "en": "Which Shogakukan magazine serialized \"InuYasha\" and \"Detective Conan\"?",
       "ja": "『犬夜叉』『名探偵コナン』を連載する小学館の漫画雑誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148243,6 +150350,7 @@
     "question_text": {
       "en": "Who created \"Kingdom\"?",
       "ja": "漫画『キングダム』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   }
 ]

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -21045,7 +21045,7 @@
         "ja": "オスマン帝国",
         "en": "Ottoman Empire",
         "ja_typings": [
-          "osumantekoku"
+          "osumanteikoku"
         ]
       },
       {
@@ -50931,7 +50931,7 @@
         "en": "Doubly linked list + hash map",
         "ja": "双方向連結リスト + ハッシュマップ",
         "ja_typings": [
-          "souhoukourenketsurisuto/+/hasshumappu"
+          "souhoukourenketsurisuto+hasshumappu"
         ]
       },
       {
@@ -84563,28 +84563,28 @@
         "en": "Henry IV",
         "ja": "アンリ4世",
         "ja_typings": [
-          "anri/4/sei"
+          "anri4sei"
         ]
       },
       {
         "en": "Louis XIII",
         "ja": "ルイ13世",
         "ja_typings": [
-          "rui/13/sei"
+          "rui13sei"
         ]
       },
       {
         "en": "Henry III",
         "ja": "アンリ3世",
         "ja_typings": [
-          "anri/3/sei"
+          "anri3sei"
         ]
       },
       {
         "en": "Charles IX",
         "ja": "シャルル9世",
         "ja_typings": [
-          "sharuru/9/sei"
+          "sharuru9sei"
         ]
       }
     ],
@@ -84727,28 +84727,28 @@
         "en": "Crimean War",
         "ja": "クリミア戦争",
         "ja_typings": [
-          "kurimia/sensou"
+          "kurimiasensou"
         ]
       },
       {
         "en": "Russo-Turkish War",
         "ja": "露土戦争",
         "ja_typings": [
-          "roto/sensou"
+          "rotosensou"
         ]
       },
       {
         "en": "Franco-Prussian War",
         "ja": "普仏戦争",
         "ja_typings": [
-          "fufutsu/sensou"
+          "fufutsusensou"
         ]
       },
       {
         "en": "Austro-Prussian War",
         "ja": "普墺戦争",
         "ja_typings": [
-          "fuou/sensou"
+          "fuousensou"
         ]
       }
     ],
@@ -84816,14 +84816,14 @@
         "en": "Storming of the Bastille",
         "ja": "バスティーユ襲撃",
         "ja_typings": [
-          "basuthi-yu/shuugeki"
+          "basuthi-yushuugeki"
         ]
       },
       {
         "en": "Night of August 4",
         "ja": "8月4日の夜",
         "ja_typings": [
-          "8gatsu/4nichi/no/yoru"
+          "8gatsu4nichinoyoru"
         ]
       },
       {
@@ -84850,28 +84850,28 @@
         "en": "Battle of Valmy",
         "ja": "ヴァルミーの戦い",
         "ja_typings": [
-          "varumi-/no/tatakai"
+          "varumi-notatakai"
         ]
       },
       {
         "en": "Battle of Jemappes",
         "ja": "ジェマップの戦い",
         "ja_typings": [
-          "jemappu/no/tatakai"
+          "jemappunotatakai"
         ]
       },
       {
         "en": "Battle of Fleurus",
         "ja": "フルーリュスの戦い",
         "ja_typings": [
-          "furu-ryusu/no/tatakai"
+          "furu-ryusunotatakai"
         ]
       },
       {
         "en": "Battle of Marengo",
         "ja": "マレンゴの戦い",
         "ja_typings": [
-          "marengo/no/tatakai"
+          "marengonotatakai"
         ]
       }
     ],
@@ -85096,14 +85096,14 @@
         "en": "Charles X",
         "ja": "シャルル10世",
         "ja_typings": [
-          "sharuru/10/sei"
+          "sharuru10sei"
         ]
       },
       {
         "en": "Louis XVIII",
         "ja": "ルイ18世",
         "ja_typings": [
-          "rui/18/sei"
+          "rui18sei"
         ]
       },
       {
@@ -85117,7 +85117,7 @@
         "en": "Napoleon III",
         "ja": "ナポレオン3世",
         "ja_typings": [
-          "naporeon/3/sei"
+          "naporeon3sei"
         ]
       }
     ],
@@ -85178,28 +85178,28 @@
         "en": "Battle of Leipzig",
         "ja": "ライプツィヒの戦い",
         "ja_typings": [
-          "raiputsihi/no/tatakai"
+          "raiputsihinotatakai"
         ]
       },
       {
         "en": "Battle of Waterloo",
         "ja": "ワーテルローの戦い",
         "ja_typings": [
-          "wa-teruro-/no/tatakai"
+          "wa-teruro-notatakai"
         ]
       },
       {
         "en": "Battle of Borodino",
         "ja": "ボロジノの戦い",
         "ja_typings": [
-          "borojino/no/tatakai"
+          "borojinonotatakai"
         ]
       },
       {
         "en": "Battle of Austerlitz",
         "ja": "アウステルリッツの戦い",
         "ja_typings": [
-          "ausuterurittsu/no/tatakai"
+          "ausuterurittsunotatakai"
         ]
       }
     ],
@@ -85629,28 +85629,28 @@
         "en": "Balkan War",
         "ja": "バルカン戦争",
         "ja_typings": [
-          "barukan/sensou"
+          "barukansensou"
         ]
       },
       {
         "en": "Crimean War",
         "ja": "クリミア戦争",
         "ja_typings": [
-          "kurimia/sensou"
+          "kurimiasensou"
         ]
       },
       {
         "en": "Russo-Turkish War",
         "ja": "露土戦争",
         "ja_typings": [
-          "roto/sensou"
+          "rotosensou"
         ]
       },
       {
         "en": "Greco-Turkish War",
         "ja": "希土戦争",
         "ja_typings": [
-          "kido/sensou"
+          "kidosensou"
         ]
       }
     ],
@@ -85800,21 +85800,21 @@
         "en": "Edward VII",
         "ja": "エドワード7世",
         "ja_typings": [
-          "edowa-do/7/sei"
+          "edowa-do7sei"
         ]
       },
       {
         "en": "George V",
         "ja": "ジョージ5世",
         "ja_typings": [
-          "jo-ji/5/sei"
+          "jo-ji5sei"
         ]
       },
       {
         "en": "William IV",
         "ja": "ウィリアム4世",
         "ja_typings": [
-          "wiriamu/4/sei"
+          "wiriamu4sei"
         ]
       }
     ],
@@ -85916,28 +85916,28 @@
         "en": "Vietnam War",
         "ja": "ベトナム戦争",
         "ja_typings": [
-          "betonamu/sensou"
+          "betonamusensou"
         ]
       },
       {
         "en": "Korean War",
         "ja": "朝鮮戦争",
         "ja_typings": [
-          "chousen/sensou"
+          "chousensensou"
         ]
       },
       {
         "en": "Gulf War",
         "ja": "湾岸戦争",
         "ja_typings": [
-          "wangan/sensou"
+          "wangansensou"
         ]
       },
       {
         "en": "Cambodian Civil War",
         "ja": "カンボジア内戦",
         "ja_typings": [
-          "kanbojia/naisen"
+          "kanbojianaisen"
         ]
       }
     ],
@@ -85957,28 +85957,28 @@
         "en": "Holy Roman Empire",
         "ja": "神聖ローマ帝国",
         "ja_typings": [
-          "shinsei/ro-ma/teikoku"
+          "shinseiro-mateikoku"
         ]
       },
       {
         "en": "Byzantine Empire",
         "ja": "ビザンツ帝国",
         "ja_typings": [
-          "bizantsu/teikoku"
+          "bizantsuteikoku"
         ]
       },
       {
         "en": "Carolingian Empire",
         "ja": "カロリング帝国",
         "ja_typings": [
-          "karoringu/teikoku"
+          "karoringuteikoku"
         ]
       },
       {
         "en": "Frankish Kingdom",
         "ja": "フランク王国",
         "ja_typings": [
-          "furanku/oukoku"
+          "furankuoukoku"
         ]
       }
     ],
@@ -85998,28 +85998,28 @@
         "en": "Abu Simbel Temple",
         "ja": "アブ・シンベル神殿",
         "ja_typings": [
-          "abu/shinberu/shinden"
+          "abushinberushinden"
         ]
       },
       {
         "en": "Luxor Temple",
         "ja": "ルクソール神殿",
         "ja_typings": [
-          "rukuso-ru/shinden"
+          "rukuso-rushinden"
         ]
       },
       {
         "en": "Karnak Temple",
         "ja": "カルナック神殿",
         "ja_typings": [
-          "karunakku/shinden"
+          "karunakkushinden"
         ]
       },
       {
         "en": "Temple of Hatshepsut",
         "ja": "ハトシェプスト葬祭殿",
         "ja_typings": [
-          "hatoshepusuto/sousaiden"
+          "hatoshepusutosousaiden"
         ]
       }
     ],
@@ -86039,28 +86039,28 @@
         "en": "Luxor Temple",
         "ja": "ルクソール神殿",
         "ja_typings": [
-          "rukuso-ru/shinden"
+          "rukuso-rushinden"
         ]
       },
       {
         "en": "Karnak Temple",
         "ja": "カルナック神殿",
         "ja_typings": [
-          "karunakku/shinden"
+          "karunakkushinden"
         ]
       },
       {
         "en": "Abu Simbel Temple",
         "ja": "アブ・シンベル神殿",
         "ja_typings": [
-          "abu/shinberu/shinden"
+          "abushinberushinden"
         ]
       },
       {
         "en": "Edfu Temple",
         "ja": "エドフ神殿",
         "ja_typings": [
-          "edofu/shinden"
+          "edofushinden"
         ]
       }
     ],
@@ -86080,28 +86080,28 @@
         "en": "Karnak Temple",
         "ja": "カルナック神殿",
         "ja_typings": [
-          "karunakku/shinden"
+          "karunakkushinden"
         ]
       },
       {
         "en": "Luxor Temple",
         "ja": "ルクソール神殿",
         "ja_typings": [
-          "rukuso-ru/shinden"
+          "rukuso-rushinden"
         ]
       },
       {
         "en": "Abu Simbel Temple",
         "ja": "アブ・シンベル神殿",
         "ja_typings": [
-          "abu/shinberu/shinden"
+          "abushinberushinden"
         ]
       },
       {
         "en": "Philae Temple",
         "ja": "フィラエ神殿",
         "ja_typings": [
-          "firae/shinden"
+          "firaeshinden"
         ]
       }
     ],
@@ -86162,28 +86162,28 @@
         "en": "Tokugawa Iemochi",
         "ja": "徳川家茂",
         "ja_typings": [
-          "tokugawa/iemochi"
+          "tokugawaiemochi"
         ]
       },
       {
         "en": "Tokugawa Iesada",
         "ja": "徳川家定",
         "ja_typings": [
-          "tokugawa/iesada"
+          "tokugawaiesada"
         ]
       },
       {
         "en": "Tokugawa Nariaki",
         "ja": "徳川斉昭",
         "ja_typings": [
-          "tokugawa/nariaki"
+          "tokugawanariaki"
         ]
       },
       {
         "en": "Tokugawa Yoshinobu",
         "ja": "徳川慶喜",
         "ja_typings": [
-          "tokugawa/yoshinobu"
+          "tokugawayoshinobu"
         ]
       }
     ],
@@ -86203,28 +86203,28 @@
         "en": "Tokugawa Iesada",
         "ja": "徳川家定",
         "ja_typings": [
-          "tokugawa/iesada"
+          "tokugawaiesada"
         ]
       },
       {
         "en": "Tokugawa Iemochi",
         "ja": "徳川家茂",
         "ja_typings": [
-          "tokugawa/iemochi"
+          "tokugawaiemochi"
         ]
       },
       {
         "en": "Tokugawa Ieyoshi",
         "ja": "徳川家慶",
         "ja_typings": [
-          "tokugawa/ieyoshi"
+          "tokugawaieyoshi"
         ]
       },
       {
         "en": "Tokugawa Yoshinobu",
         "ja": "徳川慶喜",
         "ja_typings": [
-          "tokugawa/yoshinobu"
+          "tokugawayoshinobu"
         ]
       }
     ],
@@ -86244,28 +86244,28 @@
         "en": "Tokugawa Nariaki",
         "ja": "徳川斉昭",
         "ja_typings": [
-          "tokugawa/nariaki"
+          "tokugawanariaki"
         ]
       },
       {
         "en": "Tokugawa Iemochi",
         "ja": "徳川家茂",
         "ja_typings": [
-          "tokugawa/iemochi"
+          "tokugawaiemochi"
         ]
       },
       {
         "en": "Tokugawa Iesada",
         "ja": "徳川家定",
         "ja_typings": [
-          "tokugawa/iesada"
+          "tokugawaiesada"
         ]
       },
       {
         "en": "Ii Naosuke",
         "ja": "井伊直弼",
         "ja_typings": [
-          "ii/naosuke"
+          "iinaosuke"
         ]
       }
     ],
@@ -86285,28 +86285,28 @@
         "en": "Emperor Wu of Han",
         "ja": "漢の武帝",
         "ja_typings": [
-          "kan/no/butei"
+          "kannnobutei"
         ]
       },
       {
         "en": "Emperor Gaozu of Han",
         "ja": "漢の高祖",
         "ja_typings": [
-          "kan/no/kouso"
+          "kannnokouso"
         ]
       },
       {
         "en": "Emperor Wen of Han",
         "ja": "漢の文帝",
         "ja_typings": [
-          "kan/no/buntei"
+          "kannnobuntei"
         ]
       },
       {
         "en": "Emperor Jing of Han",
         "ja": "漢の景帝",
         "ja_typings": [
-          "kan/no/keitei"
+          "kannnokeitei"
         ]
       }
     ],
@@ -86326,28 +86326,28 @@
         "en": "Emperor Taizong of Tang",
         "ja": "唐の太宗",
         "ja_typings": [
-          "tou/no/taisou"
+          "tounotaisou"
         ]
       },
       {
         "en": "Emperor Gaozu of Tang",
         "ja": "唐の高祖",
         "ja_typings": [
-          "tou/no/kouso"
+          "tounokouso"
         ]
       },
       {
         "en": "Emperor Xuanzong of Tang",
         "ja": "唐の玄宗",
         "ja_typings": [
-          "tou/no/gensou"
+          "tounogensou"
         ]
       },
       {
         "en": "Emperor Gaozong of Tang",
         "ja": "唐の高宗",
         "ja_typings": [
-          "tou/no/kousou"
+          "tounokousou"
         ]
       }
     ],
@@ -86367,28 +86367,28 @@
         "en": "Emperor Yang of Sui",
         "ja": "隋の煬帝",
         "ja_typings": [
-          "zui/no/youdai"
+          "zuinoyoudai"
         ]
       },
       {
         "en": "Emperor Wen of Sui",
         "ja": "隋の文帝",
         "ja_typings": [
-          "zui/no/buntei"
+          "zuinobuntei"
         ]
       },
       {
         "en": "Emperor Gong of Sui",
         "ja": "隋の恭帝",
         "ja_typings": [
-          "zui/no/kyoutei"
+          "zuinokyoutei"
         ]
       },
       {
         "en": "Emperor Taizong of Tang",
         "ja": "唐の太宗",
         "ja_typings": [
-          "tou/no/taisou"
+          "tounotaisou"
         ]
       }
     ],
@@ -86408,14 +86408,14 @@
         "en": "Bill of Rights",
         "ja": "権利章典",
         "ja_typings": [
-          "kenri/shouten"
+          "kenrishouten"
         ]
       },
       {
         "en": "Petition of Right",
         "ja": "権利の請願",
         "ja_typings": [
-          "kenri/no/seigan"
+          "kenrinoseigan"
         ]
       },
       {
@@ -86429,7 +86429,7 @@
         "en": "Habeas Corpus Act",
         "ja": "人身保護法",
         "ja_typings": [
-          "jinshin/hogo/hou"
+          "jinshinhogohou"
         ]
       }
     ],
@@ -86449,14 +86449,14 @@
         "en": "Petition of Right",
         "ja": "権利の請願",
         "ja_typings": [
-          "kenri/no/seigan"
+          "kenrinoseigan"
         ]
       },
       {
         "en": "Bill of Rights",
         "ja": "権利章典",
         "ja_typings": [
-          "kenri/shouten"
+          "kenrishouten"
         ]
       },
       {
@@ -86470,7 +86470,7 @@
         "en": "Act of Settlement",
         "ja": "王位継承法",
         "ja_typings": [
-          "oui/keishou/hou"
+          "ouikeishouhou"
         ]
       }
     ],
@@ -86490,28 +86490,28 @@
         "en": "Edict of Nantes",
         "ja": "ナント勅令",
         "ja_typings": [
-          "nanto/chokurei"
+          "nantochokurei"
         ]
       },
       {
         "en": "Edict of Fontainebleau",
         "ja": "フォンテーヌブロー勅令",
         "ja_typings": [
-          "fonte-nuburo-/chokurei"
+          "fonte-nuburo-chokurei"
         ]
       },
       {
         "en": "Bill of Rights",
         "ja": "権利章典",
         "ja_typings": [
-          "kenri/shouten"
+          "kenrishouten"
         ]
       },
       {
         "en": "Concordat of Bologna",
         "ja": "ボローニャ政教条約",
         "ja_typings": [
-          "boro-nya/seikyou/jouyaku"
+          "boro-nyaseikyoujouyaku"
         ]
       }
     ],
@@ -86531,28 +86531,28 @@
         "en": "Elba",
         "ja": "エルバ島",
         "ja_typings": [
-          "eruba/tou"
+          "erubatou"
         ]
       },
       {
         "en": "Saint Helena",
         "ja": "セントヘレナ島",
         "ja_typings": [
-          "sentoherena/tou"
+          "sentoherenatou"
         ]
       },
       {
         "en": "Corsica",
         "ja": "コルシカ島",
         "ja_typings": [
-          "korushika/tou"
+          "korushikatou"
         ]
       },
       {
         "en": "Sardinia",
         "ja": "サルデーニャ島",
         "ja_typings": [
-          "sarude-nya/tou"
+          "sarude-nyatou"
         ]
       }
     ],

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -30913,7 +30913,8 @@
     "question_text": {
       "en": "Which language family does Finnish belong to?",
       "ja": "フィンランド語が属する語族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30953,7 +30954,8 @@
     "question_text": {
       "en": "What is the linguistic term for words that sound the same but have different meanings?",
       "ja": "音は同じだが意味が異なる単語を指す言語学用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30993,7 +30995,8 @@
     "question_text": {
       "en": "Which writing system was used in ancient Mesopotamia?",
       "ja": "古代メソポタミアで使われた文字体系は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31033,7 +31036,8 @@
     "question_text": {
       "en": "Which Japanese honorific form lowers the speaker to elevate the listener?",
       "ja": "話者を低めて聴者を高める日本語の敬語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31073,7 +31077,8 @@
     "question_text": {
       "en": "Which grammatical case marks the direct object in Latin?",
       "ja": "ラテン語で直接目的語を示す格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31113,7 +31118,8 @@
     "question_text": {
       "en": "Which Chinese tone is described as a sharp falling tone?",
       "ja": "中国語で鋭く下がる調子とされる四声は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31128,7 +31134,7 @@
         "en": "Calque",
         "ja": "翻訳借用",
         "ja_typings": [
-          "honyakushakuyou"
+          "honnyakushakuyou"
         ]
       },
       {
@@ -31153,7 +31159,8 @@
     "question_text": {
       "en": "Which term refers to the borrowing of a word from another language with adaptation?",
       "ja": "他言語からの適応付き単語借用を指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31193,7 +31200,8 @@
     "question_text": {
       "en": "In English grammar, which tense expresses an action completed before another past action?",
       "ja": "英文法で、別の過去の行為より前に完了した行為を表す時制は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31233,7 +31241,8 @@
     "question_text": {
       "en": "Which Romance language is the official language of Romania?",
       "ja": "ルーマニアの公用語であるロマンス諸語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31273,7 +31282,8 @@
     "question_text": {
       "en": "Which is the official script used to write Korean?",
       "ja": "朝鮮語の表記に使われる公式文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31313,7 +31323,8 @@
     "question_text": {
       "en": "Which kind of word in Japanese conjugates and ends in u?",
       "ja": "日本語でウ段で終わり活用する品詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31328,7 +31339,7 @@
         "en": "Metaphor",
         "ja": "隠喩",
         "ja_typings": [
-          "inyu"
+          "innyu"
         ]
       },
       {
@@ -31353,7 +31364,8 @@
     "question_text": {
       "en": "Which figure of speech compares two things using like or as?",
       "ja": "「ようだ」「みたいに」を使って似たものを喩える修辞法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31393,7 +31405,8 @@
     "question_text": {
       "en": "Which Slavic language is written with both Latin and Cyrillic scripts officially?",
       "ja": "ラテン文字とキリル文字の両方が公式に使われるスラブ語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31433,7 +31446,8 @@
     "question_text": {
       "en": "Which is the largest language family in the world by number of languages?",
       "ja": "言語数で世界最大の語族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31462,7 +31476,7 @@
         "en": "Kun-yomi",
         "ja": "訓読み",
         "ja_typings": [
-          "kunyomi"
+          "kunnyomi"
         ]
       }
     ],
@@ -31473,7 +31487,8 @@
     "question_text": {
       "en": "Which Japanese kanji reading was brought from Tang-dynasty China?",
       "ja": "唐代中国から伝わった漢字の読みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31513,7 +31528,8 @@
     "question_text": {
       "en": "Which is the oldest known fully deciphered writing system?",
       "ja": "完全に解読された最古の文字体系は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31635,7 +31651,8 @@
     "question_text": {
       "en": "Which Japanese summer festival features paper lanterns and is held in mid-August to honor ancestors?",
       "ja": "8月中旬に先祖供養のため灯籠を掲げる日本の夏祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31716,7 +31733,8 @@
     "question_text": {
       "en": "Which Mexican festival on November 1-2 honors deceased relatives?",
       "ja": "11月1日から2日に故人を讃えるメキシコの祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -31756,7 +31774,8 @@
     "question_text": {
       "en": "Which Japanese garden style uses raked gravel and rocks to represent landscapes?",
       "ja": "砂利や岩で景色を表現する日本庭園の様式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32165,7 +32184,8 @@
     "question_text": {
       "en": "Which type of Japanese sake brewing requires polishing rice to at least 50% of its original size?",
       "ja": "米を原料の50%以下まで精米する日本酒の種類は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32246,7 +32266,8 @@
     "question_text": {
       "en": "Which traditional Chinese dress for women features a high collar and side slits?",
       "ja": "高い襟とサイドスリットが特徴の中国伝統衣装(女性用)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32286,7 +32307,8 @@
     "question_text": {
       "en": "Which Mexican holiday on May 5 commemorates the 1862 victory over the French at Puebla?",
       "ja": "1862年のプエブラでの対仏勝利を讃える5月5日のメキシコの祝日は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32449,7 +32471,8 @@
     "question_text": {
       "en": "Which field of linguistics studies meaning in language?",
       "ja": "言語の意味を研究する言語学の分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32489,7 +32512,8 @@
     "question_text": {
       "en": "Which kind of Japanese characters represent meaning rather than sound?",
       "ja": "音ではなく意味を表現する日本語の文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32529,7 +32553,8 @@
     "question_text": {
       "en": "In English grammar, which voice has the subject performing the action?",
       "ja": "主語が動作を行う英文法の態は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32569,7 +32594,8 @@
     "question_text": {
       "en": "Which part of speech modifies verbs, adjectives, or other adverbs?",
       "ja": "動詞、形容詞、または他の副詞を修飾する品詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32609,7 +32635,8 @@
     "question_text": {
       "en": "Which language family includes Mandarin Chinese and Tibetan?",
       "ja": "中国語とチベット語を含む語族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32649,7 +32676,8 @@
     "question_text": {
       "en": "Which language family includes Indonesian, Tagalog, and Malagasy?",
       "ja": "インドネシア語、タガログ語、マダガスカル語を含む語族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32664,7 +32692,7 @@
         "en": "Metaphor",
         "ja": "隠喩",
         "ja_typings": [
-          "inyu"
+          "innyu"
         ]
       },
       {
@@ -32689,7 +32717,8 @@
     "question_text": {
       "en": "Which figure of speech exaggerates for emphasis or effect?",
       "ja": "強調や効果のため誇張する修辞法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -32729,7 +32758,8 @@
     "question_text": {
       "en": "Which Mandarin phonetic system uses zhuyin symbols and is used in Taiwan?",
       "ja": "台湾で使われる注音符号のマンダリン発音表記は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33179,7 +33209,8 @@
     "question_text": {
       "en": "Which noble gas is used to inflate party balloons and is the second lightest element?",
       "ja": "パーティー用風船に使われ、2番目に軽い気体元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33219,7 +33250,8 @@
     "question_text": {
       "en": "Which human organ produces bile and detoxifies the blood?",
       "ja": "胆汁を分泌し血液を解毒するヒトの臓器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33473,7 +33505,7 @@
         "en": "Battle of Waterloo",
         "ja": "ワーテルローの戦い",
         "ja_typings": [
-          "wa-teru-notatakai"
+          "wa-teruro-notatakai"
         ]
       },
       {
@@ -33505,7 +33537,8 @@
     "question_text": {
       "en": "In which 1815 battle was Napoleon finally defeated?",
       "ja": "1815年にナポレオンが最終的に敗北した戦闘は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -33545,7 +33578,8 @@
     "question_text": {
       "en": "Which Portuguese explorer was the first European to reach India by sea?",
       "ja": "海路で初めてインドに到達したポルトガル人探検家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34323,7 +34357,8 @@
     "question_text": {
       "en": "Which river flows through London?",
       "ja": "ロンドンを流れる河川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34363,7 +34398,8 @@
     "question_text": {
       "en": "Which river flows through Paris?",
       "ja": "パリを流れる河川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34403,7 +34439,8 @@
     "question_text": {
       "en": "Which river is the longest in China?",
       "ja": "中国最長の河川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34443,7 +34480,8 @@
     "question_text": {
       "en": "Which mountain range stretches across South America's west coast?",
       "ja": "南米の西海岸に連なる山脈は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34483,7 +34521,8 @@
     "question_text": {
       "en": "Which mountain range divides Europe and Asia?",
       "ja": "ヨーロッパとアジアを分ける山脈は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34523,7 +34562,8 @@
     "question_text": {
       "en": "Which sea lies between Italy and the Balkans?",
       "ja": "イタリアとバルカン半島の間の海は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34563,7 +34603,8 @@
     "question_text": {
       "en": "Which sea lies between Greece and Turkey?",
       "ja": "ギリシャとトルコの間の海は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34603,7 +34644,8 @@
     "question_text": {
       "en": "Which is the world's largest desert (after the polar ones)?",
       "ja": "極地を除く世界最大の砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34643,7 +34685,8 @@
     "question_text": {
       "en": "Which desert lies between Mongolia and China?",
       "ja": "モンゴルと中国の間にある砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34683,7 +34726,8 @@
     "question_text": {
       "en": "Which is the largest country by area?",
       "ja": "面積が世界最大の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34723,7 +34767,8 @@
     "question_text": {
       "en": "Which is the smallest country in the world?",
       "ja": "世界最小の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34763,7 +34808,8 @@
     "question_text": {
       "en": "Which is the world's largest lake by area?",
       "ja": "世界最大の湖は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34803,7 +34849,8 @@
     "question_text": {
       "en": "Which is the deepest lake in the world?",
       "ja": "世界で最も深い湖は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34843,7 +34890,8 @@
     "question_text": {
       "en": "Which strait separates Europe and Africa?",
       "ja": "ヨーロッパとアフリカを隔てる海峡は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34883,7 +34931,8 @@
     "question_text": {
       "en": "Which strait separates Asia and North America?",
       "ja": "アジアと北米を隔てる海峡は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -34964,7 +35013,8 @@
     "question_text": {
       "en": "Which continent has the most countries?",
       "ja": "国の数が最も多い大陸は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35004,7 +35054,8 @@
     "question_text": {
       "en": "Which is the highest mountain in Africa?",
       "ja": "アフリカ最高峰は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35085,7 +35136,8 @@
     "question_text": {
       "en": "Who was the first emperor of unified China?",
       "ja": "中国を統一した最初の皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35617,7 +35669,8 @@
     "question_text": {
       "en": "Who first circumnavigated the globe?",
       "ja": "世界一周航海を最初に成し遂げたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35821,7 +35874,8 @@
     "question_text": {
       "en": "Which dynasty preceded the Tang in China?",
       "ja": "中国で唐の前の王朝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35861,7 +35915,8 @@
     "question_text": {
       "en": "Which dynasty followed the Tang in China?",
       "ja": "中国で唐の次の王朝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35901,7 +35956,8 @@
     "question_text": {
       "en": "Which dynasty was the last imperial dynasty of China?",
       "ja": "中国最後の王朝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35941,7 +35997,8 @@
     "question_text": {
       "en": "Which war was triggered by the assassination in Sarajevo?",
       "ja": "サラエボ事件で勃発した戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -35981,7 +36038,8 @@
     "question_text": {
       "en": "Which war ended with the Treaty of Versailles?",
       "ja": "ベルサイユ条約で終わった戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36021,7 +36079,8 @@
     "question_text": {
       "en": "Which treaty ended the Russo-Japanese War?",
       "ja": "日露戦争を終結させた条約は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36061,7 +36120,8 @@
     "question_text": {
       "en": "Which treaty ended the Sino-Japanese War of 1894-95?",
       "ja": "日清戦争を終結させた条約は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36224,7 +36284,8 @@
     "question_text": {
       "en": "Which civilization flourished along the Indus river?",
       "ja": "インダス川流域で栄えた文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36273,7 +36334,7 @@
         "en": "Storming of the Bastille",
         "ja": "バスティーユ襲撃",
         "ja_typings": [
-          "basuthi-yuushuugeki"
+          "basuthi-yushuugeki"
         ]
       },
       {
@@ -36305,7 +36366,8 @@
     "question_text": {
       "en": "Which event in 1789 began the French Revolution?",
       "ja": "1789年フランス革命の発端となった事件は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36313,7 +36375,7 @@
         "en": "Battle of Waterloo",
         "ja": "ワーテルローの戦い",
         "ja_typings": [
-          "wa-terurro-notatakai"
+          "wa-teruro-notatakai"
         ]
       },
       {
@@ -36345,7 +36407,8 @@
     "question_text": {
       "en": "Which battle marked Napoleon's final defeat?",
       "ja": "ナポレオンが最終的に敗れた戦いは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36385,7 +36448,8 @@
     "question_text": {
       "en": "Which year did the Berlin Wall fall?",
       "ja": "ベルリンの壁が崩壊した年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36425,7 +36489,8 @@
     "question_text": {
       "en": "Which year did the Meiji era begin?",
       "ja": "明治時代が始まった年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36465,7 +36530,8 @@
     "question_text": {
       "en": "Who was the first shogun of the Kamakura shogunate?",
       "ja": "鎌倉幕府の初代将軍は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36628,7 +36694,8 @@
     "question_text": {
       "en": "What is the most abundant gas in Earth's atmosphere?",
       "ja": "地球大気で最も多い気体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36668,7 +36735,8 @@
     "question_text": {
       "en": "Which gas is most responsible for the greenhouse effect from human activity?",
       "ja": "人類活動由来で温室効果に最も寄与する気体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36708,7 +36776,8 @@
     "question_text": {
       "en": "What planet is known as the Red Planet?",
       "ja": "赤い惑星と呼ばれるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36723,7 +36792,7 @@
         "en": "Uranus",
         "ja": "天王星",
         "ja_typings": [
-          "tennousei"
+          "tennnousei"
         ]
       },
       {
@@ -36748,7 +36817,8 @@
     "question_text": {
       "en": "Which planet has the most prominent ring system?",
       "ja": "最も目立つ環を持つ惑星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36763,7 +36833,7 @@
         "en": "Uranus",
         "ja": "天王星",
         "ja_typings": [
-          "tennousei"
+          "tennnousei"
         ]
       },
       {
@@ -36788,7 +36858,8 @@
     "question_text": {
       "en": "Which planet is farthest from the Sun (excluding Pluto)?",
       "ja": "太陽から最も遠い惑星（冥王星除く）は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36828,7 +36899,8 @@
     "question_text": {
       "en": "What is the powerhouse of the cell?",
       "ja": "細胞のエネルギー工場と呼ばれる小器官は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -36868,7 +36940,8 @@
     "question_text": {
       "en": "Which process do plants use to make food?",
       "ja": "植物が栄養を作る働きは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37072,7 +37145,8 @@
     "question_text": {
       "en": "What law states pressure and volume are inversely related at constant temperature?",
       "ja": "一定温度で圧力と体積が反比例する法則は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37112,7 +37186,8 @@
     "question_text": {
       "en": "What law relates volume and temperature of a gas at constant pressure?",
       "ja": "一定圧力で気体の体積と温度を関係づける法則は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37134,7 +37209,7 @@
         "en": "Salinity",
         "ja": "塩分濃度",
         "ja_typings": [
-          "enbunnoudo"
+          "enbunnnoudo"
         ]
       },
       {
@@ -37152,7 +37227,8 @@
     "question_text": {
       "en": "What does pH measure?",
       "ja": "pHが測定するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37192,7 +37268,8 @@
     "question_text": {
       "en": "What is the hardest natural substance?",
       "ja": "天然で最も硬い物質は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37207,7 +37284,7 @@
         "en": "AB positive",
         "ja": "AB型プラス",
         "ja_typings": [
-          "abugatapurasu"
+          "abgatapurasu"
         ]
       },
       {
@@ -37221,7 +37298,7 @@
         "en": "B negative",
         "ja": "B型マイナス",
         "ja_typings": [
-          "bigatamainasu"
+          "bgatamainasu"
         ]
       }
     ],
@@ -37232,7 +37309,8 @@
     "question_text": {
       "en": "What blood type is the universal donor?",
       "ja": "万能供血者とされる血液型は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37272,7 +37350,8 @@
     "question_text": {
       "en": "Which organ produces insulin?",
       "ja": "インスリンを分泌する臓器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37312,7 +37391,8 @@
     "question_text": {
       "en": "Which bone is the longest in the human body?",
       "ja": "人体で最も長い骨は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37393,7 +37473,8 @@
     "question_text": {
       "en": "What rock type forms from cooled magma?",
       "ja": "マグマが冷えて固まってできる岩石は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -37415,14 +37496,14 @@
         "en": "Beaufort scale",
         "ja": "ビューフォート風力階級",
         "ja_typings": [
-          "byu-fo-rtofuuryokukaikyuu"
+          "byu-fo-tofuuryokukaikyuu"
         ]
       },
       {
         "en": "Kelvin scale",
         "ja": "ケルビン温度",
         "ja_typings": [
-          "kerubinondo"
+          "kerubinnondo"
         ]
       }
     ],
@@ -37433,7 +37514,8 @@
     "question_text": {
       "en": "Which scale measures earthquake magnitude?",
       "ja": "地震のマグニチュードを表す尺度は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38703,7 +38785,8 @@
     "question_text": {
       "en": "Which data structure is best suited for implementing priority queues?",
       "ja": "プライオリティキューに最適なデータ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38841,7 +38924,7 @@
         "en": "Greedy",
         "ja": "貪欲法",
         "ja_typings": [
-          "donyokuhou"
+          "donnyokuhou"
         ]
       },
       {
@@ -38866,7 +38949,8 @@
     "question_text": {
       "en": "Which technique solves problems by combining solutions to subproblems?",
       "ja": "部分問題の解を結合して解くアルゴリズム技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -38888,7 +38972,7 @@
         "en": "Procedural",
         "ja": "手続き型",
         "ja_typings": [
-          "tetsuzukigata"
+          "tetsudukigata"
         ]
       },
       {
@@ -38906,7 +38990,8 @@
     "question_text": {
       "en": "Which paradigm builds programs by composing pure functions?",
       "ja": "純粋関数の合成でプログラムを構成するパラダイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39479,7 +39564,8 @@
     "question_text": {
       "en": "What does ACID stand for in database transactions?",
       "ja": "データベースの ACID 特性のうち独立性を示すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39501,7 +39587,7 @@
         "en": "Procedural",
         "ja": "手続き型",
         "ja_typings": [
-          "tetsuzukigata"
+          "tetsudukigata"
         ]
       },
       {
@@ -39519,7 +39605,8 @@
     "question_text": {
       "en": "Which paradigm focuses on what to compute, not how?",
       "ja": "「何を計算するか」を記述するパラダイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -39559,7 +39646,8 @@
     "question_text": {
       "en": "Which testing approach writes tests before implementation?",
       "ja": "実装前にテストを書く開発手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45585,7 +45673,8 @@
     "question_text": {
       "en": "Which anime features a high school detective shrunk into a child?",
       "ja": "高校生探偵が子供の姿にされるアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45707,7 +45796,8 @@
     "question_text": {
       "en": "Which anime studio produced 'Your Name'?",
       "ja": "『君の名は。』を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45747,7 +45837,8 @@
     "question_text": {
       "en": "Who directed 'Princess Mononoke'?",
       "ja": "『もののけ姫』の監督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45787,7 +45878,8 @@
     "question_text": {
       "en": "Which anime is about a girl who becomes a Soul Reaper?",
       "ja": "死神になる少女が登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45827,7 +45919,8 @@
     "question_text": {
       "en": "Which anime studio made 'Attack on Titan' final seasons?",
       "ja": "『進撃の巨人』最終章を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45867,7 +45960,8 @@
     "question_text": {
       "en": "Which anime features alchemists searching for the Philosopher's Stone?",
       "ja": "賢者の石を探す錬金術師のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45907,7 +46001,8 @@
     "question_text": {
       "en": "Which anime is about volleyball at Karasuno High?",
       "ja": "烏野高校のバレーボールのアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -45997,7 +46092,7 @@
         "en": "Rurouni Kenshin",
         "ja": "るろうに剣心",
         "ja_typings": [
-          "rurouninikenshin"
+          "rurounikenshin"
         ]
       },
       {
@@ -46029,7 +46124,8 @@
     "question_text": {
       "en": "Which anime is about a samurai who wanders Meiji-era Japan?",
       "ja": "明治時代を流浪する侍のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46069,7 +46165,8 @@
     "question_text": {
       "en": "Which director made 'Weathering with You'?",
       "ja": "『天気の子』の監督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46110,7 +46207,8 @@
     "question_text": {
       "en": "Which anime features four siblings playing card games?",
       "ja": "カードゲームをする四姉妹のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46191,7 +46289,8 @@
     "question_text": {
       "en": "Who voices Goku in the Japanese dub of Dragon Ball?",
       "ja": "ドラゴンボールの孫悟空の日本語声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46231,7 +46330,8 @@
     "question_text": {
       "en": "Which anime is about a girl who befriends a fox spirit?",
       "ja": "狐の妖怪と仲良くなる少女のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46246,7 +46346,7 @@
         "en": "Eureka Seven",
         "ja": "交響詩篇エウレカセブン",
         "ja_typings": [
-          "koukyoushiheneurekasebun"
+          "koukyoushihenneurekasebun"
         ]
       },
       {
@@ -46271,7 +46371,8 @@
     "question_text": {
       "en": "Which anime features a giant mecha called Lagann?",
       "ja": "ラガンというロボットが登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46352,7 +46453,8 @@
     "question_text": {
       "en": "Which anime studio produced 'Violet Evergarden'?",
       "ja": "『ヴァイオレット・エヴァーガーデン』を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46433,7 +46535,8 @@
     "question_text": {
       "en": "Which anime features a girl named Mikasa Ackerman?",
       "ja": "ミカサ・アッカーマンが登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46473,7 +46576,8 @@
     "question_text": {
       "en": "Which anime is about gymnastics rhythmic at Hanazono?",
       "ja": "花園を目指す体操のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46513,7 +46617,8 @@
     "question_text": {
       "en": "Which anime features the Akatsuki organization?",
       "ja": "暁という組織が登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46553,7 +46658,8 @@
     "question_text": {
       "en": "Which anime is set in a magical library city called Academy City?",
       "ja": "学園都市が舞台のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46575,7 +46681,7 @@
         "en": "Katekyo Hitman Reborn",
         "ja": "家庭教師ヒットマンリボーン",
         "ja_typings": [
-          "kateikyoushihittomanribo-un"
+          "kateikyoushihittomanribo-n"
         ]
       },
       {
@@ -46593,7 +46699,8 @@
     "question_text": {
       "en": "Which anime features the Phantom Troupe?",
       "ja": "幻影旅団が登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46633,7 +46740,8 @@
     "question_text": {
       "en": "Which anime is about a girl in a magical school for vampires?",
       "ja": "ヴァンパイアの学園が舞台のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46673,7 +46781,8 @@
     "question_text": {
       "en": "Which anime features Lelouch and Geass powers?",
       "ja": "ルルーシュとギアスの力が登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46795,7 +46904,8 @@
     "question_text": {
       "en": "Which anime features a girl who can turn into a wolf?",
       "ja": "狼に変身する少女のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46835,7 +46945,8 @@
     "question_text": {
       "en": "Which anime features a high school baseball team called Nishiura?",
       "ja": "西浦高校野球部のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46875,7 +46986,8 @@
     "question_text": {
       "en": "Which anime features a cooking competition at Totsuki Academy?",
       "ja": "遠月学園の料理対決のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46915,7 +47027,8 @@
     "question_text": {
       "en": "Which anime features a piano prodigy named Kousei?",
       "ja": "公生というピアノの天才が登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46955,7 +47068,8 @@
     "question_text": {
       "en": "Which anime is about a girl who befriends a yokai cat?",
       "ja": "妖怪の猫を友達にする少女のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -46995,7 +47109,8 @@
     "question_text": {
       "en": "Which anime features Tanjiro Kamado?",
       "ja": "竈門炭治郎が主人公のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47035,7 +47150,8 @@
     "question_text": {
       "en": "Which anime features a girl named Holo with wolf ears?",
       "ja": "狼の耳を持つホロが登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47075,7 +47191,8 @@
     "question_text": {
       "en": "Which anime features Saitama, a hero who defeats enemies in one punch?",
       "ja": "一撃で敵を倒すサイタマのアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47115,7 +47232,8 @@
     "question_text": {
       "en": "Which anime is about kart racing in another world with Re:Zero?",
       "ja": "リゼロの主人公の名前は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47155,7 +47273,8 @@
     "question_text": {
       "en": "Which anime features a Quincy named Uryu Ishida?",
       "ja": "石田雨竜というクインシーが登場するアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47195,7 +47314,8 @@
     "question_text": {
       "en": "Which manga is published in Weekly Shonen Sunday?",
       "ja": "週刊少年サンデーで連載されている漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47235,7 +47355,8 @@
     "question_text": {
       "en": "Who is the author of 'Monster' and '20th Century Boys'?",
       "ja": "『モンスター』『20世紀少年』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47275,7 +47396,8 @@
     "question_text": {
       "en": "Which manga magazine publishes 'One Piece'?",
       "ja": "『ONE PIECE』を連載している雑誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47315,7 +47437,8 @@
     "question_text": {
       "en": "Who is the author of 'Vagabond' and 'Slam Dunk'?",
       "ja": "『バガボンド』『スラムダンク』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47355,7 +47478,8 @@
     "question_text": {
       "en": "Which manga features the Joestar family across generations?",
       "ja": "ジョースター家の物語の漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47395,7 +47519,8 @@
     "question_text": {
       "en": "Which manga features chefs competing at Totsuki Academy?",
       "ja": "遠月学園で料理を競う漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47517,7 +47642,8 @@
     "question_text": {
       "en": "Who is the author of 'Vinland Saga'?",
       "ja": "『ヴィンランド・サガ』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47557,7 +47683,8 @@
     "question_text": {
       "en": "Which manga features a maid named Misaki Ayuzawa?",
       "ja": "鮎沢美咲というメイドが登場する漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47597,7 +47724,8 @@
     "question_text": {
       "en": "Which manga is set in the Bakumatsu era with Gintoki?",
       "ja": "幕末を舞台にした銀時の漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47612,7 +47740,7 @@
         "en": "Shueisha",
         "ja": "集英社",
         "ja_typings": [
-          "shueisha"
+          "shuueisha"
         ]
       },
       {
@@ -47637,7 +47765,8 @@
     "question_text": {
       "en": "Which publisher releases 'Attack on Titan'?",
       "ja": "『進撃の巨人』の出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47677,7 +47806,8 @@
     "question_text": {
       "en": "Who is the author of 'Yotsuba&!'?",
       "ja": "『よつばと!』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47717,7 +47847,8 @@
     "question_text": {
       "en": "Which manga features a basketball team called Seirin?",
       "ja": "誠凛高校バスケ部の漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47757,7 +47888,8 @@
     "question_text": {
       "en": "Which manga features the Survey Corps?",
       "ja": "調査兵団が登場する漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47765,7 +47897,7 @@
         "en": "Tokyo Ghoul",
         "ja": "東京喰種",
         "ja_typings": [
-          "toukyouguuru"
+          "toukyougu-ru"
         ]
       },
       {
@@ -47797,7 +47929,8 @@
     "question_text": {
       "en": "Which manga features ghouls in modern Tokyo?",
       "ja": "現代東京の喰種が登場する漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -47960,7 +48093,8 @@
     "question_text": {
       "en": "Which manga features a girl who travels with a wolf merchant?",
       "ja": "狼の商人と旅をする漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48000,7 +48134,8 @@
     "question_text": {
       "en": "Which manga is about a delivery service in a fantasy world?",
       "ja": "異世界の配達サービスが題材の漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48040,7 +48175,8 @@
     "question_text": {
       "en": "Who is the author of 'Inuyasha' and 'Ranma 1/2'?",
       "ja": "『犬夜叉』『らんま1/2』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48080,7 +48216,8 @@
     "question_text": {
       "en": "Which manga features a sushi chef apprentice named Shota?",
       "ja": "翔太という寿司職人見習いの漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48161,7 +48298,8 @@
     "question_text": {
       "en": "Which manga features Senku, a science genius rebuilding civilization?",
       "ja": "千空が文明を再建する科学漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48242,7 +48380,8 @@
     "question_text": {
       "en": "Which game features a silent protagonist named Link?",
       "ja": "リンクという主人公が登場するゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48405,7 +48544,8 @@
     "question_text": {
       "en": "Which game features the city of Yharnam?",
       "ja": "ヤーナムが舞台のゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48445,7 +48585,8 @@
     "question_text": {
       "en": "Which game features a samurai named Wolf in Sengoku Japan?",
       "ja": "戦国時代の隻腕の狼が主人公のゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48485,7 +48626,8 @@
     "question_text": {
       "en": "Which company developed 'Splatoon'?",
       "ja": "『スプラトゥーン』を開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48648,7 +48790,8 @@
     "question_text": {
       "en": "Which game features Kazuma Kiryu as the dragon of Dojima?",
       "ja": "堂島の龍・桐生一馬が主人公のゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48688,7 +48831,8 @@
     "question_text": {
       "en": "Which game genre is 'Stardew Valley'?",
       "ja": "『スターデュー・バレー』のジャンルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48728,7 +48872,8 @@
     "question_text": {
       "en": "Which game features the world of Hyrule?",
       "ja": "ハイラルが舞台のゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48850,7 +48995,8 @@
     "question_text": {
       "en": "Which game features Ryu and his Hadouken?",
       "ja": "リュウと波動拳が登場するゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -48890,7 +49036,8 @@
     "question_text": {
       "en": "Which game series features the Mishima family rivalry?",
       "ja": "三島家の確執が描かれる格闘ゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49094,7 +49241,8 @@
     "question_text": {
       "en": "Which game genre is 'Civilization'?",
       "ja": "『シヴィライゼーション』のジャンルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49257,7 +49405,8 @@
     "question_text": {
       "en": "Which game series features survival in a haunted town?",
       "ja": "幽霊の町でのサバイバルゲームシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49338,7 +49487,8 @@
     "question_text": {
       "en": "Which game features a janitor turned hero named Isaac in Dead Space?",
       "ja": "デッドスペースの主人公アイザックの職業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -49838,7 +49988,7 @@
         "en": "? operator",
         "ja": "クエスチョン演算子",
         "ja_typings": [
-          "kuesuchonenzanshi"
+          "kuesuchonnenzanshi"
         ]
       },
       {
@@ -49870,7 +50020,8 @@
     "question_text": {
       "en": "What is Rust's zero-cost abstraction for fallible operations?",
       "ja": "失敗しうる操作のための Rust のゼロコスト抽象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50812,7 +50963,8 @@
     "question_text": {
       "en": "Which data structure is best for LRU cache implementation?",
       "ja": "LRU キャッシュ実装に最適なデータ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -50975,7 +51127,8 @@
     "question_text": {
       "en": "Which data structure supports efficient prefix search of strings?",
       "ja": "文字列の効率的な前方一致検索を支援するデータ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51015,7 +51168,8 @@
     "question_text": {
       "en": "What is the technique to amortize the cost of dynamic array resizing?",
       "ja": "動的配列リサイズコストを償却する手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51055,7 +51209,8 @@
     "question_text": {
       "en": "Which structure provides O(1) amortized push and pop from both ends?",
       "ja": "両端からの償却 O(1) push/pop を提供する構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51177,7 +51332,8 @@
     "question_text": {
       "en": "What GC technique segregates objects by age?",
       "ja": "オブジェクトを年齢で分離する GC 技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51463,7 +51619,8 @@
     "question_text": {
       "en": "Which functional concept transforms a multi-arg function into chained single-arg functions?",
       "ja": "多引数関数を連鎖した単一引数関数に変換する関数型概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51749,7 +51906,8 @@
     "question_text": {
       "en": "What is the term for a function that calls itself?",
       "ja": "自分自身を呼び出す関数の用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51871,7 +52029,8 @@
     "question_text": {
       "en": "Which technique inlines small functions at call sites?",
       "ja": "呼び出し箇所に小さな関数を展開する技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -51993,7 +52152,8 @@
     "question_text": {
       "en": "What is the term for converting an object into a byte stream?",
       "ja": "オブジェクトをバイト列に変換することを指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -53632,7 +53792,8 @@
     "question_text": {
       "en": "What security mechanism uses a nonce in CSP?",
       "ja": "CSP で nonce を使うセキュリティ機構は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54533,7 +54694,8 @@
     "question_text": {
       "en": "Which 1988 Studio Ghibli film features two sisters and a cat bus?",
       "ja": "1988年公開で姉妹と猫バスが登場するジブリ作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54573,7 +54735,8 @@
     "question_text": {
       "en": "Which 1995 Ghibli film centers on Shizuku writing a novel?",
       "ja": "雫が小説を書く1995年のジブリ作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54588,7 +54751,8 @@
         "en": "Galaxy Express 999",
         "ja": "銀河鉄道999",
         "ja_typings": [
-          "gingatetsudousurii"
+          "gingatetsudousuri-nain",
+          "gingatetsudou999"
         ]
       },
       {
@@ -54613,7 +54777,8 @@
     "question_text": {
       "en": "Which 1979 anime features Captain Harlock as the protagonist?",
       "ja": "ハーロック船長が主人公の1979年アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54628,7 +54793,8 @@
         "en": "Galaxy Express 999",
         "ja": "銀河鉄道999",
         "ja_typings": [
-          "gingatetsudousurii"
+          "gingatetsudousuri-nain",
+          "gingatetsudou999"
         ]
       },
       {
@@ -54653,7 +54819,8 @@
     "question_text": {
       "en": "Which 1974 anime depicts a journey to recover the Cosmo DNA?",
       "ja": "コスモクリーナーDを取りに行く1974年のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54693,7 +54860,8 @@
     "question_text": {
       "en": "Which 1982 mecha anime features Hikaru, Misa, and Minmay?",
       "ja": "輝・未沙・ミンメイが登場する1982年のメカアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54733,7 +54901,8 @@
     "question_text": {
       "en": "Which 1983 anime is set in the world of Byston Well?",
       "ja": "バイストン・ウェルが舞台の1983年のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54773,7 +54942,8 @@
     "question_text": {
       "en": "Which 1988 OVA film by Mamoru Oshii features a sentient airliner?",
       "ja": "意思を持つ旅客機が登場する1988年押井守監督のOVAは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54813,7 +54983,8 @@
     "question_text": {
       "en": "Which 1985 Ghibli film follows Pazu and Sheeta?",
       "ja": "パズーとシータが登場する1985年のジブリ作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54853,7 +55024,8 @@
     "question_text": {
       "en": "Which 1984 Ghibli-precursor film features Ohmu and toxic jungles?",
       "ja": "オームと腐海が登場する1984年の作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54893,7 +55065,8 @@
     "question_text": {
       "en": "Which 1987 Gainax film follows Shirotsugh joining a space program?",
       "ja": "シロツグが宇宙軍に入隊する1987年のガイナックス作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54933,7 +55106,8 @@
     "question_text": {
       "en": "Which 1988 OVA features Noriko piloting RX-7?",
       "ja": "ノリコがRX-7に乗る1988年のOVAは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -54973,7 +55147,8 @@
     "question_text": {
       "en": "Which 1990 NHK anime follows Jean and Nadia searching for Atlantis?",
       "ja": "ジャンとナディアがアトランティスを探す1990年のNHKアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55013,7 +55188,8 @@
     "question_text": {
       "en": "Which 1978 Miyazaki TV series follows Conan after a global cataclysm?",
       "ja": "大災害後の世界を描く1978年宮崎駿監督のTVシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55053,7 +55229,8 @@
     "question_text": {
       "en": "Which 1992 anime is about a girl boxing kickboxer named Hibiki?",
       "ja": "響子が主人公の1992年のキックボクシングアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55093,7 +55270,8 @@
     "question_text": {
       "en": "Which 2022 anime features Bojji, a deaf prince?",
       "ja": "耳の聞こえない王子ボッジが主人公の2022年アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55133,7 +55311,8 @@
     "question_text": {
       "en": "Which 2021 anime by Naoko Yamada retells a classical war chronicle?",
       "ja": "山田尚子監督による2021年の古典戦記アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55173,7 +55352,8 @@
     "question_text": {
       "en": "Which 2021 anime features a talking cat solving crimes in Tokyo?",
       "ja": "東京で事件を解決する話す猫が登場する2021年のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55335,7 +55515,8 @@
     "question_text": {
       "en": "Which 2023 anime follows a country girl Mitsumi adjusting to Tokyo high school?",
       "ja": "上京した田舎の少女みつみが主人公の2023年のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55375,7 +55556,8 @@
     "question_text": {
       "en": "Which 2023 anime depicts Maru and Kiruko traveling post-apocalyptic Japan?",
       "ja": "マルとキルコがポストアポカリプスの日本を旅する2023年アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55456,7 +55638,8 @@
     "question_text": {
       "en": "Which 2018 Mamoru Hosoda film is about a boy meeting his future sister?",
       "ja": "未来の妹に出会う少年を描く2018年細田守監督の映画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55496,7 +55679,8 @@
     "question_text": {
       "en": "Which 2021 Hosoda film features a VR singer with a dragon?",
       "ja": "竜とVR世界の歌姫を描く2021年の細田守監督作は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55536,7 +55720,8 @@
     "question_text": {
       "en": "Which 2022 film by Mari Okada features a hidden village of red eyes?",
       "ja": "岡田麿里監督による2022年の赤い瞳の村を描く映画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55576,7 +55761,8 @@
     "question_text": {
       "en": "Which 2006 Kon Satoshi film is about a dream-invading device?",
       "ja": "夢に入る装置を描く2006年今敏監督の映画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55616,7 +55802,8 @@
     "question_text": {
       "en": "Which 2001 Kon Satoshi film blends an actress's memories with film history?",
       "ja": "女優の記憶と映画史を交錯させる2001年今敏監督作は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55656,7 +55843,8 @@
     "question_text": {
       "en": "Which 1997 Satoshi Kon film follows a pop idol turned actress?",
       "ja": "アイドルから女優に転身した少女を描く1997年今敏監督作は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55778,7 +55966,8 @@
     "question_text": {
       "en": "Which studio produced Violet Evergarden?",
       "ja": "ヴァイオレット・エヴァーガーデンを制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55818,7 +56007,8 @@
     "question_text": {
       "en": "Which studio is known for Hanasaku Iroha and Shirobako?",
       "ja": "花咲くいろは・SHIROBAKOで知られるスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55899,7 +56089,8 @@
     "question_text": {
       "en": "Who voices Lelouch vi Britannia?",
       "ja": "ルルーシュ・ヴィ・ブリタニアの声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55939,7 +56130,8 @@
     "question_text": {
       "en": "Who voices Holo in Spice and Wolf?",
       "ja": "狼と香辛料のホロの声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -55979,7 +56171,8 @@
     "question_text": {
       "en": "Which director made Cowboy Bebop?",
       "ja": "カウボーイビバップの監督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56019,7 +56212,8 @@
     "question_text": {
       "en": "Which director helmed Samurai Champloo?",
       "ja": "サムライチャンプルーの監督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56059,7 +56253,8 @@
     "question_text": {
       "en": "Which director made Mind Game and Devilman Crybaby?",
       "ja": "マインド・ゲームとDEVILMAN crybabyの監督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56222,7 +56417,8 @@
     "question_text": {
       "en": "Which 1995 anime features Kenshin Himura?",
       "ja": "緋村剣心が主人公の1995年のアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56262,7 +56458,8 @@
     "question_text": {
       "en": "Which 1992 anime by Rumiko Takahashi features a half-demon dog hero?",
       "ja": "高橋留美子原作、半妖の少年が主人公の長編アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56302,7 +56499,8 @@
     "question_text": {
       "en": "Which 1989 anime by Rumiko Takahashi is set in Ikkoku-kan apartment?",
       "ja": "一刻館を舞台にした1989年の高橋留美子原作アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56342,7 +56540,8 @@
     "question_text": {
       "en": "Who created Cyborg 009 and Kamen Rider?",
       "ja": "サイボーグ009と仮面ライダーの原作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56382,7 +56581,8 @@
     "question_text": {
       "en": "Who created Mazinger Z and Devilman?",
       "ja": "マジンガーZとデビルマンの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56422,7 +56622,8 @@
     "question_text": {
       "en": "Who created Tetsujin 28-go?",
       "ja": "鉄人28号の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56462,7 +56663,8 @@
     "question_text": {
       "en": "Who wrote Phoenix (Hi no Tori)?",
       "ja": "火の鳥の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56477,7 +56679,7 @@
         "en": "Asao Takamori",
         "ja": "高森朝雄",
         "ja_typings": [
-          "takamorisaoo"
+          "takamoriasao"
         ]
       },
       {
@@ -56502,7 +56704,8 @@
     "question_text": {
       "en": "Who created Tomorrow's Joe?",
       "ja": "あしたのジョーの作画担当は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56542,7 +56745,8 @@
     "question_text": {
       "en": "Who is the author of Touch and Cross Game?",
       "ja": "タッチとクロスゲームの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56582,7 +56786,8 @@
     "question_text": {
       "en": "Who created Captain Tsubasa?",
       "ja": "キャプテン翼の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56622,7 +56827,8 @@
     "question_text": {
       "en": "Who created Galaxy Express 999?",
       "ja": "銀河鉄道999の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56662,7 +56868,8 @@
     "question_text": {
       "en": "Which magazine serialized Touch and H2?",
       "ja": "タッチとH2が連載された雑誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56702,7 +56909,8 @@
     "question_text": {
       "en": "Which magazine serialized Tomorrow's Joe?",
       "ja": "あしたのジョーが連載された雑誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56742,7 +56950,8 @@
     "question_text": {
       "en": "Which publisher releases Shonen Jump?",
       "ja": "週刊少年ジャンプの出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56782,7 +56991,8 @@
     "question_text": {
       "en": "Which publisher releases Shonen Magazine?",
       "ja": "週刊少年マガジンの出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56822,7 +57032,8 @@
     "question_text": {
       "en": "Which publisher releases Shonen Sunday?",
       "ja": "週刊少年サンデーの出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56862,7 +57073,8 @@
     "question_text": {
       "en": "Which publisher releases Shonen Champion?",
       "ja": "週刊少年チャンピオンの出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56902,7 +57114,8 @@
     "question_text": {
       "en": "Who created Astro Boy?",
       "ja": "鉄腕アトムの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56942,7 +57155,8 @@
     "question_text": {
       "en": "Who created Black Jack?",
       "ja": "ブラック・ジャックの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -56982,7 +57196,8 @@
     "question_text": {
       "en": "Who created The Rose of Versailles?",
       "ja": "ベルサイユのばらの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57022,7 +57237,8 @@
     "question_text": {
       "en": "Who created The Heart of Thomas?",
       "ja": "トーマの心臓の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57062,7 +57278,8 @@
     "question_text": {
       "en": "Who is the author of Vagabond and Real?",
       "ja": "バガボンドとREALの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57102,7 +57319,8 @@
     "question_text": {
       "en": "Who wrote Pluto and Billy Bat?",
       "ja": "PLUTOとBILLY BATの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57142,7 +57360,8 @@
     "question_text": {
       "en": "Who created Parasyte (Kiseiju)?",
       "ja": "寄生獣の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57182,7 +57401,8 @@
     "question_text": {
       "en": "Who created the manga GTO?",
       "ja": "GTOの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57222,7 +57442,8 @@
     "question_text": {
       "en": "Who created City Hunter?",
       "ja": "シティーハンターの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57262,7 +57483,8 @@
     "question_text": {
       "en": "Who created Crows and Worst?",
       "ja": "クローズとWORSTの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57302,7 +57524,8 @@
     "question_text": {
       "en": "Who created Initial D?",
       "ja": "頭文字Dの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57342,7 +57565,8 @@
     "question_text": {
       "en": "Who created Glass Mask (Garasu no Kamen)?",
       "ja": "ガラスの仮面の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57382,7 +57606,8 @@
     "question_text": {
       "en": "Who created Nodame Cantabile?",
       "ja": "のだめカンタービレの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57422,7 +57647,8 @@
     "question_text": {
       "en": "Who created NANA?",
       "ja": "NANAの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57462,7 +57688,8 @@
     "question_text": {
       "en": "Who created Honey and Clover?",
       "ja": "ハチミツとクローバーの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57502,7 +57729,8 @@
     "question_text": {
       "en": "Who created March Comes in Like a Lion (3-gatsu no Lion)?",
       "ja": "3月のライオンの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57542,7 +57770,8 @@
     "question_text": {
       "en": "Who created Princess Jellyfish (Kuragehime)?",
       "ja": "海月姫の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57582,7 +57811,8 @@
     "question_text": {
       "en": "Who created Yotsuba&!?",
       "ja": "よつばと!の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57622,7 +57852,8 @@
     "question_text": {
       "en": "Who created Oyasumi Punpun?",
       "ja": "おやすみプンプンの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57662,7 +57893,8 @@
     "question_text": {
       "en": "Who created Sunny and Number 5?",
       "ja": "Sunnyとナンバーファイブの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57702,7 +57934,8 @@
     "question_text": {
       "en": "Who created The Walking Man (Aruku Hito)?",
       "ja": "歩くひとの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57742,7 +57975,8 @@
     "question_text": {
       "en": "Who created Children of the Sea (Kaijuu no Kodomo)?",
       "ja": "海獣の子供の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57782,7 +58016,8 @@
     "question_text": {
       "en": "Who is the author of Made in Abyss?",
       "ja": "メイドインアビスの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57822,7 +58057,8 @@
     "question_text": {
       "en": "Who created Tokyo Ghoul?",
       "ja": "東京喰種の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57862,7 +58098,8 @@
     "question_text": {
       "en": "Which magazine serialized Berserk?",
       "ja": "ベルセルクが連載された雑誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57902,7 +58139,8 @@
     "question_text": {
       "en": "Which magazine serialized Vinland Saga?",
       "ja": "ヴィンランド・サガが連載されている雑誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -57942,7 +58180,8 @@
     "question_text": {
       "en": "Which company developed the Yakuza/Like a Dragon series?",
       "ja": "龍が如く/ライクアドラゴンを開発した会社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58351,7 +58590,8 @@
     "question_text": {
       "en": "Who is the silent protagonist of Persona 4?",
       "ja": "ペルソナ4の主人公の通称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58391,7 +58631,8 @@
     "question_text": {
       "en": "Which game features the protagonist Kazuma Kiryu?",
       "ja": "桐生一馬が主人公のシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58431,7 +58672,8 @@
     "question_text": {
       "en": "Which game features Ichiban Kasuga as protagonist?",
       "ja": "春日一番が主人公のゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58594,7 +58836,8 @@
     "question_text": {
       "en": "Which Konami series features Solid Snake?",
       "ja": "ソリッド・スネークが主人公のコナミシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58634,7 +58877,8 @@
     "question_text": {
       "en": "Which Konami series is known as Akumajo Dracula in Japan?",
       "ja": "日本で「悪魔城ドラキュラ」と呼ばれるコナミシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58674,7 +58918,8 @@
     "question_text": {
       "en": "Which Konami shooter features a Vic Viper spaceship?",
       "ja": "ビックバイパーが主人公機のコナミシューティングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58714,7 +58959,8 @@
     "question_text": {
       "en": "Which game series features the SaGa Frontier?",
       "ja": "サガフロンティアが属するシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58754,7 +59000,8 @@
     "question_text": {
       "en": "Which 1993 SNES action RPG features the Mana Tree?",
       "ja": "1993年のスーファミでマナの樹が登場するアクションRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58794,7 +59041,8 @@
     "question_text": {
       "en": "Which 1995 SNES action RPG by Quintet is set on a rebuilding Earth?",
       "ja": "1995年クインテット制作で地球再生がテーマのスーファミ作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58834,7 +59082,8 @@
     "question_text": {
       "en": "Which 1986 Capcom platformer features the Red Falcon enemies?",
       "ja": "1986年カプコンの横スクロール作品でレッドファルコンが登場する作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58915,7 +59164,8 @@
     "question_text": {
       "en": "Which SNK series features Terry Bogard?",
       "ja": "テリー・ボガードが登場するSNKシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58955,7 +59205,8 @@
     "question_text": {
       "en": "Which SNK series features Ryo Sakazaki?",
       "ja": "坂崎良が主人公のSNKシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -58995,7 +59246,8 @@
     "question_text": {
       "en": "Which SNK series features Haohmaru?",
       "ja": "覇王丸が主人公のSNKシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59035,7 +59287,8 @@
     "question_text": {
       "en": "Which 1996 SNK fighter introduced team battle with Kyo Kusanagi?",
       "ja": "草薙京が登場し、チーム制を導入した1996年のSNK格闘は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59731,7 +59984,8 @@
     "question_text": {
       "en": "Which country has Bangkok as its capital?",
       "ja": "バンコクを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59771,7 +60025,8 @@
     "question_text": {
       "en": "Which country has Kuala Lumpur as its capital?",
       "ja": "クアラルンプールを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -59893,7 +60148,8 @@
     "question_text": {
       "en": "Which country has Riyadh as its capital?",
       "ja": "リヤドを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60056,7 +60312,8 @@
     "question_text": {
       "en": "Which country has Havana as its capital?",
       "ja": "ハバナを首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60096,7 +60353,8 @@
     "question_text": {
       "en": "Which is the longest river in Europe?",
       "ja": "ヨーロッパで最も長い川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60136,7 +60394,8 @@
     "question_text": {
       "en": "Which is the longest river in North America?",
       "ja": "北米で最も長い川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60177,7 +60436,8 @@
     "question_text": {
       "en": "Which is the longest river in China?",
       "ja": "中国で最も長い川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60217,7 +60477,8 @@
     "question_text": {
       "en": "Which mountain range runs through Italy?",
       "ja": "イタリアを縦断する山脈は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60257,7 +60518,8 @@
     "question_text": {
       "en": "Which is the largest desert on Earth?",
       "ja": "地球で最も広い砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60297,7 +60559,8 @@
     "question_text": {
       "en": "Which desert is in Mongolia and China?",
       "ja": "モンゴルと中国にまたがる砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60338,7 +60601,8 @@
     "question_text": {
       "en": "Which is the largest lake in Africa?",
       "ja": "アフリカで最大の湖は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60378,7 +60642,8 @@
     "question_text": {
       "en": "Which peninsula is located in southern Europe and shaped like a boot?",
       "ja": "ブーツ型の南欧の半島は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60418,7 +60683,8 @@
     "question_text": {
       "en": "Which peninsula contains Spain and Portugal?",
       "ja": "スペインとポルトガルがある半島は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60458,7 +60724,8 @@
     "question_text": {
       "en": "Which is the largest island in the Mediterranean?",
       "ja": "地中海最大の島は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60498,7 +60765,8 @@
     "question_text": {
       "en": "Which is the smallest continent?",
       "ja": "最も小さい大陸は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60538,7 +60806,8 @@
     "question_text": {
       "en": "Which sea lies between Europe and Africa?",
       "ja": "ヨーロッパとアフリカの間にある海は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60578,7 +60847,8 @@
     "question_text": {
       "en": "Which is the largest country by area in South America?",
       "ja": "南米で面積最大の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60659,7 +60929,8 @@
     "question_text": {
       "en": "Which country is known as the Land of the Rising Sun?",
       "ja": "「日出ずる国」と呼ばれる国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60699,7 +60970,8 @@
     "question_text": {
       "en": "Which country is shaped like a long thin strip on the west of South America?",
       "ja": "南米西岸で細長い形の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60739,7 +61011,8 @@
     "question_text": {
       "en": "Which country surrounds the Vatican City?",
       "ja": "バチカン市国を囲む国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60761,7 +61034,7 @@
         "en": "Wu Zetian",
         "ja": "武則天",
         "ja_typings": [
-          "sokuten"
+          "busokuten"
         ]
       },
       {
@@ -60779,7 +61052,8 @@
     "question_text": {
       "en": "Who was the first Emperor of unified China?",
       "ja": "中国を初めて統一した皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -60860,7 +61134,8 @@
     "question_text": {
       "en": "Who unified Germany in 1871?",
       "ja": "1871年にドイツを統一した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61155,7 +61430,7 @@
         "en": "Ivan IV",
         "ja": "イヴァン四世",
         "ja_typings": [
-          "ivanyonsei"
+          "ivannyonsei"
         ]
       },
       {
@@ -61187,7 +61462,8 @@
     "question_text": {
       "en": "Who was the first Tsar of Russia?",
       "ja": "ロシア最初のツァーリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61227,7 +61503,8 @@
     "question_text": {
       "en": "Who modernized Russia in the early 18th century?",
       "ja": "18世紀初頭にロシアを近代化した皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61267,7 +61544,8 @@
     "question_text": {
       "en": "Who was Queen of England during the Spanish Armada defeat?",
       "ja": "スペイン無敵艦隊撃退時の英女王は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61430,7 +61708,8 @@
     "question_text": {
       "en": "Which dynasty built most of the Great Wall as seen today?",
       "ja": "現在の万里の長城を主に築いた王朝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61470,7 +61749,8 @@
     "question_text": {
       "en": "Which dynasty ruled China just before the Qing?",
       "ja": "清の直前に中国を統治した王朝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61510,7 +61790,8 @@
     "question_text": {
       "en": "Which Japanese era came after Meiji?",
       "ja": "明治の次の時代は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61550,7 +61831,8 @@
     "question_text": {
       "en": "Which Japanese era came after Taisho?",
       "ja": "大正の次の時代は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61579,7 +61861,7 @@
         "en": "Treaty of Brest-Litovsk",
         "ja": "ブレスト・リトフスク条約",
         "ja_typings": [
-          "buresutoritofusukujouyaku"
+          "buresuto/ritofusukujouyaku"
         ]
       }
     ],
@@ -61590,7 +61872,8 @@
     "question_text": {
       "en": "Which treaty ended World War I?",
       "ja": "第一次大戦を終結させた条約は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61630,7 +61913,8 @@
     "question_text": {
       "en": "Which war was fought between 1950 and 1953 on the Korean peninsula?",
       "ja": "1950-1953年に朝鮮半島で起きた戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61670,7 +61954,8 @@
     "question_text": {
       "en": "Which war was fought between US-led forces and Iraq in 1991?",
       "ja": "1991年の米国主導とイラクの戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61710,7 +61995,8 @@
     "question_text": {
       "en": "In which year did the Soviet Union dissolve?",
       "ja": "ソ連が崩壊した年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61750,7 +62036,8 @@
     "question_text": {
       "en": "In which year did Columbus reach the Americas?",
       "ja": "コロンブスが新大陸に到達した年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61790,7 +62077,8 @@
     "question_text": {
       "en": "Which civilization is credited with inventing cuneiform writing?",
       "ja": "楔形文字を発明したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61830,7 +62118,8 @@
     "question_text": {
       "en": "Which ancient empire was led by Cyrus the Great?",
       "ja": "キュロス大王が築いた古代帝国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61871,7 +62160,8 @@
     "question_text": {
       "en": "Which empire fell in 1453 with the fall of Constantinople?",
       "ja": "1453年に滅亡した帝国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -61912,7 +62202,8 @@
     "question_text": {
       "en": "Which empire captured Constantinople in 1453?",
       "ja": "1453年にコンスタンティノープルを陥落させたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62157,7 +62448,8 @@
     "question_text": {
       "en": "Which French king was beheaded during the French Revolution?",
       "ja": "フランス革命で処刑されたフランス王は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62197,7 +62489,8 @@
     "question_text": {
       "en": "Which French king was called the Sun King?",
       "ja": "「太陽王」と呼ばれたフランス王は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62278,7 +62571,8 @@
     "question_text": {
       "en": "Which queen ruled both England and Scotland from 1702?",
       "ja": "1702年から英国とスコットランドを統治した女王は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62318,7 +62612,8 @@
     "question_text": {
       "en": "Which Japanese general led the attack on Pearl Harbor planning?",
       "ja": "真珠湾攻撃を立案した日本の提督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62358,7 +62653,8 @@
     "question_text": {
       "en": "Which conflict was triggered by the assassination of Archduke Franz Ferdinand?",
       "ja": "フランツ・フェルディナント大公暗殺が引き金となった戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62439,7 +62735,8 @@
     "question_text": {
       "en": "Which gas makes up about 78% of Earth's atmosphere?",
       "ja": "地球の大気の約78%を占める気体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62479,7 +62776,8 @@
     "question_text": {
       "en": "Which gas is most responsible for global warming from human activity?",
       "ja": "人為的温暖化の主因となる気体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62535,7 +62833,7 @@
         "en": "Uranus",
         "ja": "天王星",
         "ja_typings": [
-          "tennousei"
+          "tennnousei"
         ]
       },
       {
@@ -62560,7 +62858,8 @@
     "question_text": {
       "en": "Which planet has the most moons?",
       "ja": "最も多くの衛星を持つ惑星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62600,7 +62899,8 @@
     "question_text": {
       "en": "Which planet has the Great Red Spot?",
       "ja": "大赤斑がある惑星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62640,7 +62940,8 @@
     "question_text": {
       "en": "Which planet is known as the Red Planet?",
       "ja": "「赤い惑星」と呼ばれるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -62655,7 +62956,7 @@
         "en": "Uranus",
         "ja": "天王星",
         "ja_typings": [
-          "tennousei"
+          "tennnousei"
         ]
       },
       {
@@ -62680,7 +62981,8 @@
     "question_text": {
       "en": "Which planet is the farthest from the Sun (recognized as a planet)?",
       "ja": "太陽系で最遠の惑星(認定されたもの)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63499,7 +63801,8 @@
     "question_text": {
       "en": "What is the largest organ of the human body?",
       "ja": "人体最大の臓器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63539,7 +63842,8 @@
     "question_text": {
       "en": "Which blood cells carry oxygen?",
       "ja": "酸素を運ぶ血球は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63579,7 +63883,8 @@
     "question_text": {
       "en": "Which scale measures mineral hardness?",
       "ja": "鉱物硬度の尺度は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63619,7 +63924,8 @@
     "question_text": {
       "en": "Which phenomenon causes the bending of light passing through different media?",
       "ja": "媒質間で光が曲がる現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63700,7 +64006,8 @@
     "question_text": {
       "en": "Which conjecture concerns prime gaps of 2?",
       "ja": "素数の差が2となる予想はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63742,7 +64049,8 @@
     "question_text": {
       "en": "Which structure has both addition and multiplication?",
       "ja": "加法と乗法を両方持つ代数構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63782,7 +64090,8 @@
     "question_text": {
       "en": "What is a manifold locally homeomorphic to?",
       "ja": "多様体は局所的に何と同相?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63822,7 +64131,8 @@
     "question_text": {
       "en": "Which number system extends complex numbers to 4D?",
       "ja": "複素数を4次元に拡張した数体系は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63862,7 +64172,8 @@
     "question_text": {
       "en": "Which theorem relates Euler characteristic to genus?",
       "ja": "オイラー標数と種数を結ぶ定理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63902,7 +64213,8 @@
     "question_text": {
       "en": "Which problem asks if P equals NP?",
       "ja": "PとNPが等しいかを問う問題は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63942,7 +64254,8 @@
     "question_text": {
       "en": "What is a non-trivial example of a fractal dimension?",
       "ja": "非自明なフラクタル次元の例は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -63964,7 +64277,7 @@
         "en": "MST",
         "ja": "最小全域木問題",
         "ja_typings": [
-          "saishouzennnikimondai"
+          "saishouzennikimondai"
         ]
       },
       {
@@ -63982,7 +64295,8 @@
     "question_text": {
       "en": "Which graph problem is NP-complete?",
       "ja": "NP完全のグラフ問題は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64063,7 +64377,8 @@
     "question_text": {
       "en": "Which set is uncountable?",
       "ja": "非可算集合はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64103,7 +64418,8 @@
     "question_text": {
       "en": "Which group describes symmetries of a tetrahedron?",
       "ja": "正四面体の対称群は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64118,7 +64434,7 @@
         "en": "metric spaces only",
         "ja": "距離空間のみ",
         "ja_typings": [
-          "kyorikuukannnomi"
+          "kyorikuukannomi"
         ]
       },
       {
@@ -64143,7 +64459,8 @@
     "question_text": {
       "en": "What is the formal definition of a continuous map between?",
       "ja": "連続写像が定義される対象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64183,7 +64500,8 @@
     "question_text": {
       "en": "Which constant appears in the prime number theorem?",
       "ja": "素数定理に現れる関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64223,7 +64541,8 @@
     "question_text": {
       "en": "Which structure is used in elliptic curve cryptography?",
       "ja": "楕円曲線暗号で用いる構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64263,7 +64582,8 @@
     "question_text": {
       "en": "What is a key concept in category theory?",
       "ja": "圏論の中心概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64285,7 +64605,7 @@
         "en": "Jensen",
         "ja": "イェンセンの不等式",
         "ja_typings": [
-          "iensennnofutoushiki"
+          "iensennofutoushiki"
         ]
       },
       {
@@ -64303,7 +64623,8 @@
     "question_text": {
       "en": "Which inequality bounds variance and expectation?",
       "ja": "分散と期待値を結ぶ不等式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64343,7 +64664,8 @@
     "question_text": {
       "en": "Which distribution describes rare events?",
       "ja": "稀な事象を表す分布は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64383,7 +64705,8 @@
     "question_text": {
       "en": "Which lemma is essential in homological algebra?",
       "ja": "ホモロジー代数で重要な補題は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64423,7 +64746,8 @@
     "question_text": {
       "en": "What is a Mobius strip an example of?",
       "ja": "メビウスの帯は何の例?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64463,7 +64787,8 @@
     "question_text": {
       "en": "Which equation governs heat diffusion?",
       "ja": "熱拡散を表す方程式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64503,7 +64828,8 @@
     "question_text": {
       "en": "Which method numerically solves ODEs?",
       "ja": "常微分方程式の数値解法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64543,7 +64869,8 @@
     "question_text": {
       "en": "What problem is associated with the Konigsberg bridges?",
       "ja": "ケーニヒスベルクの橋に関する問題は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64583,7 +64910,8 @@
     "question_text": {
       "en": "Which transform converts time to frequency domain?",
       "ja": "時間領域を周波数領域に変換する手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64623,7 +64951,8 @@
     "question_text": {
       "en": "Which space is complete and inner-product?",
       "ja": "完備かつ内積を持つ空間は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64663,7 +64992,8 @@
     "question_text": {
       "en": "Which Millennium Prize problem was solved?",
       "ja": "ミレニアム懸賞問題で解決済みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64703,7 +65033,8 @@
     "question_text": {
       "en": "Which sequence is used in cryptographic hashing?",
       "ja": "暗号ハッシュの基礎となる数列は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64743,7 +65074,8 @@
     "question_text": {
       "en": "Which game theory concept is a stable strategy?",
       "ja": "ゲーム理論で安定戦略を示す概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64783,7 +65115,8 @@
     "question_text": {
       "en": "Which curve is defined by y squared equals x cubed plus ax plus b?",
       "ja": "y² = x³+ax+b で定義される曲線は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64864,7 +65197,8 @@
     "question_text": {
       "en": "What does the four-character idiom 'isseki nichou' mean?",
       "ja": "四字熟語『一石二鳥』の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64904,7 +65238,8 @@
     "question_text": {
       "en": "Which constellation contains Betelgeuse?",
       "ja": "ベテルギウスを含む星座は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -64985,7 +65320,8 @@
     "question_text": {
       "en": "What does the idiom 'neko no te mo karitai' express?",
       "ja": "『猫の手も借りたい』が表す状況は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65025,7 +65361,8 @@
     "question_text": {
       "en": "Which family crest depicts three hollyhock leaves?",
       "ja": "三つ葉葵を描く家紋を使った家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65106,7 +65443,8 @@
     "question_text": {
       "en": "Which zodiac sign is represented by scales?",
       "ja": "天秤で表される星座は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65135,7 +65473,7 @@
         "en": "Naval Astronautics Society Association",
         "ja": "海軍宇宙協会",
         "ja_typings": [
-          "kaiguniuchuukyoukai"
+          "kaigunnuchuukyoukai"
         ]
       }
     ],
@@ -65146,7 +65484,8 @@
     "question_text": {
       "en": "What does NASA stand for?",
       "ja": "NASAは何の略?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65186,7 +65525,8 @@
     "question_text": {
       "en": "Which idiom means inseparable friends?",
       "ja": "切っても切れない友を意味するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65267,7 +65607,8 @@
     "question_text": {
       "en": "What does ISBN identify?",
       "ja": "ISBNが識別するものは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65307,7 +65648,8 @@
     "question_text": {
       "en": "Which constellation contains the North Star?",
       "ja": "北極星を含む星座は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65347,7 +65689,8 @@
     "question_text": {
       "en": "What does 'gashin shoutan' mean?",
       "ja": "『臥薪嘗胆』の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65469,7 +65812,8 @@
     "question_text": {
       "en": "Which idiom describes a perfect match?",
       "ja": "完璧な組合せを表す四字熟語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65509,7 +65853,8 @@
     "question_text": {
       "en": "What does the word 'tsundoku' describe?",
       "ja": "『積ん読』が表すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65590,7 +65935,8 @@
     "question_text": {
       "en": "What does 'wabi sabi' express in aesthetics?",
       "ja": "美学の『侘び寂び』が表すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65660,7 +66006,7 @@
         "en": "good and evil",
         "ja": "善悪",
         "ja_typings": [
-          "zenaku"
+          "zennaku"
         ]
       }
     ],
@@ -65671,7 +66017,8 @@
     "question_text": {
       "en": "What does the Yin-Yang symbol represent?",
       "ja": "陰陽のシンボルが表すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65711,7 +66058,8 @@
     "question_text": {
       "en": "Which Japanese fan crest is associated with the Asai clan?",
       "ja": "浅井家の家紋は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65751,7 +66099,8 @@
     "question_text": {
       "en": "What does the idiom 'gyokuseki konkou' mean?",
       "ja": "『玉石混淆』の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65832,7 +66181,8 @@
     "question_text": {
       "en": "Which constellation is shaped like a W?",
       "ja": "Wの形をした星座は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65872,7 +66222,8 @@
     "question_text": {
       "en": "What does WHO stand for?",
       "ja": "WHOの略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65880,7 +66231,7 @@
         "en": "nou aru taka wa tsume wo kakusu",
         "ja": "能ある鷹は爪を隠す",
         "ja_typings": [
-          "nouarutakawatsumewokakusu"
+          "nouarutakahatsumewokakusu"
         ]
       },
       {
@@ -65912,7 +66263,8 @@
     "question_text": {
       "en": "Which idiom describes hidden talents?",
       "ja": "隠れた才能を表す慣用句は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -65993,7 +66345,8 @@
     "question_text": {
       "en": "What does the family crest 'agehacho' depict?",
       "ja": "家紋『揚羽蝶』が描くのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66033,7 +66386,8 @@
     "question_text": {
       "en": "Who is known as the first virtual YouTuber?",
       "ja": "初代バーチャルYouTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66114,7 +66468,8 @@
     "question_text": {
       "en": "What does 'kusa' mean in Japanese net slang?",
       "ja": "ネットスラング『草』の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66154,7 +66509,8 @@
     "question_text": {
       "en": "What is a 'Discord raid'?",
       "ja": "『Discord荒らし』とは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66235,7 +66591,8 @@
     "question_text": {
       "en": "What does 'AFK' stand for?",
       "ja": "『AFK』の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66316,7 +66673,8 @@
     "question_text": {
       "en": "What does 'pepega' refer to in Twitch culture?",
       "ja": "Twitch文化での『pepega』は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66356,7 +66714,8 @@
     "question_text": {
       "en": "What is 'doxxing'?",
       "ja": "『ドキシング』とは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66437,7 +66796,8 @@
     "question_text": {
       "en": "What does the meme 'Big Brain' express?",
       "ja": "ミーム『Big Brain』の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66477,7 +66837,8 @@
     "question_text": {
       "en": "Which Hololive member is known as the shark girl?",
       "ja": "サメ少女として知られるホロメンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66485,7 +66846,7 @@
         "en": "amazed reaction",
         "ja": "驚嘆の反応",
         "ja_typings": [
-          "kyoutannohannou"
+          "kyoutannohannnou"
         ]
       },
       {
@@ -66517,7 +66878,8 @@
     "question_text": {
       "en": "What does 'POG' mean in stream chat?",
       "ja": "配信チャットの『POG』の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66598,7 +66960,8 @@
     "question_text": {
       "en": "What is a 'copypasta'?",
       "ja": "『コピペ』とは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66679,7 +67042,8 @@
     "question_text": {
       "en": "Which Vtuber created the song 'Hyperdontia'?",
       "ja": "『Hyperdontia』を歌ったVtuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66719,7 +67083,8 @@
     "question_text": {
       "en": "What is 'shadowbanning'?",
       "ja": "『シャドウバン』とは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66759,7 +67124,8 @@
     "question_text": {
       "en": "What does 'Kappa' represent in Twitch chat?",
       "ja": "Twitchの『Kappa』エモートは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66799,7 +67165,8 @@
     "question_text": {
       "en": "Which platform did 2channel evolve into?",
       "ja": "2ちゃんねるが進化したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66839,7 +67206,8 @@
     "question_text": {
       "en": "What does the meme 'F in chat' express?",
       "ja": "ミーム『F in chat』の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66879,7 +67247,8 @@
     "question_text": {
       "en": "Which Nijisanji liver is known as the demon lord?",
       "ja": "にじさんじで魔王として知られるライバーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66919,7 +67288,8 @@
     "question_text": {
       "en": "What is 'stream sniping'?",
       "ja": "『ストリームスナイプ』とは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66927,7 +67297,7 @@
         "en": "one of my mutuals",
         "ja": "相互フォロワー",
         "ja_typings": [
-          "sougofororowa-"
+          "sougoforowa-"
         ]
       },
       {
@@ -66959,7 +67329,8 @@
     "question_text": {
       "en": "What does 'OOMfie' refer to on Twitter?",
       "ja": "X(Twitter)の『OOMfie』は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -66999,7 +67370,8 @@
     "question_text": {
       "en": "Which Vtuber graduation event is called 'sotsugyou'?",
       "ja": "Vtuberが活動終了することを何という?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67039,7 +67411,8 @@
     "question_text": {
       "en": "Which meme features Drake approving/disapproving?",
       "ja": "Drakeが承認/否認するミームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67079,7 +67452,8 @@
     "question_text": {
       "en": "What does 'mukoukotsu' mean in net slang?",
       "ja": "ネット用語『無向骨』に近い意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67142,7 +67516,7 @@
         "en": "disgust",
         "ja": "嫌悪",
         "ja_typings": [
-          "keno"
+          "kennno"
         ]
       },
       {
@@ -67160,7 +67534,8 @@
     "question_text": {
       "en": "What does 'KEKW' express in Twitch chat?",
       "ja": "Twitchの『KEKW』が表すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -67578,7 +67953,7 @@
         "en": "802.11ax extended",
         "ja": "802.11ax拡張",
         "ja_typings": [
-          "8021axkakuchou"
+          "802.11axkakuchou"
         ]
       },
       {
@@ -67610,7 +67985,8 @@
     "question_text": {
       "en": "Which wireless standard is also called WiFi 6E?",
       "ja": "WiFi 6Eの正式名称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68124,7 +68500,7 @@
         "en": "Coaxial",
         "ja": "同軸ケーブル",
         "ja_typings": [
-          "doujike-buru"
+          "doujikuke-buru"
         ]
       },
       {
@@ -68142,7 +68518,8 @@
     "question_text": {
       "en": "Which cable type uses fiber optics?",
       "ja": "光ファイバを使うケーブルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68264,7 +68641,8 @@
     "question_text": {
       "en": "Which port number does SSH use?",
       "ja": "SSHが使うポート番号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69666,7 +70044,7 @@
         "en": "ergative case",
         "ja": "能格",
         "ja_typings": [
-          "nougaku"
+          "noukaku"
         ]
       },
       {
@@ -69698,7 +70076,8 @@
     "question_text": {
       "en": "Which case marks the subject of a transitive verb in ergative languages?",
       "ja": "能格言語で他動詞の主語を表す格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69738,7 +70117,8 @@
     "question_text": {
       "en": "Which writing system uses consonant-vowel syllables?",
       "ja": "子音+母音の音節を表す文字体系は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69778,7 +70158,8 @@
     "question_text": {
       "en": "Which language family includes Finnish and Hungarian?",
       "ja": "フィンランド語とハンガリー語を含む語族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69818,7 +70199,8 @@
     "question_text": {
       "en": "Which writing system represents only consonants?",
       "ja": "子音のみを表す文字体系は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69858,7 +70240,8 @@
     "question_text": {
       "en": "What is the study of word structure?",
       "ja": "語形成を研究する分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69898,7 +70281,8 @@
     "question_text": {
       "en": "Which feature describes Mandarin tones?",
       "ja": "中国語のトーンを表す特徴は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69938,7 +70322,8 @@
     "question_text": {
       "en": "Which language uses Devanagari script?",
       "ja": "デーヴァナーガリーを使う言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69978,7 +70363,8 @@
     "question_text": {
       "en": "What is the IPA symbol for the glottal stop?",
       "ja": "声門閉鎖音のIPA記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70018,7 +70404,8 @@
     "question_text": {
       "en": "Which tense expresses past relative to past?",
       "ja": "過去より前を表す時制は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70058,7 +70445,8 @@
     "question_text": {
       "en": "Which language is the most spoken Bantu language?",
       "ja": "最も話されるバントゥー語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70098,7 +70486,8 @@
     "question_text": {
       "en": "Which type of word changes form by case in Russian?",
       "ja": "ロシア語で格によって変化する語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70138,7 +70527,8 @@
     "question_text": {
       "en": "Which script does Korean use natively?",
       "ja": "韓国語が固有に使う文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70178,7 +70568,8 @@
     "question_text": {
       "en": "Which area of phonetics studies sound production?",
       "ja": "音声生成を研究する分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70218,7 +70609,8 @@
     "question_text": {
       "en": "Which language is an isolate spoken in northern Spain?",
       "ja": "スペイン北部で話される孤立言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70240,7 +70632,7 @@
         "en": "genitive",
         "ja": "属格",
         "ja_typings": [
-          "zokukaku"
+          "zokkaku"
         ]
       },
       {
@@ -70258,7 +70650,8 @@
     "question_text": {
       "en": "Which case is used for direct objects in Latin?",
       "ja": "ラテン語の直接目的語に使う格は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70298,7 +70691,8 @@
     "question_text": {
       "en": "Which feature distinguishes Korean honorifics?",
       "ja": "韓国語の敬語を特徴づけるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70338,7 +70732,8 @@
     "question_text": {
       "en": "Which Semitic language is the oldest still spoken?",
       "ja": "現在も話される最古のセム語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70353,7 +70748,7 @@
         "en": "nasal lengthening",
         "ja": "鼻音延長",
         "ja_typings": [
-          "bionnnenchou"
+          "bionnenchou"
         ]
       },
       {
@@ -70378,7 +70773,8 @@
     "question_text": {
       "en": "Which sound change is called palatalization?",
       "ja": "口蓋化と呼ばれる音変化は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70418,7 +70814,8 @@
     "question_text": {
       "en": "Which dialect of Chinese is spoken in Hong Kong?",
       "ja": "香港で話される中国語方言は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70458,7 +70855,8 @@
     "question_text": {
       "en": "Which writing direction is traditional Mongolian?",
       "ja": "伝統的モンゴル文字の書字方向は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70498,7 +70896,8 @@
     "question_text": {
       "en": "Which Indo-European subgroup includes Latin?",
       "ja": "ラテン語が属するインド・ヨーロッパ語派は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70527,7 +70926,7 @@
         "en": "vowel mutation",
         "ja": "母音変異",
         "ja_typings": [
-          "boinhennni"
+          "boinhenni"
         ]
       }
     ],
@@ -70538,7 +70937,8 @@
     "question_text": {
       "en": "Which feature distinguishes agglutinative languages?",
       "ja": "膠着語を特徴づけるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70578,7 +70978,8 @@
     "question_text": {
       "en": "Which ancient writing system is cuneiform?",
       "ja": "古代の楔形文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70618,7 +71019,8 @@
     "question_text": {
       "en": "Which mood expresses wish or possibility?",
       "ja": "願望や可能性を表すムードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70658,7 +71060,8 @@
     "question_text": {
       "en": "Which language uses click consonants?",
       "ja": "クリック子音を使う言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70698,7 +71101,8 @@
     "question_text": {
       "en": "Which feature does Vietnamese have?",
       "ja": "ベトナム語が持つ特徴は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70738,7 +71142,8 @@
     "question_text": {
       "en": "Which Austronesian language is spoken in New Zealand?",
       "ja": "ニュージーランドで話されるオーストロネシア語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70828,7 +71233,7 @@
         "en": "triconsonantal root",
         "ja": "三子音語根",
         "ja_typings": [
-          "sanshiongokon"
+          "sanshiingokon"
         ]
       },
       {
@@ -70860,7 +71265,8 @@
     "question_text": {
       "en": "Which feature describes Arabic root system?",
       "ja": "アラビア語の語根体系の特徴は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70941,7 +71347,8 @@
     "question_text": {
       "en": "Which Brazilian martial art combines dance and acrobatics?",
       "ja": "ダンスとアクロバットを組合せたブラジル武術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -70981,7 +71388,8 @@
     "question_text": {
       "en": "Which Spanish festival celebrates tomatoes?",
       "ja": "トマトの祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71226,7 +71634,8 @@
     "question_text": {
       "en": "Which Korean court dance uses fans?",
       "ja": "扇を使う韓国宮廷舞踊は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71266,7 +71675,8 @@
     "question_text": {
       "en": "Which Mexican holiday honors deceased relatives?",
       "ja": "故人を偲ぶメキシコの祭日は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71347,7 +71757,8 @@
     "question_text": {
       "en": "Which Russian dish is layered with herring and beets?",
       "ja": "ニシンとビーツの層状ロシア料理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71551,7 +71962,8 @@
     "question_text": {
       "en": "Which Japanese festival is in Akita with paper lanterns balanced on poles?",
       "ja": "秋田で行われる竿燈の祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71591,7 +72003,8 @@
     "question_text": {
       "en": "Which African religion focuses on ancestors and Orishas?",
       "ja": "祖先とオリシャを崇拝するアフリカ宗教は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -71852,7 +72265,7 @@
         "en": "Cantonese opera",
         "ja": "粤劇",
         "ja_typings": [
-          "echigeki"
+          "etsugeki"
         ]
       },
       {
@@ -71877,7 +72290,8 @@
     "question_text": {
       "en": "Which Chinese opera region is most famous?",
       "ja": "中国京劇の中心地は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72122,7 +72536,8 @@
     "question_text": {
       "en": "Which voice actress voices Rukia Kuchiki in Bleach?",
       "ja": "『BLEACH』で朽木ルキアを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72162,7 +72577,8 @@
     "question_text": {
       "en": "Which voice actor voices Izaya Orihara in Durarara!!?",
       "ja": "『デュラララ!!』で折原臨也を演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72202,7 +72618,8 @@
     "question_text": {
       "en": "Which voice actor voices Gintoki Sakata in Gintama?",
       "ja": "『銀魂』で坂田銀時を演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72242,7 +72659,8 @@
     "question_text": {
       "en": "Which voice actor voices Eren Yeager in Attack on Titan?",
       "ja": "『進撃の巨人』でエレン・イェーガーを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72282,7 +72700,8 @@
     "question_text": {
       "en": "Which voice actor voices Sebastian Michaelis in Black Butler?",
       "ja": "『黒執事』でセバスチャン・ミカエリスを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72322,7 +72741,8 @@
     "question_text": {
       "en": "Which voice actress is well known for tsundere roles like Shana and Louise?",
       "ja": "シャナやルイズなどツンデレ役で知られる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72362,7 +72782,8 @@
     "question_text": {
       "en": "Which voice actor voices Kirito in Sword Art Online?",
       "ja": "『ソードアート・オンライン』でキリトを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72402,7 +72823,8 @@
     "question_text": {
       "en": "Which voice actor voices Iida Tenya in My Hero Academia?",
       "ja": "『僕のヒーローアカデミア』で飯田天哉を演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72442,7 +72864,8 @@
     "question_text": {
       "en": "Which voice actor is widely known for roles like Cloud Strife and Suzaku Kururugi?",
       "ja": "クラウド・ストライフや枢木スザクなどで知られる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72482,7 +72905,8 @@
     "question_text": {
       "en": "Which voice actor voices Tetsuya Kuroko in Kuroko's Basketball?",
       "ja": "『黒子のバスケ』で黒子テツヤを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72522,7 +72946,8 @@
     "question_text": {
       "en": "Which actor voices L in the live-action Death Note films?",
       "ja": "実写映画『デスノート』でLを演じた俳優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72562,7 +72987,8 @@
     "question_text": {
       "en": "Which voice actress voices Hitagi Senjogahara in the Monogatari series?",
       "ja": "『〈物語〉シリーズ』で戦場ヶ原ひたぎを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72602,7 +73028,8 @@
     "question_text": {
       "en": "Which voice actress voices Usagi Tsukino in the original Sailor Moon anime?",
       "ja": "初代『美少女戦士セーラームーン』アニメで月野うさぎを演じた声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72642,7 +73069,8 @@
     "question_text": {
       "en": "Which voice actress voices Sailor Mercury / Ami Mizuno in the original Sailor Moon anime?",
       "ja": "初代『セーラームーン』アニメで水野亜美/セーラーマーキュリーを演じた声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72682,7 +73110,8 @@
     "question_text": {
       "en": "Which voice actor voices Char Aznable in Mobile Suit Gundam?",
       "ja": "『機動戦士ガンダム』でシャア・アズナブルを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72722,7 +73151,8 @@
     "question_text": {
       "en": "Which voice actor is famous for playing Kakashi Hatake in Naruto?",
       "ja": "『NARUTO』ではたけカカシを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72762,7 +73192,8 @@
     "question_text": {
       "en": "Which voice actress voices Yor Forger in Spy x Family?",
       "ja": "『SPY×FAMILY』でヨル・フォージャーを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -72802,7 +73233,8 @@
     "question_text": {
       "en": "Which voice actress voices Haruhi Suzumiya in The Melancholy of Haruhi Suzumiya?",
       "ja": "『涼宮ハルヒの憂鬱』で涼宮ハルヒを演じる声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73088,7 +73520,8 @@
     "question_text": {
       "en": "Which classic anime features Yusuke Urameshi as a Spirit Detective?",
       "ja": "浦飯幽助が霊界探偵を務める名作アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73128,7 +73561,8 @@
     "question_text": {
       "en": "Which space western anime features Gene Starwind and his ship the Outlaw?",
       "ja": "ジーン・スターウィンドが主人公の宇宙ウェスタンアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73168,7 +73602,8 @@
     "question_text": {
       "en": "Which Rumiko Takahashi work follows a boy who turns into a girl when splashed with cold water?",
       "ja": "高橋留美子作で水をかぶると女になる少年の物語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73208,7 +73643,8 @@
     "question_text": {
       "en": "Which Rumiko Takahashi work features the alien Lum and Ataru Moroboshi?",
       "ja": "高橋留美子作でラムちゃんと諸星あたるが登場する作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73330,7 +73766,8 @@
     "question_text": {
       "en": "Which Hiro Mashima anime follows Natsu and his guild of mages?",
       "ja": "真島ヒロ原作、ナツが所属する魔導士ギルドの物語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73411,7 +73848,8 @@
     "question_text": {
       "en": "Which baseball anime follows the Seido High pitching ace Eijun Sawamura?",
       "ja": "沢村栄純が主人公の高校野球アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73451,7 +73889,8 @@
     "question_text": {
       "en": "Which Osamu Tezuka work features a boy reclaiming his body parts from demons?",
       "ja": "手塚治虫原作、体の部位を魔物から取り戻す少年の物語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73491,7 +73930,8 @@
     "question_text": {
       "en": "Which Rei Hiroe anime follows the mercenary crew of the Black Lagoon Company?",
       "ja": "広江礼威原作、傭兵チーム『ブラック・ラグーン商会』の物語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73531,7 +73971,8 @@
     "question_text": {
       "en": "Which Mamoru Hosoda film features a single mother raising two half-wolf children?",
       "ja": "細田守監督、狼男との間に生まれた姉弟を描く映画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73571,7 +74012,8 @@
     "question_text": {
       "en": "Which Mamoru Hosoda film centers on a virtual world called OZ?",
       "ja": "細田守監督、仮想空間 OZ を舞台にした映画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73611,7 +74053,8 @@
     "question_text": {
       "en": "Which Satoshi Kon film follows three homeless people who find an abandoned baby?",
       "ja": "今敏監督、ホームレス3人が捨て子を拾う物語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73651,7 +74094,8 @@
     "question_text": {
       "en": "Which Yutaka Yamamoto-directed anime follows an Edo-period executioner sent to a flower island?",
       "ja": "江戸時代の処刑人が花の島に派遣される死刑囚との物語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73691,7 +74135,8 @@
     "question_text": {
       "en": "Which Leiji Matsumoto work features a steam locomotive traveling through space?",
       "ja": "松本零士原作で宇宙を走る蒸気機関車を描く作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73731,7 +74176,8 @@
     "question_text": {
       "en": "Which World Masterpiece Theater anime is set in the Swiss Alps?",
       "ja": "世界名作劇場でスイスアルプスを舞台にした作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73771,7 +74217,8 @@
     "question_text": {
       "en": "Which 2021 original anime by CloverWorks features girls fighting in dream worlds to bring back the dead?",
       "ja": "2021年クローバーワークス制作、夢の世界で戦う少女たちのオリジナルアニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73811,7 +74258,8 @@
     "question_text": {
       "en": "Which Hajime Komoto anime follows Mash Burnedead, a magicless boy attending magic school?",
       "ja": "甲本一原作、魔法が使えない少年マッシュが魔法学校に通う作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73851,7 +74299,8 @@
     "question_text": {
       "en": "Who created Akira and directed its 1988 film adaptation?",
       "ja": "『AKIRA』の原作者で1988年映画版の監督も務めたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73891,7 +74340,8 @@
     "question_text": {
       "en": "Who directed Tales from Earthsea and From Up on Poppy Hill at Studio Ghibli?",
       "ja": "ジブリで『ゲド戦記』『コクリコ坂から』を監督したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -73931,7 +74381,8 @@
     "question_text": {
       "en": "Who is the character designer for Neon Genesis Evangelion?",
       "ja": "『新世紀エヴァンゲリオン』のキャラクターデザイナーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74012,7 +74463,8 @@
     "question_text": {
       "en": "Which Kodansha weekly serializes Fairy Tail and Hajime no Ippo?",
       "ja": "『フェアリーテイル』『はじめの一歩』を連載する講談社の週刊誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74052,7 +74504,8 @@
     "question_text": {
       "en": "Which Kodansha seinen magazine serializes Vagabond and Vinland Saga?",
       "ja": "『バガボンド』『ヴィンランド・サガ』を連載する講談社の青年誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74092,7 +74545,8 @@
     "question_text": {
       "en": "Which Kodansha monthly serialized Blame! and Mushishi?",
       "ja": "『BLAME!』『蟲師』を連載した講談社の月刊誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74132,7 +74586,8 @@
     "question_text": {
       "en": "Which Shogakukan biweekly serializes Golgo 13?",
       "ja": "『ゴルゴ13』を連載する小学館の隔週誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74172,7 +74627,8 @@
     "question_text": {
       "en": "Which Shogakukan biweekly serialized Sanctuary and 3-gatsu no Lion?",
       "ja": "『サンクチュアリ』『3月のライオン』を連載した小学館の隔週誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74212,7 +74668,8 @@
     "question_text": {
       "en": "Which Akita Shoten weekly serializes Baki and serialized Grappler Baki?",
       "ja": "『バキ』を連載する秋田書店の週刊誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74252,7 +74709,8 @@
     "question_text": {
       "en": "Which Shueisha magazine serializes One Piece and Jujutsu Kaisen?",
       "ja": "『ONE PIECE』『呪術廻戦』を連載する集英社の雑誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74456,7 +74914,8 @@
     "question_text": {
       "en": "Which Shinobu Kaitani manga revolves around a deception tournament with huge debts?",
       "ja": "甲斐谷忍の漫画で、巨額の借金を賭けた騙し合いトーナメントを描く作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74496,7 +74955,8 @@
     "question_text": {
       "en": "Which Daisuke Hashimoto cooking manga follows young chef Yoichi Ajiyoshi?",
       "ja": "味吉陽一を主人公とする料理漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74536,7 +74996,8 @@
     "question_text": {
       "en": "Which Mamare Touno light-novel-based manga is set in a dark fantasy of demon-human peace?",
       "ja": "魔王と勇者の和平を描く橙乃ままれ原作のダーク・ファンタジー漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74576,7 +75037,8 @@
     "question_text": {
       "en": "Who is the author of Video Girl Ai and I\"s?",
       "ja": "『電影少女』『I\"s』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74616,7 +75078,8 @@
     "question_text": {
       "en": "Who is the author of Rookies and Rokudenashi Blues?",
       "ja": "『ROOKIES』『ろくでなしBLUES』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74656,7 +75119,8 @@
     "question_text": {
       "en": "Who is the Year 24 Group member behind Kaze to Ki no Uta and Toward the Terra?",
       "ja": "『風と木の詩』『地球へ…』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74696,7 +75160,8 @@
     "question_text": {
       "en": "Who is the author of Basara and 7 Seeds?",
       "ja": "『BASARA』『7SEEDS』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74736,7 +75201,8 @@
     "question_text": {
       "en": "Who is the author of Saint Seiya?",
       "ja": "『聖闘士星矢』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74776,7 +75242,8 @@
     "question_text": {
       "en": "Who created Tensai Bakabon and Osomatsu-kun?",
       "ja": "『天才バカボン』『おそ松くん』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74816,7 +75283,8 @@
     "question_text": {
       "en": "Which all-female group created Cardcaptor Sakura and X/1999?",
       "ja": "『カードキャプターさくら』『X』を生み出した女性作家グループは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74856,7 +75324,8 @@
     "question_text": {
       "en": "Who wrote the original story for Fist of the North Star?",
       "ja": "『北斗の拳』の原作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74896,7 +75365,8 @@
     "question_text": {
       "en": "Who wrote the original story for Star of the Giants and Tomorrow's Joe?",
       "ja": "『巨人の星』『あしたのジョー』の原作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74936,7 +75406,8 @@
     "question_text": {
       "en": "Who is the duo behind Kinnikuman?",
       "ja": "『キン肉マン』の作者コンビは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74976,7 +75447,8 @@
     "question_text": {
       "en": "Who is the artist behind the One-Punch Man remake and Eyeshield 21?",
       "ja": "ワンパンマン作画版や『アイシールド21』作画の漫画家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -74984,7 +75456,7 @@
         "en": "Yoko Kamio",
         "ja": "神尾葉子",
         "ja_typings": [
-          "kamiyouko"
+          "kamioyouko"
         ]
       },
       {
@@ -75016,7 +75488,8 @@
     "question_text": {
       "en": "Who is the author of Boys Over Flowers (Hana Yori Dango)?",
       "ja": "『花より男子』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75056,7 +75529,8 @@
     "question_text": {
       "en": "Who is the author of The Star of Cottonland?",
       "ja": "『綿の国星』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75096,7 +75570,8 @@
     "question_text": {
       "en": "Who created Doraemon as one half of the duo, and later worked solo on Laughing Salesman?",
       "ja": "藤子不二雄コンビの片割れで『笑ゥせぇるすまん』も手がけたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75136,7 +75611,8 @@
     "question_text": {
       "en": "Who is the author of Section Chief Kosaku Shima?",
       "ja": "『課長島耕作』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75176,7 +75652,8 @@
     "question_text": {
       "en": "Who is the horror manga master behind The Drifting Classroom?",
       "ja": "『漂流教室』の作者であるホラー漫画の巨匠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75216,7 +75693,8 @@
     "question_text": {
       "en": "Who is the author of Otoko Oidon and Salaryman Kintaro?",
       "ja": "『男一匹ガキ大将』『サラリーマン金太郎』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75256,7 +75734,8 @@
     "question_text": {
       "en": "Who created the dog adventure manga Silver Fang?",
       "ja": "犬の冒険漫画『銀牙 -流れ星 銀-』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75296,7 +75775,8 @@
     "question_text": {
       "en": "Who created Gallery Fake and Gaki Deka counterpart Yawara!? — namely the author of Gallery Fake?",
       "ja": "『ギャラリーフェイク』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75336,7 +75816,8 @@
     "question_text": {
       "en": "Who is the author of Captain and Play Ball?",
       "ja": "『キャプテン』『プレイボール』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75376,7 +75857,8 @@
     "question_text": {
       "en": "Who is the baseball manga master behind Dokaben?",
       "ja": "『ドカベン』の作者である野球漫画の巨匠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75416,7 +75898,8 @@
     "question_text": {
       "en": "Who is the author of Patlabor (manga)?",
       "ja": "漫画版『機動警察パトレイバー』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75456,7 +75939,8 @@
     "question_text": {
       "en": "Who is the author of The Five Star Stories?",
       "ja": "『ファイブスター物語』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75496,7 +75980,8 @@
     "question_text": {
       "en": "Who is the author of Ushio and Tora?",
       "ja": "『うしおととら』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75536,7 +76021,8 @@
     "question_text": {
       "en": "Who is the author of Asari-chan?",
       "ja": "『あさりちゃん』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75565,7 +76051,7 @@
         "en": "Yoko Kamio",
         "ja": "神尾葉子",
         "ja_typings": [
-          "kamiyouko"
+          "kamioyouko"
         ]
       }
     ],
@@ -75576,7 +76062,8 @@
     "question_text": {
       "en": "Who is the author of Tenshi nanka ja nai?",
       "ja": "『天使なんかじゃない』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75616,7 +76103,8 @@
     "question_text": {
       "en": "Who is the author of Banana Fish?",
       "ja": "『BANANA FISH』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75631,7 +76119,7 @@
         "en": "Yoko Kamio",
         "ja": "神尾葉子",
         "ja_typings": [
-          "kamiyouko"
+          "kamioyouko"
         ]
       },
       {
@@ -75656,7 +76144,8 @@
     "question_text": {
       "en": "Who is the author of Kimi ni Todoke?",
       "ja": "『君に届け』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75696,7 +76185,8 @@
     "question_text": {
       "en": "Who is the author of Sayonara, Zetsubou-Sensei?",
       "ja": "『さよなら絶望先生』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75736,7 +76226,8 @@
     "question_text": {
       "en": "Who is the historical-josei master behind Tenjo no Niji?",
       "ja": "『天上の虹』を描いた歴史少女漫画の巨匠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75776,7 +76267,8 @@
     "question_text": {
       "en": "Which Japanese publisher releases Kadokawa Bunko and many light novels?",
       "ja": "角川文庫やライトノベルを多数出す日本の出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75816,7 +76308,8 @@
     "question_text": {
       "en": "Which Japanese newspaper has the largest circulation and sponsors the Giants?",
       "ja": "発行部数最大、巨人を所有する日本の新聞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75856,7 +76349,8 @@
     "question_text": {
       "en": "Which Japanese newspaper sponsors the high school baseball Summer Koshien?",
       "ja": "夏の甲子園を主催する日本の新聞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75896,7 +76390,8 @@
     "question_text": {
       "en": "Which Japanese newspaper focuses on business and economics?",
       "ja": "経済を専門に扱う日本の新聞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75936,7 +76431,8 @@
     "question_text": {
       "en": "Who is the heir to Hanagumi at the Imperial Theatre in Sakura Wars?",
       "ja": "『サクラ大戦』で帝国華撃団・花組の隊員は神崎すみれと誰? (新人の少女の名)"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -75976,7 +76472,8 @@
     "question_text": {
       "en": "Who is the rival actress in Glass Mask (Garasu no Kamen)?",
       "ja": "『ガラスの仮面』で北島マヤのライバルとなる天才女優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76016,7 +76513,8 @@
     "question_text": {
       "en": "Who is the legendary actress and mentor in Glass Mask?",
       "ja": "『ガラスの仮面』で月影先生として知られる伝説の女優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76097,7 +76595,8 @@
     "question_text": {
       "en": "Who is the creator of Virtua Fighter and Shenmue at Sega?",
       "ja": "セガで『バーチャファイター』『シェンムー』を生み出したクリエイターは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76178,7 +76677,8 @@
     "question_text": {
       "en": "Which 1995 Square JRPG features Crono and time-traveling adventures?",
       "ja": "1995年スクウェアのRPGで、クロノが時を超える物語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76218,7 +76718,8 @@
     "question_text": {
       "en": "Which long-running Square Enix JRPG series began on the Famicom in 1987?",
       "ja": "1987年ファミコンで始まったスクウェアの長寿RPGシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76308,7 +76809,7 @@
         "en": "Nioh",
         "ja": "仁王",
         "ja_typings": [
-          "nioh"
+          "niou"
         ]
       },
       {
@@ -76340,7 +76841,8 @@
     "question_text": {
       "en": "Which Team Ninja action RPG is set in Sengoku Japan starring William Adams?",
       "ja": "コーエーテクモ製、戦国時代を舞台にウィリアムが戦うアクションRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76355,7 +76857,7 @@
         "en": "Nioh",
         "ja": "仁王",
         "ja_typings": [
-          "nioh"
+          "niou"
         ]
       },
       {
@@ -76380,7 +76882,8 @@
     "question_text": {
       "en": "Which RGG Studio spin-off stars lawyer-turned-detective Takayuki Yagami?",
       "ja": "龍が如くスタジオのスピンオフで、八神隆之が主人公の作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76502,7 +77005,8 @@
     "question_text": {
       "en": "Which Square horror RPG is set in NYC starring Aya Brea?",
       "ja": "ニューヨークを舞台にアヤ・ブレアが活躍するスクウェアのホラーRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76542,7 +77046,8 @@
     "question_text": {
       "en": "Which Monolith Soft JRPG series features giant Titans and the Monado?",
       "ja": "モノリスソフトの巨神とモナドが登場するJRPGシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76564,7 +77069,7 @@
         "en": "Nioh",
         "ja": "仁王",
         "ja_typings": [
-          "nioh"
+          "niou"
         ]
       },
       {
@@ -76582,7 +77087,8 @@
     "question_text": {
       "en": "Which PlatinumGames action title stars a witch named Cereza?",
       "ja": "プラチナゲームズ製、魔女セレッサが主人公のアクションは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76622,7 +77128,8 @@
     "question_text": {
       "en": "Which Capcom action series stars demon hunter Dante?",
       "ja": "カプコン製、悪魔狩人ダンテが主人公のアクションシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76719,7 +77226,7 @@
         "en": "Nioh",
         "ja": "仁王",
         "ja_typings": [
-          "nioh"
+          "niou"
         ]
       },
       {
@@ -76744,7 +77251,8 @@
     "question_text": {
       "en": "Which FromSoftware action RPG series began with Lordran in 2011?",
       "ja": "2011年にロードランから始まったフロム・ソフトウェアのアクションRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76759,7 +77267,7 @@
         "en": "Nioh",
         "ja": "仁王",
         "ja_typings": [
-          "nioh"
+          "niou"
         ]
       },
       {
@@ -76784,7 +77292,8 @@
     "question_text": {
       "en": "Which Capcom action series is set in Sengoku-era Japan with samurai vs demons?",
       "ja": "カプコン製、戦国時代を舞台に侍が鬼と戦うアクションシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76806,7 +77315,7 @@
         "en": "Nioh",
         "ja": "仁王",
         "ja_typings": [
-          "nioh"
+          "niou"
         ]
       },
       {
@@ -76824,7 +77333,8 @@
     "question_text": {
       "en": "Which Acquire-developed series lets you live as a wandering samurai?",
       "ja": "アクワイア開発、流浪の侍として生きるシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76864,7 +77374,8 @@
     "question_text": {
       "en": "Which 1979 Atari arcade game lets you shoot rocks drifting in space?",
       "ja": "1979年アタリ製、宇宙の岩を撃つアーケードゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -76904,7 +77415,8 @@
     "question_text": {
       "en": "Which Sega Yu Suzuki series stars Ryo Hazuki searching for his father's killer?",
       "ja": "鈴木裕監修、芭月涼が父の仇を追うセガの大作シリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77026,7 +77538,8 @@
     "question_text": {
       "en": "Which Konami run-and-gun series began in 1987 with two commandos?",
       "ja": "1987年に始まったコナミの2人コマンドのラン&ガンシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77066,7 +77579,8 @@
     "question_text": {
       "en": "Which Konami cute-em-up features a bell-shooting flying ship?",
       "ja": "コナミ製、鈴を撃つ可愛い縦シューティングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77259,7 +77773,7 @@
         "en": "Yo-kai Watch",
         "ja": "妖怪ウォッチ",
         "ja_typings": [
-          "youkaiuocchi"
+          "youkaiwocchi"
         ]
       }
     ],
@@ -77270,7 +77784,8 @@
     "question_text": {
       "en": "Which HAL Laboratory Nintendo series stars a pink puffball hero?",
       "ja": "HAL研究所製、ピンクの丸い主人公が活躍する任天堂のシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77299,7 +77814,7 @@
         "en": "Yo-kai Watch",
         "ja": "妖怪ウォッチ",
         "ja_typings": [
-          "youkaiuocchi"
+          "youkaiwocchi"
         ]
       }
     ],
@@ -77310,7 +77825,8 @@
     "question_text": {
       "en": "Which Intelligent Systems tactical RPG series began on the Famicom?",
       "ja": "ファミコンで始まったインテリジェントシステムズのSRPGシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77325,7 +77841,7 @@
         "en": "Yo-kai Watch",
         "ja": "妖怪ウォッチ",
         "ja_typings": [
-          "youkaiuocchi"
+          "youkaiwocchi"
         ]
       },
       {
@@ -77350,7 +77866,8 @@
     "question_text": {
       "en": "Which Bandai franchise features creatures hatched from Digivices?",
       "ja": "デジヴァイスから生まれる生物のバンダイ製シリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77358,7 +77875,7 @@
         "en": "Yo-kai Watch",
         "ja": "妖怪ウォッチ",
         "ja_typings": [
-          "youkaiuocchi"
+          "youkaiwocchi"
         ]
       },
       {
@@ -77390,7 +77907,8 @@
     "question_text": {
       "en": "Which Level-5 RPG series features Keita Amano befriending youkai with a watch?",
       "ja": "レベルファイブ製、ケータくんが時計で妖怪と友達になるシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77471,7 +77989,8 @@
     "question_text": {
       "en": "Which Square action RPG series began in 1991 as a Final Fantasy spin-off?",
       "ja": "1991年にFFスピンオフとして始まったスクウェアのアクションRPGシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77511,7 +78030,8 @@
     "question_text": {
       "en": "Which Bandai Namco JRPG franchise includes Symphonia and Vesperia?",
       "ja": "『シンフォニア』『ヴェスペリア』を含むバンダイナムコのJRPGシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77551,7 +78071,8 @@
     "question_text": {
       "en": "Which 1997 PS1 Square RPG features seven scenarios across Regions?",
       "ja": "1997年PS1スクウェア製、7つのシナリオを行き来するRPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -77607,7 +78128,7 @@
         "en": "Yo-kai Watch",
         "ja": "妖怪ウォッチ",
         "ja_typings": [
-          "youkaiuocchi"
+          "youkaiwocchi"
         ]
       },
       {
@@ -77632,7 +78153,8 @@
     "question_text": {
       "en": "Which Square Enix Minecraft-like spin-off stars a hero who builds with blocks?",
       "ja": "スクエニ製、ブロックを積んで世界を作るマイクラ風スピンオフは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78082,7 +78604,8 @@
     "question_text": {
       "en": "Which OOP concept allows a class to acquire properties from another class?",
       "ja": "あるクラスが別のクラスのプロパティを受け継ぐオブジェクト指向の概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78165,7 +78688,8 @@
     "question_text": {
       "en": "Which self-balancing tree is widely used in databases and filesystems?",
       "ja": "データベースやファイルシステムで広く使われる自己平衡木は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78246,7 +78770,8 @@
     "question_text": {
       "en": "Which JVM language has functional features and is used at Twitter?",
       "ja": "JVM 上で動く関数型機能を持つ言語で Twitter でも使われていたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78409,7 +78934,8 @@
     "question_text": {
       "en": "Which design principle forwards a request from one object to another helper object?",
       "ja": "あるオブジェクトが処理を別のヘルパーオブジェクトに転送する設計原則は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78736,7 +79262,8 @@
     "question_text": {
       "en": "Which company created the Go programming language?",
       "ja": "プログラミング言語 Go を生み出した企業は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78765,7 +79292,7 @@
         "en": "Insertion sort",
         "ja": "挿入ソート",
         "ja_typings": [
-          "so-nyuusooto"
+          "sounyuuso-to"
         ]
       }
     ],
@@ -78776,7 +79303,8 @@
     "question_text": {
       "en": "Which divide-and-conquer sort uses a pivot to partition the array?",
       "ja": "ピボットを使って配列を分割する分割統治法のソートは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -78857,7 +79385,8 @@
     "question_text": {
       "en": "Which control-flow concept repeats a block of code using loops?",
       "ja": "ループを用いてコードブロックを繰り返す制御フローの概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79102,7 +79631,8 @@
     "question_text": {
       "en": "In C++, which keyword hints the compiler to expand a function at call site?",
       "ja": "C++ で関数を呼び出し位置に展開するようコンパイラに示唆するキーワードは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79183,7 +79713,8 @@
     "question_text": {
       "en": "Which Pascal-like statically typed language compiles to C, JS, and more?",
       "ja": "Pascal 風の静的型付け言語で C や JS にコンパイル可能なのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79224,7 +79755,8 @@
     "question_text": {
       "en": "Which probabilistic data structure layers linked lists for fast search?",
       "ja": "リンクリストを多層化して高速検索を実現する確率的データ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79305,7 +79837,8 @@
     "question_text": {
       "en": "Which programming paradigm focuses on explicit statements that change state?",
       "ja": "状態を変化させる明示的な命令文を中心とするプログラミングパラダイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79345,7 +79878,8 @@
     "question_text": {
       "en": "Which paradigm organizes code into reusable procedures or routines?",
       "ja": "コードを再利用可能な手続きにまとめるパラダイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79467,7 +80001,8 @@
     "question_text": {
       "en": "Which Python built-in pairs elements from multiple iterables?",
       "ja": "複数のイテラブルから要素をペアにする Python 組み込み関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79482,7 +80017,7 @@
         "en": "&&",
         "ja": "論理積演算子",
         "ja_typings": [
-          "ronritekienzanshi"
+          "ronrisekienzanshi"
         ]
       },
       {
@@ -79507,7 +80042,8 @@
     "question_text": {
       "en": "Which C operator selects between two expressions based on a condition?",
       "ja": "条件によって 2 つの式を選ぶ C 言語の演算子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79588,7 +80124,8 @@
     "question_text": {
       "en": "Which linear data structure stores elements with pointers to the next node?",
       "ja": "次ノードへのポインタで要素を繋ぐ線形データ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79628,7 +80165,8 @@
     "question_text": {
       "en": "Which contiguous-memory data structure offers O(1) index access?",
       "ja": "添字アクセスが O(1) で可能な連続メモリのデータ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79668,7 +80206,8 @@
     "question_text": {
       "en": "Which function maps keys to indices in a hash table?",
       "ja": "ハッシュテーブルで鍵を添字に変換する関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79710,7 +80249,8 @@
     "question_text": {
       "en": "Which tree variant has at most three children per node?",
       "ja": "各ノードが最大 3 つの子を持つ木は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79718,7 +80258,7 @@
         "en": "Complete Graph",
         "ja": "完全グラフ",
         "ja_typings": [
-          "kanzenngurafu"
+          "kanzengurafu"
         ]
       },
       {
@@ -79750,7 +80290,8 @@
     "question_text": {
       "en": "Which graph has an edge between every pair of distinct vertices?",
       "ja": "任意の 2 頂点間に辺がある無向グラフは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -79790,7 +80331,8 @@
     "question_text": {
       "en": "Which OOP concept hides implementation details behind a simple interface?",
       "ja": "実装詳細を隠して簡潔なインタフェースを公開する OOP の概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80076,7 +80618,8 @@
     "question_text": {
       "en": "Which Rust standard collection is a growable, heap-allocated array?",
       "ja": "ヒープ確保で可変長配列を表す Rust の標準コレクションは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80781,7 +81324,7 @@
         "en": "`<picture>`",
         "ja": "ピクチャ要素",
         "ja_typings": [
-          "pikutyayouso"
+          "pikuchayouso"
         ]
       },
       {
@@ -80813,7 +81356,8 @@
     "question_text": {
       "en": "Which HTML element lets you supply multiple image sources for different conditions?",
       "ja": "条件ごとに複数の画像ソースを与える HTML 要素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -80853,7 +81397,8 @@
     "question_text": {
       "en": "Which CSS at-rule applies styles only when the browser supports given features?",
       "ja": "ブラウザが指定機能を支持する場合だけスタイルを適用する CSS の at-rule は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81312,28 +81857,28 @@
         "en": "`title` attribute",
         "ja": "タイトル属性",
         "ja_typings": [
-          "taitorusokusei"
+          "taitoruzokusei"
         ]
       },
       {
         "en": "`alt` attribute",
         "ja": "オルト属性",
         "ja_typings": [
-          "orutosokusei"
+          "orutozokusei"
         ]
       },
       {
         "en": "`aria-label` attribute",
         "ja": "エリアラベル属性",
         "ja_typings": [
-          "ariaraberusokusei"
+          "eriaraberuzokusei"
         ]
       },
       {
         "en": "`label` attribute",
         "ja": "ラベル属性",
         "ja_typings": [
-          "raberusokusei"
+          "raberuzokusei"
         ]
       }
     ],
@@ -81344,7 +81889,8 @@
     "question_text": {
       "en": "Which HTML attribute provides advisory text shown as a tooltip on hover?",
       "ja": "ホバー時にツールチップとして表示される補助テキストの HTML 属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81352,28 +81898,28 @@
         "en": "`src` attribute",
         "ja": "ソース属性",
         "ja_typings": [
-          "so-susokusei"
+          "so-suzokusei"
         ]
       },
       {
         "en": "`href` attribute",
         "ja": "エイチレフ属性",
         "ja_typings": [
-          "eichirefusokusei"
+          "eichirefuzokusei"
         ]
       },
       {
         "en": "`data` attribute",
         "ja": "データ属性",
         "ja_typings": [
-          "de-tasokusei"
+          "de-tazokusei"
         ]
       },
       {
         "en": "`action` attribute",
         "ja": "アクション属性",
         "ja_typings": [
-          "akushonsokusei"
+          "akushonzokusei"
         ]
       }
     ],
@@ -81384,7 +81930,8 @@
     "question_text": {
       "en": "Which HTML attribute specifies the URL of an external resource like an image?",
       "ja": "画像など外部リソースの URL を指定する HTML 属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81392,28 +81939,28 @@
         "en": "`name` attribute",
         "ja": "ネーム属性",
         "ja_typings": [
-          "ne-musokusei"
+          "ne-muzokusei"
         ]
       },
       {
         "en": "`id` attribute",
         "ja": "アイディー属性",
         "ja_typings": [
-          "aidhi-sokusei"
+          "aidhi-zokusei"
         ]
       },
       {
         "en": "`for` attribute",
         "ja": "フォー属性",
         "ja_typings": [
-          "fo-sokusei"
+          "fo-zokusei"
         ]
       },
       {
         "en": "`value` attribute",
         "ja": "バリュー属性",
         "ja_typings": [
-          "baryu-sokusei"
+          "baryu-zokusei"
         ]
       }
     ],
@@ -81424,7 +81971,8 @@
     "question_text": {
       "en": "Which HTML attribute identifies a form control when submitted to the server?",
       "ja": "送信時にサーバへ送られるフォーム部品の識別子を表す HTML 属性は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -81979,7 +82527,7 @@
         "en": "United States",
         "ja": "アメリカ合衆国",
         "ja_typings": [
-          "amerika/gasshuukoku"
+          "amerikagasshuukoku"
         ]
       },
       {
@@ -81997,7 +82545,8 @@
     "question_text": {
       "en": "Which country has the world's largest population by historical record in 2020?",
       "ja": "2020年時点で世界最大の人口を持っていた国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82005,28 +82554,28 @@
         "en": "Gobi Desert",
         "ja": "ゴビ砂漠",
         "ja_typings": [
-          "gobi/sabaku"
+          "gobisabaku"
         ]
       },
       {
         "en": "Taklamakan",
         "ja": "タクラマカン砂漠",
         "ja_typings": [
-          "takuramakan/sabaku"
+          "takuramakansabaku"
         ]
       },
       {
         "en": "Karakum",
         "ja": "カラクム砂漠",
         "ja_typings": [
-          "karakumu/sabaku"
+          "karakumusabaku"
         ]
       },
       {
         "en": "Thar",
         "ja": "タール砂漠",
         "ja_typings": [
-          "ta-ru/sabaku"
+          "ta-rusabaku"
         ]
       }
     ],
@@ -82037,7 +82586,8 @@
     "question_text": {
       "en": "Which desert stretches across southern Mongolia and northern China?",
       "ja": "モンゴル南部と中国北部に広がる砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82045,28 +82595,28 @@
         "en": "Lake Tanganyika",
         "ja": "タンガニーカ湖",
         "ja_typings": [
-          "tangani-ka/ko"
+          "tangani-kako"
         ]
       },
       {
         "en": "Lake Victoria",
         "ja": "ヴィクトリア湖",
         "ja_typings": [
-          "vikutoria/ko"
+          "vikutoriako"
         ]
       },
       {
         "en": "Lake Malawi",
         "ja": "マラウイ湖",
         "ja_typings": [
-          "maraui/ko"
+          "marauiko"
         ]
       },
       {
         "en": "Lake Chad",
         "ja": "チャド湖",
         "ja_typings": [
-          "chado/ko"
+          "chadoko"
         ]
       }
     ],
@@ -82077,7 +82627,8 @@
     "question_text": {
       "en": "Which African lake is the world's second-deepest freshwater lake?",
       "ja": "世界で2番目に深い淡水湖であるアフリカの湖は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82085,28 +82636,28 @@
         "en": "Lake Superior",
         "ja": "スペリオル湖",
         "ja_typings": [
-          "superioru/ko"
+          "superioruko"
         ]
       },
       {
         "en": "Lake Huron",
         "ja": "ヒューロン湖",
         "ja_typings": [
-          "hyu-ron/ko"
+          "hyu-ronko"
         ]
       },
       {
         "en": "Lake Michigan",
         "ja": "ミシガン湖",
         "ja_typings": [
-          "mishigan/ko"
+          "mishiganko"
         ]
       },
       {
         "en": "Lake Erie",
         "ja": "エリー湖",
         "ja_typings": [
-          "eri-/ko"
+          "eri-ko"
         ]
       }
     ],
@@ -82117,7 +82668,8 @@
     "question_text": {
       "en": "Which of the Great Lakes has the largest surface area?",
       "ja": "五大湖のうち最も面積が大きい湖は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82125,28 +82677,28 @@
         "en": "Alps",
         "ja": "アルプス山脈",
         "ja_typings": [
-          "arupusu/sanmyaku"
+          "arupususanmyaku"
         ]
       },
       {
         "en": "Pyrenees",
         "ja": "ピレネー山脈",
         "ja_typings": [
-          "pirene-/sanmyaku"
+          "pirene-sanmyaku"
         ]
       },
       {
         "en": "Carpathians",
         "ja": "カルパティア山脈",
         "ja_typings": [
-          "karupathia/sanmyaku"
+          "karupathiasanmyaku"
         ]
       },
       {
         "en": "Apennines",
         "ja": "アペニン山脈",
         "ja_typings": [
-          "apenin/sanmyaku"
+          "apeninsanmyaku"
         ]
       }
     ],
@@ -82157,7 +82709,8 @@
     "question_text": {
       "en": "Which mountain range runs through Switzerland, Austria, and northern Italy?",
       "ja": "スイス・オーストリア・北イタリアを貫く山脈は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82247,7 +82800,7 @@
         "en": "United States",
         "ja": "アメリカ合衆国",
         "ja_typings": [
-          "amerika/gasshuukoku"
+          "amerikagasshuukoku"
         ]
       },
       {
@@ -82279,7 +82832,8 @@
     "question_text": {
       "en": "Which country has Washington D.C. as its capital?",
       "ja": "ワシントンD.C.を首都とする国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82287,28 +82841,28 @@
         "en": "Atacama Desert",
         "ja": "アタカマ砂漠",
         "ja_typings": [
-          "atakama/sabaku"
+          "atakamasabaku"
         ]
       },
       {
         "en": "Patagonian Desert",
         "ja": "パタゴニア砂漠",
         "ja_typings": [
-          "patagonia/sabaku"
+          "patagoniasabaku"
         ]
       },
       {
         "en": "Sechura Desert",
         "ja": "セチュラ砂漠",
         "ja_typings": [
-          "sechura/sabaku"
+          "sechurasabaku"
         ]
       },
       {
         "en": "Monte Desert",
         "ja": "モンテ砂漠",
         "ja_typings": [
-          "monte/sabaku"
+          "montesabaku"
         ]
       }
     ],
@@ -82319,7 +82873,8 @@
     "question_text": {
       "en": "Which desert is one of the driest places on Earth, located in Chile?",
       "ja": "チリにある、地球上で最も乾燥した場所の一つの砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82327,14 +82882,14 @@
         "en": "North America",
         "ja": "北アメリカ",
         "ja_typings": [
-          "kita/amerika"
+          "kitaamerika"
         ]
       },
       {
         "en": "South America",
         "ja": "南アメリカ",
         "ja_typings": [
-          "minami/amerika"
+          "minamiamerika"
         ]
       },
       {
@@ -82359,7 +82914,8 @@
     "question_text": {
       "en": "Which continent contains Canada and Mexico?",
       "ja": "カナダとメキシコを含む大陸は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82367,7 +82923,7 @@
         "en": "Antarctica",
         "ja": "南極大陸",
         "ja_typings": [
-          "nankyoku/tairiku"
+          "nankyokutairiku"
         ]
       },
       {
@@ -82381,7 +82937,7 @@
         "en": "South America",
         "ja": "南アメリカ",
         "ja_typings": [
-          "minami/amerika"
+          "minamiamerika"
         ]
       },
       {
@@ -82399,7 +82955,8 @@
     "question_text": {
       "en": "Which is the southernmost continent on Earth?",
       "ja": "地球上で最も南にある大陸は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82407,28 +82964,28 @@
         "en": "Mount Kenya",
         "ja": "ケニア山",
         "ja_typings": [
-          "kenia/san"
+          "keniasan"
         ]
       },
       {
         "en": "Mount Kilimanjaro",
         "ja": "キリマンジャロ山",
         "ja_typings": [
-          "kirimanjaro/san"
+          "kirimanjarosan"
         ]
       },
       {
         "en": "Mount Stanley",
         "ja": "スタンレー山",
         "ja_typings": [
-          "sutanre-/san"
+          "sutanre-san"
         ]
       },
       {
         "en": "Mount Meru",
         "ja": "メルー山",
         "ja_typings": [
-          "meru-/san"
+          "meru-san"
         ]
       }
     ],
@@ -82439,7 +82996,8 @@
     "question_text": {
       "en": "Which is the second-highest mountain in Africa, located in central Kenya?",
       "ja": "ケニア中央部にあるアフリカで2番目に高い山は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82488,28 +83046,28 @@
         "en": "Pyrenees",
         "ja": "ピレネー山脈",
         "ja_typings": [
-          "pirene-/sanmyaku"
+          "pirene-sanmyaku"
         ]
       },
       {
         "en": "Alps",
         "ja": "アルプス山脈",
         "ja_typings": [
-          "arupusu/sanmyaku"
+          "arupususanmyaku"
         ]
       },
       {
         "en": "Apennines",
         "ja": "アペニン山脈",
         "ja_typings": [
-          "apenin/sanmyaku"
+          "apeninsanmyaku"
         ]
       },
       {
         "en": "Cantabrian Mountains",
         "ja": "カンタブリア山脈",
         "ja_typings": [
-          "kantaburia/sanmyaku"
+          "kantaburiasanmyaku"
         ]
       }
     ],
@@ -82520,7 +83078,8 @@
     "question_text": {
       "en": "Which mountain range forms the border between France and Spain?",
       "ja": "フランスとスペインの国境を成す山脈は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -82583,7 +83142,7 @@
         "en": "Faroe Islands",
         "ja": "フェロー諸島",
         "ja_typings": [
-          "fero-/shotou"
+          "fero-shotou"
         ]
       },
       {
@@ -82601,7 +83160,8 @@
     "question_text": {
       "en": "Which Nordic island country has Reykjavik as its capital?",
       "ja": "レイキャビクを首都とする北欧の島国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83101,28 +83661,28 @@
         "en": "Rhine",
         "ja": "ライン川",
         "ja_typings": [
-          "rain/gawa"
+          "raingawa"
         ]
       },
       {
         "en": "Elbe",
         "ja": "エルベ川",
         "ja_typings": [
-          "erube/gawa"
+          "erubegawa"
         ]
       },
       {
         "en": "Danube",
         "ja": "ドナウ川",
         "ja_typings": [
-          "donau/gawa"
+          "donaugawa"
         ]
       },
       {
         "en": "Seine",
         "ja": "セーヌ川",
         "ja_typings": [
-          "se-nu/gawa"
+          "se-nugawa"
         ]
       }
     ],
@@ -83133,7 +83693,8 @@
     "question_text": {
       "en": "Which river flows through Germany and the Netherlands into the North Sea?",
       "ja": "ドイツとオランダを流れ北海に注ぐ川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83141,28 +83702,28 @@
         "en": "Danube",
         "ja": "ドナウ川",
         "ja_typings": [
-          "donau/gawa"
+          "donaugawa"
         ]
       },
       {
         "en": "Rhine",
         "ja": "ライン川",
         "ja_typings": [
-          "rain/gawa"
+          "raingawa"
         ]
       },
       {
         "en": "Volga",
         "ja": "ヴォルガ川",
         "ja_typings": [
-          "voruga/gawa"
+          "vorugagawa"
         ]
       },
       {
         "en": "Dnieper",
         "ja": "ドニエプル川",
         "ja_typings": [
-          "doniepuru/gawa"
+          "doniepurugawa"
         ]
       }
     ],
@@ -83173,7 +83734,8 @@
     "question_text": {
       "en": "Which river flows through Vienna, Budapest, and Belgrade into the Black Sea?",
       "ja": "ウィーン・ブダペスト・ベオグラードを流れ黒海に注ぐ川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83181,28 +83743,28 @@
         "en": "Loire",
         "ja": "ロワール川",
         "ja_typings": [
-          "rowa-ru/gawa"
+          "rowa-rugawa"
         ]
       },
       {
         "en": "Seine",
         "ja": "セーヌ川",
         "ja_typings": [
-          "se-nu/gawa"
+          "se-nugawa"
         ]
       },
       {
         "en": "Rhone",
         "ja": "ローヌ川",
         "ja_typings": [
-          "ro-nu/gawa"
+          "ro-nugawa"
         ]
       },
       {
         "en": "Garonne",
         "ja": "ガロンヌ川",
         "ja_typings": [
-          "garonnu/gawa"
+          "garonnugawa"
         ]
       }
     ],
@@ -83213,7 +83775,8 @@
     "question_text": {
       "en": "Which is the longest river in France?",
       "ja": "フランスで最も長い川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83242,7 +83805,7 @@
         "en": "Mekong",
         "ja": "メコン川",
         "ja_typings": [
-          "mekon/gawa"
+          "mekongawa"
         ]
       }
     ],
@@ -83253,7 +83816,8 @@
     "question_text": {
       "en": "Which Chinese river is also known as the Huang He?",
       "ja": "「黄河」とも呼ばれる中国の川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83261,7 +83825,7 @@
         "en": "Mekong",
         "ja": "メコン川",
         "ja_typings": [
-          "mekon/gawa"
+          "mekongawa"
         ]
       },
       {
@@ -83275,14 +83839,14 @@
         "en": "Salween",
         "ja": "サルウィン川",
         "ja_typings": [
-          "saruuin/gawa"
+          "saruuingawa"
         ]
       },
       {
         "en": "Irrawaddy",
         "ja": "イラワジ川",
         "ja_typings": [
-          "irawaji/gawa"
+          "irawajigawa"
         ]
       }
     ],
@@ -83293,7 +83857,8 @@
     "question_text": {
       "en": "Which river flows from Tibet through Laos and Vietnam into the South China Sea?",
       "ja": "チベットからラオス・ベトナムを流れ南シナ海に注ぐ川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83322,7 +83887,7 @@
         "en": "Mekong",
         "ja": "メコン川",
         "ja_typings": [
-          "mekon/gawa"
+          "mekongawa"
         ]
       }
     ],
@@ -83333,7 +83898,8 @@
     "question_text": {
       "en": "Which river flows through Guangzhou into the South China Sea?",
       "ja": "広州を流れ南シナ海に注ぐ中国の川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83348,14 +83914,14 @@
         "en": "Caspian Sea",
         "ja": "カスピ海",
         "ja_typings": [
-          "kasupi/kai"
+          "kasupikai"
         ]
       },
       {
         "en": "Aegean Sea",
         "ja": "エーゲ海",
         "ja_typings": [
-          "e-ge/kai"
+          "e-gekai"
         ]
       },
       {
@@ -83373,7 +83939,8 @@
     "question_text": {
       "en": "Which sea lies between Turkey and Ukraine?",
       "ja": "トルコとウクライナの間にある海は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83381,28 +83948,28 @@
         "en": "Taklamakan",
         "ja": "タクラマカン砂漠",
         "ja_typings": [
-          "takuramakan/sabaku"
+          "takuramakansabaku"
         ]
       },
       {
         "en": "Gobi Desert",
         "ja": "ゴビ砂漠",
         "ja_typings": [
-          "gobi/sabaku"
+          "gobisabaku"
         ]
       },
       {
         "en": "Karakum",
         "ja": "カラクム砂漠",
         "ja_typings": [
-          "karakumu/sabaku"
+          "karakumusabaku"
         ]
       },
       {
         "en": "Kyzylkum",
         "ja": "キジルクム砂漠",
         "ja_typings": [
-          "kijirukumu/sabaku"
+          "kijirukumusabaku"
         ]
       }
     ],
@@ -83413,7 +83980,8 @@
     "question_text": {
       "en": "Which desert lies in the Tarim Basin of northwest China?",
       "ja": "中国北西部タリム盆地にある砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83421,28 +83989,28 @@
         "en": "Karakum",
         "ja": "カラクム砂漠",
         "ja_typings": [
-          "karakumu/sabaku"
+          "karakumusabaku"
         ]
       },
       {
         "en": "Kyzylkum",
         "ja": "キジルクム砂漠",
         "ja_typings": [
-          "kijirukumu/sabaku"
+          "kijirukumusabaku"
         ]
       },
       {
         "en": "Taklamakan",
         "ja": "タクラマカン砂漠",
         "ja_typings": [
-          "takuramakan/sabaku"
+          "takuramakansabaku"
         ]
       },
       {
         "en": "Gobi Desert",
         "ja": "ゴビ砂漠",
         "ja_typings": [
-          "gobi/sabaku"
+          "gobisabaku"
         ]
       }
     ],
@@ -83453,7 +84021,8 @@
     "question_text": {
       "en": "Which desert covers most of Turkmenistan?",
       "ja": "トルクメニスタンの大部分を覆う砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83461,28 +84030,28 @@
         "en": "Thar",
         "ja": "タール砂漠",
         "ja_typings": [
-          "ta-ru/sabaku"
+          "ta-rusabaku"
         ]
       },
       {
         "en": "Karakum",
         "ja": "カラクム砂漠",
         "ja_typings": [
-          "karakumu/sabaku"
+          "karakumusabaku"
         ]
       },
       {
         "en": "Gobi Desert",
         "ja": "ゴビ砂漠",
         "ja_typings": [
-          "gobi/sabaku"
+          "gobisabaku"
         ]
       },
       {
         "en": "Negev",
         "ja": "ネゲヴ砂漠",
         "ja_typings": [
-          "negevu/sabaku"
+          "negevusabaku"
         ]
       }
     ],
@@ -83493,7 +84062,8 @@
     "question_text": {
       "en": "Which desert lies in northwestern India and southeastern Pakistan?",
       "ja": "インド北西部とパキスタン南東部にある砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83583,28 +84153,28 @@
         "en": "Strait of Hormuz",
         "ja": "ホルムズ海峡",
         "ja_typings": [
-          "horumuzu/kaikyou"
+          "horumuzukaikyou"
         ]
       },
       {
         "en": "Strait of Malacca",
         "ja": "マラッカ海峡",
         "ja_typings": [
-          "marakka/kaikyou"
+          "marakkakaikyou"
         ]
       },
       {
         "en": "Bab-el-Mandeb",
         "ja": "バブ・エル・マンデブ海峡",
         "ja_typings": [
-          "babu/eru/mandebu/kaikyou"
+          "babu/eru/mandebukaikyou"
         ]
       },
       {
         "en": "Bosphorus",
         "ja": "ボスポラス海峡",
         "ja_typings": [
-          "bosuporasu/kaikyou"
+          "bosuporasukaikyou"
         ]
       }
     ],
@@ -83615,7 +84185,8 @@
     "question_text": {
       "en": "Which strait connects the Persian Gulf to the Gulf of Oman?",
       "ja": "ペルシア湾とオマーン湾を結ぶ海峡は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83623,28 +84194,28 @@
         "en": "Strait of Malacca",
         "ja": "マラッカ海峡",
         "ja_typings": [
-          "marakka/kaikyou"
+          "marakkakaikyou"
         ]
       },
       {
         "en": "Strait of Hormuz",
         "ja": "ホルムズ海峡",
         "ja_typings": [
-          "horumuzu/kaikyou"
+          "horumuzukaikyou"
         ]
       },
       {
         "en": "Sunda Strait",
         "ja": "スンダ海峡",
         "ja_typings": [
-          "sunda/kaikyou"
+          "sundakaikyou"
         ]
       },
       {
         "en": "Taiwan Strait",
         "ja": "台湾海峡",
         "ja_typings": [
-          "taiwan/kaikyou"
+          "taiwankaikyou"
         ]
       }
     ],
@@ -83655,7 +84226,8 @@
     "question_text": {
       "en": "Which strait connects the Indian Ocean and the South China Sea?",
       "ja": "インド洋と南シナ海を結ぶ海峡は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -83766,7 +84338,7 @@
         "en": "East Timor",
         "ja": "東ティモール",
         "ja_typings": [
-          "higashi/thimo-ru"
+          "higashithimo-ru"
         ]
       }
     ],
@@ -83777,7 +84349,8 @@
     "question_text": {
       "en": "Which small Southeast Asian country on Borneo is ruled by a sultan?",
       "ja": "ボルネオ島にある、スルタンが統治する東南アジアの小国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84022,7 +84595,8 @@
     "question_text": {
       "en": "Which French king issued the Edict of Nantes in 1598?",
       "ja": "1598年にナント勅令を発したフランス王は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84144,7 +84718,8 @@
     "question_text": {
       "en": "Which Chinese dynasty was founded by Kublai Khan in 1271?",
       "ja": "1271年にフビライ・ハンが建てた中国の王朝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84184,7 +84759,8 @@
     "question_text": {
       "en": "Which 19th-century war was fought between Russia and an alliance of Britain, France, and the Ottoman Empire?",
       "ja": "ロシアと英仏オスマン連合の間で起こった19世紀の戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84265,7 +84841,8 @@
     "question_text": {
       "en": "Which 1794 event ended the Reign of Terror in revolutionary France?",
       "ja": "1794年に恐怖政治を終わらせたフランス革命期の事件は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84305,7 +84882,8 @@
     "question_text": {
       "en": "Which 1792 battle saw French revolutionary forces stop a Prussian invasion?",
       "ja": "1792年にフランス革命軍がプロイセン軍を阻止した戦いは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84550,7 +85128,8 @@
     "question_text": {
       "en": "Which French king was overthrown in the July Revolution of 1830?",
       "ja": "1830年7月革命で退位したフランス王は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -84599,14 +85178,14 @@
         "en": "Battle of Leipzig",
         "ja": "ライプツィヒの戦い",
         "ja_typings": [
-          "raiputsuhi/no/tatakai"
+          "raiputsihi/no/tatakai"
         ]
       },
       {
         "en": "Battle of Waterloo",
         "ja": "ワーテルローの戦い",
         "ja_typings": [
-          "wa-teruroo/no/tatakai"
+          "wa-teruro-/no/tatakai"
         ]
       },
       {
@@ -84631,7 +85210,8 @@
     "question_text": {
       "en": "Which 1813 battle saw Napoleon defeated by a coalition of European powers?",
       "ja": "1813年にナポレオンが欧州連合軍に敗れた戦いは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85081,7 +85661,8 @@
     "question_text": {
       "en": "Which 1912-1913 war was fought between Balkan states and the Ottoman Empire?",
       "ja": "1912〜13年にバルカン諸国とオスマン帝国の間で起きた戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85203,7 +85784,8 @@
     "question_text": {
       "en": "Which ancient civilization invented paper and gunpowder?",
       "ja": "紙と火薬を発明した古代文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85225,7 +85807,7 @@
         "en": "George V",
         "ja": "ジョージ5世",
         "ja_typings": [
-          "jo-jii/5/sei"
+          "jo-ji/5/sei"
         ]
       },
       {
@@ -85243,7 +85825,8 @@
     "question_text": {
       "en": "Which British monarch reigned during the height of the British Empire from 1837 to 1901?",
       "ja": "1837〜1901年に大英帝国の絶頂期に在位した君主は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85283,7 +85866,8 @@
     "question_text": {
       "en": "Which Japanese era ran from 1989 to 2019?",
       "ja": "1989年から2019年まで続いた日本の元号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85323,7 +85907,8 @@
     "question_text": {
       "en": "Which Japanese era began in 2019?",
       "ja": "2019年に始まった日本の元号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85363,7 +85948,8 @@
     "question_text": {
       "en": "Which 20th-century war involved US military intervention in Southeast Asia from 1955 to 1975?",
       "ja": "1955〜1975年に米軍が東南アジアに介入した20世紀の戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85403,7 +85989,8 @@
     "question_text": {
       "en": "Which European political entity existed from 962 to 1806 in central Europe?",
       "ja": "962年から1806年まで中欧に存在した政治体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85443,7 +86030,8 @@
     "question_text": {
       "en": "Which Egyptian temple complex was relocated due to the Aswan High Dam?",
       "ja": "アスワンハイダム建設のため移築された古代エジプトの神殿は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85483,7 +86071,8 @@
     "question_text": {
       "en": "Which Egyptian temple in modern Luxor was the southern sanctuary of Amun?",
       "ja": "現在のルクソールにあるアモン神の南方聖域とされた神殿は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85523,7 +86112,8 @@
     "question_text": {
       "en": "Which vast Egyptian temple complex was dedicated mainly to Amun-Ra?",
       "ja": "主にアモン・ラー神に捧げられたエジプト最大の神殿群は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85604,7 +86194,8 @@
     "question_text": {
       "en": "Which 14th Tokugawa shogun reigned during the late Bakumatsu period?",
       "ja": "幕末期に在職した第14代徳川将軍は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85644,7 +86235,8 @@
     "question_text": {
       "en": "Which 13th Tokugawa shogun ruled from 1853 to 1858?",
       "ja": "1853〜1858年に在職した第13代徳川将軍は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85684,7 +86276,8 @@
     "question_text": {
       "en": "Which lord of Mito Domain was a major reformist figure in the late Edo period?",
       "ja": "幕末に活躍した水戸藩主の改革派の人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85724,7 +86317,8 @@
     "question_text": {
       "en": "Which Han emperor greatly expanded the empire and reigned 141-87 BC?",
       "ja": "紀元前141〜87年に在位し領土を大きく拡げた前漢の皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85746,7 +86340,7 @@
         "en": "Emperor Xuanzong of Tang",
         "ja": "唐の玄宗",
         "ja_typings": [
-          "tou/no/genso"
+          "tou/no/gensou"
         ]
       },
       {
@@ -85764,7 +86358,8 @@
     "question_text": {
       "en": "Which Tang emperor presided over the early Tang golden age?",
       "ja": "唐初の黄金期を築いた皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85804,7 +86399,8 @@
     "question_text": {
       "en": "Which Sui emperor built the Grand Canal but lost the throne to rebellion?",
       "ja": "大運河を建設したが反乱で帝位を失った隋の皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85844,7 +86440,8 @@
     "question_text": {
       "en": "Which 1689 English document limited royal power and established parliamentary rights?",
       "ja": "1689年に王権を制限し議会の権利を定めたイギリスの文書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85884,7 +86481,8 @@
     "question_text": {
       "en": "Which 1628 English document was drafted by Parliament against Charles I?",
       "ja": "1628年に議会がチャールズ1世に対し起草した文書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85924,7 +86522,8 @@
     "question_text": {
       "en": "Which 1598 French royal edict granted religious tolerance to Huguenots?",
       "ja": "1598年にユグノーに信仰の自由を与えたフランス王令は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -85939,7 +86538,7 @@
         "en": "Saint Helena",
         "ja": "セントヘレナ島",
         "ja_typings": [
-          "sentohelena/tou"
+          "sentoherena/tou"
         ]
       },
       {
@@ -85964,7 +86563,8 @@
     "question_text": {
       "en": "Which Mediterranean island was Napoleon exiled to in 1814?",
       "ja": "1814年にナポレオンが流された地中海の島は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86013,7 +86613,7 @@
         "en": "Uranus",
         "ja": "天王星",
         "ja_typings": [
-          "tennousei"
+          "tennnousei"
         ]
       },
       {
@@ -86045,7 +86645,8 @@
     "question_text": {
       "en": "Which planet is the seventh from the Sun and tilted on its side?",
       "ja": "太陽から7番目の、横倒しに自転する惑星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86126,7 +86727,8 @@
     "question_text": {
       "en": "Which planet is the second from the Sun and the hottest in the solar system?",
       "ja": "太陽から2番目で太陽系で最も高温の惑星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86166,7 +86768,8 @@
     "question_text": {
       "en": "Which human organ filters blood and produces urine?",
       "ja": "血液を濾過し尿を生成する人体の臓器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86206,7 +86809,8 @@
     "question_text": {
       "en": "Which organ stores white blood cells and recycles old red blood cells?",
       "ja": "白血球を蓄え古い赤血球を分解する臓器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86328,7 +86932,8 @@
     "question_text": {
       "en": "Which optical phenomenon describes light bouncing off a surface?",
       "ja": "光が表面で跳ね返る光学現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86368,7 +86973,8 @@
     "question_text": {
       "en": "Which wave phenomenon describes bending around obstacles or through narrow slits?",
       "ja": "障害物や狭い隙間で波が回り込む現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86449,7 +87055,8 @@
     "question_text": {
       "en": "Which unit of pressure equals 100,000 pascals?",
       "ja": "10万パスカルに相当する圧力の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86530,7 +87137,8 @@
     "question_text": {
       "en": "Which atmospheric gas, O3, forms a protective layer in the stratosphere?",
       "ja": "化学式O3で成層圏に保護層を形成する気体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86538,28 +87146,28 @@
         "en": "Hooke's law",
         "ja": "フックの法則",
         "ja_typings": [
-          "fukku/no/housoku"
+          "fukkunohousoku"
         ]
       },
       {
         "en": "Newton's law",
         "ja": "ニュートンの法則",
         "ja_typings": [
-          "nyu-ton/no/housoku"
+          "nyu-tonnnohousoku"
         ]
       },
       {
         "en": "Boyle's law",
         "ja": "ボイルの法則",
         "ja_typings": [
-          "boiru/no/housoku"
+          "boirunohousoku"
         ]
       },
       {
         "en": "Ohm's law",
         "ja": "オームの法則",
         "ja_typings": [
-          "o-mu/no/housoku"
+          "o-munohousoku"
         ]
       }
     ],
@@ -86570,7 +87178,8 @@
     "question_text": {
       "en": "Which physical law states that the force exerted by a spring is proportional to its extension?",
       "ja": "ばねの力が伸びに比例するという物理法則は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86578,7 +87187,7 @@
         "en": "Beaufort scale",
         "ja": "ビューフォート風力階級",
         "ja_typings": [
-          "byu-fo-to/fuuryoku/kaikyuu"
+          "byu-fo-tofuuryokukaikyuu"
         ]
       },
       {
@@ -86592,14 +87201,14 @@
         "en": "Fujita scale",
         "ja": "藤田スケール",
         "ja_typings": [
-          "fujita/suke-ru"
+          "fujitasuke-ru"
         ]
       },
       {
         "en": "Mercalli scale",
         "ja": "メルカリ震度階級",
         "ja_typings": [
-          "merukari/shindo/kaikyuu"
+          "merukarishindokaikyuu"
         ]
       }
     ],
@@ -86610,7 +87219,8 @@
     "question_text": {
       "en": "Which empirical scale measures wind force from 0 to 12?",
       "ja": "0から12までで風力を表す経験的尺度は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86650,7 +87260,8 @@
     "question_text": {
       "en": "Which dwarf planet was reclassified from full planet status in 2006?",
       "ja": "2006年に惑星から準惑星に再分類された天体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86658,14 +87269,14 @@
         "en": "CO2",
         "ja": "二酸化炭素",
         "ja_typings": [
-          "nisanka/tanso"
+          "nisankatanso"
         ]
       },
       {
         "en": "SO2",
         "ja": "二酸化硫黄",
         "ja_typings": [
-          "nisanka/iou"
+          "nisankaiou"
         ]
       },
       {
@@ -86690,7 +87301,8 @@
     "question_text": {
       "en": "Which gas with formula CO2 is a major greenhouse gas exhaled by humans?",
       "ja": "化学式CO2で人間が呼吸で排出する主要な温室効果ガスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86712,7 +87324,7 @@
         "en": "CO2",
         "ja": "二酸化炭素",
         "ja_typings": [
-          "nisanka/tanso"
+          "nisankatanso"
         ]
       },
       {
@@ -86730,7 +87342,8 @@
     "question_text": {
       "en": "Which molecule with formula O2 is essential for human respiration?",
       "ja": "化学式O2で人間の呼吸に不可欠な分子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86745,14 +87358,14 @@
         "en": "CO2",
         "ja": "二酸化炭素",
         "ja_typings": [
-          "nisanka/tanso"
+          "nisankatanso"
         ]
       },
       {
         "en": "SO2",
         "ja": "二酸化硫黄",
         "ja_typings": [
-          "nisanka/iou"
+          "nisankaiou"
         ]
       },
       {
@@ -86770,7 +87383,8 @@
     "question_text": {
       "en": "Which pungent gas with formula NH3 is widely used in fertilizers?",
       "ja": "化学式NH3で肥料に広く用いられる刺激臭の気体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86810,7 +87424,8 @@
     "question_text": {
       "en": "Which element has the chemical symbol Cu?",
       "ja": "化学記号Cuで表される元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -86850,7 +87465,8 @@
     "question_text": {
       "en": "Which element has the chemical symbol Pb?",
       "ja": "化学記号Pbで表される元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87054,7 +87670,8 @@
     "question_text": {
       "en": "Which is the third planet from the Sun?",
       "ja": "太陽から3番目の惑星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87094,7 +87711,8 @@
     "question_text": {
       "en": "Which element has the chemical symbol N?",
       "ja": "化学記号Nで表される元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87134,7 +87752,8 @@
     "question_text": {
       "en": "Which element has the chemical symbol C and is the basis of organic chemistry?",
       "ja": "化学記号Cで有機化学の基礎をなす元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87174,7 +87793,8 @@
     "question_text": {
       "en": "Which element has the chemical symbol H and is the lightest element?",
       "ja": "化学記号Hで最も軽い元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87592,28 +88212,28 @@
         "en": "23",
         "ja": "23対",
         "ja_typings": [
-          "23/tsui"
+          "23tsui"
         ]
       },
       {
         "en": "48",
         "ja": "48対",
         "ja_typings": [
-          "48/tsui"
+          "48tsui"
         ]
       },
       {
         "en": "24",
         "ja": "24対",
         "ja_typings": [
-          "24/tsui"
+          "24tsui"
         ]
       },
       {
         "en": "46",
         "ja": "46対",
         "ja_typings": [
-          "46/tsui"
+          "46tsui"
         ]
       }
     ],
@@ -87624,7 +88244,8 @@
     "question_text": {
       "en": "How many pairs of chromosomes do humans normally have?",
       "ja": "ヒトの染色体は通常何対あるか?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87632,28 +88253,28 @@
         "en": "48",
         "ja": "48本",
         "ja_typings": [
-          "48/hon"
+          "48hon"
         ]
       },
       {
         "en": "23",
         "ja": "23本",
         "ja_typings": [
-          "23/hon"
+          "23hon"
         ]
       },
       {
         "en": "24",
         "ja": "24本",
         "ja_typings": [
-          "24/hon"
+          "24hon"
         ]
       },
       {
         "en": "46",
         "ja": "46本",
         "ja_typings": [
-          "46/hon"
+          "46hon"
         ]
       }
     ],
@@ -87664,7 +88285,8 @@
     "question_text": {
       "en": "How many chromosomes do chimpanzees have in total?",
       "ja": "チンパンジーの染色体は全部で何本あるか?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87672,28 +88294,28 @@
         "en": "24",
         "ja": "24時間",
         "ja_typings": [
-          "24/jikan"
+          "24jikan"
         ]
       },
       {
         "en": "23",
         "ja": "23時間",
         "ja_typings": [
-          "23/jikan"
+          "23jikan"
         ]
       },
       {
         "en": "48",
         "ja": "48時間",
         "ja_typings": [
-          "48/jikan"
+          "48jikan"
         ]
       },
       {
         "en": "12",
         "ja": "12時間",
         "ja_typings": [
-          "12/jikan"
+          "12jikan"
         ]
       }
     ],
@@ -87704,7 +88326,8 @@
     "question_text": {
       "en": "How many hours are in one day?",
       "ja": "1日は何時間か?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87744,7 +88367,8 @@
     "question_text": {
       "en": "Which organ enables breathing by exchanging oxygen and carbon dioxide?",
       "ja": "酸素と二酸化炭素を交換し呼吸を担う臓器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87784,7 +88408,8 @@
     "question_text": {
       "en": "Which organ is the control center of the human nervous system?",
       "ja": "人間の神経系の中枢を担う臓器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87874,28 +88499,28 @@
         "en": "KCl",
         "ja": "塩化カリウム",
         "ja_typings": [
-          "enka/kariumu"
+          "enkakariumu"
         ]
       },
       {
         "en": "NaCl",
         "ja": "塩化ナトリウム",
         "ja_typings": [
-          "enka/natoriumu"
+          "enkanatoriumu"
         ]
       },
       {
         "en": "CaCl2",
         "ja": "塩化カルシウム",
         "ja_typings": [
-          "enka/karushiumu"
+          "enkakarushiumu"
         ]
       },
       {
         "en": "MgCl2",
         "ja": "塩化マグネシウム",
         "ja_typings": [
-          "enka/maguneshiumu"
+          "enkamaguneshiumu"
         ]
       }
     ],
@@ -87906,7 +88531,8 @@
     "question_text": {
       "en": "Which chemical compound with formula KCl is commonly used as a salt substitute?",
       "ja": "化学式KClで塩の代替として使われる化合物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87914,28 +88540,28 @@
         "en": "CaCO3",
         "ja": "炭酸カルシウム",
         "ja_typings": [
-          "tansan/karushiumu"
+          "tansankarushiumu"
         ]
       },
       {
         "en": "CaO",
         "ja": "酸化カルシウム",
         "ja_typings": [
-          "sanka/karushiumu"
+          "sankakarushiumu"
         ]
       },
       {
         "en": "Ca(OH)2",
         "ja": "水酸化カルシウム",
         "ja_typings": [
-          "suisanka/karushiumu"
+          "suisankakarushiumu"
         ]
       },
       {
         "en": "CaSO4",
         "ja": "硫酸カルシウム",
         "ja_typings": [
-          "ryuusan/karushiumu"
+          "ryuusankarushiumu"
         ]
       }
     ],
@@ -87946,7 +88572,8 @@
     "question_text": {
       "en": "Which compound with formula CaCO3 is the main component of limestone?",
       "ja": "化学式CaCO3で石灰岩の主成分である化合物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -87986,7 +88613,8 @@
     "question_text": {
       "en": "Which theorem states that large samples' means tend toward a normal distribution?",
       "ja": "大規模標本の平均が正規分布に近づくとする定理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88190,7 +88818,8 @@
     "question_text": {
       "en": "What do you call a number that can be expressed as a ratio of two integers?",
       "ja": "2つの整数の比で表せる数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88230,7 +88859,8 @@
     "question_text": {
       "en": "If you rotate three-quarters of a full turn, how many degrees is that?",
       "ja": "1回転の4分の3を角度で表すと?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88270,7 +88900,8 @@
     "question_text": {
       "en": "What is the value of 2 divided by 6 as a fraction in lowest terms?",
       "ja": "2÷6を既約分数にすると?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88434,7 +89065,8 @@
     "question_text": {
       "en": "What is the name of a perfectly round 3D figure where all surface points are equidistant from the center?",
       "ja": "中心から表面までの距離がすべて等しい立体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88597,7 +89229,8 @@
     "question_text": {
       "en": "Which theorem proven by Andrew Wiles in 1995 says x^n + y^n = z^n has no positive integer solutions for n > 2?",
       "ja": "1995年にワイルズが証明した、n>2でx^n+y^n=z^nが正整数解を持たないとする定理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88637,7 +89270,8 @@
     "question_text": {
       "en": "Which theorem expands (a+b)^n using combinations?",
       "ja": "(a+b)^nを組合せを使って展開する定理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88923,7 +89557,8 @@
     "question_text": {
       "en": "What do you call a positive integer with more than two divisors?",
       "ja": "約数を3つ以上もつ正の整数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -88963,7 +89598,8 @@
     "question_text": {
       "en": "What do you call a positive integer equal to the sum of its proper divisors, like 6 or 28?",
       "ja": "自分自身を除く約数の和が自分自身に等しい数(6や28)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89003,7 +89639,8 @@
     "question_text": {
       "en": "What do you call the counting numbers 1, 2, 3, ...?",
       "ja": "1, 2, 3, ... のような数え上げの数を何という?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89043,7 +89680,8 @@
     "question_text": {
       "en": "What do you call the set including negative whole numbers, zero, and positive whole numbers?",
       "ja": "負・0・正の整数すべてをまとめた数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89083,7 +89721,8 @@
     "question_text": {
       "en": "Which constant approximately 2.71828 is the base of the natural logarithm?",
       "ja": "自然対数の底となる約2.71828の定数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89123,7 +89762,8 @@
     "question_text": {
       "en": "Which constant approximately 1.618 is often denoted by the Greek letter phi?",
       "ja": "ギリシャ文字ファイで表される約1.618の定数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89163,7 +89803,8 @@
     "question_text": {
       "en": "Which constant approximately equals 3.14159?",
       "ja": "約3.14159となる定数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89203,7 +89844,8 @@
     "question_text": {
       "en": "Which constant approximately 0.5772 appears as the limit difference between harmonic sums and the natural log?",
       "ja": "調和数と自然対数の差の極限として現れる約0.5772の定数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89243,7 +89885,8 @@
     "question_text": {
       "en": "Which ratio approximately 1:1.414 appears in A4 paper sizes?",
       "ja": "A4などのコピー用紙に現れる約1:1.414の比は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89283,7 +89926,8 @@
     "question_text": {
       "en": "Which metallic ratio is the third in the series after golden and silver?",
       "ja": "黄金比、白銀比に続く第3の金属比は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89323,7 +89967,8 @@
     "question_text": {
       "en": "What do you call a ratio related to harmonic means used in music and projective geometry?",
       "ja": "音楽や射影幾何で現れる調和平均に関わる比を何という?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89363,7 +90008,8 @@
     "question_text": {
       "en": "What do you call a sequence where each term differs from the previous by a constant?",
       "ja": "隣り合う項の差が一定の数列は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89403,7 +90049,8 @@
     "question_text": {
       "en": "What do you call a sequence where each term is a constant multiple of the previous one?",
       "ja": "隣り合う項の比が一定の数列は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89443,7 +90090,8 @@
     "question_text": {
       "en": "What do you call a sequence whose reciprocals form an arithmetic progression?",
       "ja": "逆数を取ると等差数列になる数列は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89483,7 +90131,8 @@
     "question_text": {
       "en": "How many degrees is a right angle?",
       "ja": "直角は何度?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89523,7 +90172,8 @@
     "question_text": {
       "en": "What is 4 divided by 6 as a fraction in lowest terms?",
       "ja": "4÷6を既約分数で表すと?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89563,7 +90213,8 @@
     "question_text": {
       "en": "Which set operation symbol represents the union of two sets?",
       "ja": "2つの集合の和集合を表す記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89603,7 +90254,8 @@
     "question_text": {
       "en": "What do you call set A when every element of A is also in set B?",
       "ja": "Aの要素すべてがBに含まれているとき、AはBの何?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89643,7 +90295,8 @@
     "question_text": {
       "en": "Which symbol means 'is an element of'?",
       "ja": "「要素として属する」を表す記号は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89683,7 +90336,8 @@
     "question_text": {
       "en": "What do you call a single number quantity without direction?",
       "ja": "向きを持たず大きさのみの量は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89764,7 +90418,8 @@
     "question_text": {
       "en": "What do you call an ordered list of numbers indexed by natural numbers?",
       "ja": "自然数で順序付けられた数の並びは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -89804,7 +90459,8 @@
     "question_text": {
       "en": "What do you call an unordered collection of distinct objects?",
       "ja": "順序を考えない異なるものの集まりを何という?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90131,7 +90787,8 @@
     "question_text": {
       "en": "Which animal group includes salmon, tuna, and trout?",
       "ja": "サケ・マグロ・マスを含む生き物のグループは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90212,7 +90869,8 @@
     "question_text": {
       "en": "Which language is spoken as the official language of Germany?",
       "ja": "ドイツの公用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90293,7 +90951,8 @@
     "question_text": {
       "en": "In baseball, what is the name of the base that batters aim to return to score?",
       "ja": "野球で打者が戻ってきて得点となるベースは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90415,7 +91074,8 @@
     "question_text": {
       "en": "How long is one half in a standard soccer match?",
       "ja": "サッカーの前半・後半は1つあたり何分?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90455,7 +91115,8 @@
     "question_text": {
       "en": "How long is one quarter in standard NBA basketball?",
       "ja": "NBAの1クォーターは何分?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90495,7 +91156,8 @@
     "question_text": {
       "en": "How long is one period in standard ice hockey?",
       "ja": "アイスホッケーの1ピリオドは何分?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90863,7 +91525,8 @@
     "question_text": {
       "en": "Which trench off the Pacific coast of Tohoku is famous for deep-focus earthquakes?",
       "ja": "東北沖の太平洋にある深発地震で有名な海溝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90903,7 +91566,8 @@
     "question_text": {
       "en": "Which is the deepest trench in the Atlantic Ocean?",
       "ja": "大西洋で最も深い海溝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -90943,7 +91607,8 @@
     "question_text": {
       "en": "Which trench in the South Pacific is the second deepest in the world?",
       "ja": "世界で2番目に深い南太平洋の海溝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91229,7 +91894,8 @@
     "question_text": {
       "en": "Botanically classified as a fruit but commonly used as a vegetable, what red ingredient is essential to ketchup?",
       "ja": "植物学的には果実だが料理では野菜扱いされケチャップの主原料となる赤い食材は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91367,14 +92033,14 @@
         "en": "French Open",
         "ja": "全仏オープン",
         "ja_typings": [
-          "zenbutsuo-pun"
+          "zenfutsuo-pun"
         ]
       },
       {
         "en": "Australian Open",
         "ja": "全豪オープン",
         "ja_typings": [
-          "zengo-oopun"
+          "zengouo-pun"
         ]
       },
       {
@@ -91392,7 +92058,8 @@
     "question_text": {
       "en": "Which Grand Slam tennis tournament is played on grass in London?",
       "ja": "ロンドンの芝コートで開催されるテニスのグランドスラム大会は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91400,7 +92067,7 @@
         "en": "French Open",
         "ja": "全仏オープン",
         "ja_typings": [
-          "zenbutsuo-pun"
+          "zenfutsuo-pun"
         ]
       },
       {
@@ -91414,7 +92081,7 @@
         "en": "Australian Open",
         "ja": "全豪オープン",
         "ja_typings": [
-          "zengo-oopun"
+          "zengouo-pun"
         ]
       },
       {
@@ -91432,7 +92099,8 @@
     "question_text": {
       "en": "Which Grand Slam tennis tournament is played on clay courts in Paris?",
       "ja": "パリのクレーコートで開催されるテニスのグランドスラム大会は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91440,14 +92108,14 @@
         "en": "Australian Open",
         "ja": "全豪オープン",
         "ja_typings": [
-          "zengo-oopun"
+          "zengouo-pun"
         ]
       },
       {
         "en": "French Open",
         "ja": "全仏オープン",
         "ja_typings": [
-          "zenbutsuo-pun"
+          "zenfutsuo-pun"
         ]
       },
       {
@@ -91472,7 +92140,8 @@
     "question_text": {
       "en": "Which Grand Slam tennis tournament is held in Melbourne in January?",
       "ja": "1月にメルボルンで開催されるテニスのグランドスラム大会は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91758,7 +92427,8 @@
     "question_text": {
       "en": "Which early Japanese VTuber was known as the cheerful 'school idol' alongside the original four?",
       "ja": "初期4大VTuberの一人で「未来の学園アイドル」として人気を博したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91798,7 +92468,8 @@
     "question_text": {
       "en": "Which early Japanese VTuber is famous for an energetic Princess Kaguya themed persona?",
       "ja": "かぐや姫をモチーフにした奔放なキャラで知られる初期VTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91838,7 +92509,8 @@
     "question_text": {
       "en": "Which Hololive VTuber is a pirate captain known for the catchphrase 'ahoy'?",
       "ja": "「あほーい」で知られるホロライブの海賊船長は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -91878,7 +92550,8 @@
     "question_text": {
       "en": "Which Plutchik emotion is conveyed by the red angry-face emoji?",
       "ja": "赤い怒り顔の絵文字が表すプルチック基本感情は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92000,7 +92673,8 @@
     "question_text": {
       "en": "Which early VTuber's full name is 'Dennou Shoujo Siro'?",
       "ja": "「電脳少女シロ」のフルネームで知られる初期VTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92122,7 +92796,8 @@
     "question_text": {
       "en": "Which Hololive English Myth member is the detective with the catchphrase 'Watson'?",
       "ja": "ホロライブEN Mythの「探偵」キャラのメンバーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92162,7 +92837,8 @@
     "question_text": {
       "en": "Which Plutchik emotion is conveyed by the crying-face emoji?",
       "ja": "泣き顔の絵文字が表すプルチック基本感情は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92366,7 +93042,8 @@
     "question_text": {
       "en": "Which Japanese chat slang of multiple 'w' characters means laughing hard?",
       "ja": "wを連ねた「wwwww」というネットスラングの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92406,7 +93083,8 @@
     "question_text": {
       "en": "Which Western internet slang means laughing, written as an emoticon with squinted eyes?",
       "ja": "目をつぶった顔文字で笑いを表す英語圏のネットスラングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92446,7 +93124,8 @@
     "question_text": {
       "en": "Which Japanese internet phrase literally meaning 'grass grows' is used to indicate laughter?",
       "ja": "「草が生える」という言葉でネット上の笑いを表す表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92486,7 +93165,8 @@
     "question_text": {
       "en": "Which YouTube monetization feature provides paid subscribers with badges and exclusive perks?",
       "ja": "YouTubeで有料会員にバッジや限定特典を付与する仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92526,7 +93206,8 @@
     "question_text": {
       "en": "What is the general term for sending money to a streamer?",
       "ja": "配信者にお金を送る一般用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92566,7 +93247,8 @@
     "question_text": {
       "en": "Which Japanese slang word for 'Super Chat' on YouTube is used in VTuber chats?",
       "ja": "YouTubeのスーパーチャットをVTuber視聴者が略して呼ぶ言葉は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92606,7 +93288,8 @@
     "question_text": {
       "en": "Which Japanese chat slang abbreviates 'donation/tip'?",
       "ja": "「投げ銭」を意味するチャットスラングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92646,7 +93329,8 @@
     "question_text": {
       "en": "Which Japanese fan slang abbreviates 'members-only stream'?",
       "ja": "「メンバー限定配信」をファンが略す言い方は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92686,7 +93370,8 @@
     "question_text": {
       "en": "Which Japanese word meaning 'limited' is used for members-only or time-limited content?",
       "ja": "メン限や期間限定で使われる「限定」の日本語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92726,7 +93411,8 @@
     "question_text": {
       "en": "Which English abbreviation refers to a recurring paid subscription service?",
       "ja": "月額課金サービスの英語略は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92766,7 +93452,8 @@
     "question_text": {
       "en": "What is the in-app currency name commonly used in mobile games and streaming apps?",
       "ja": "モバイルゲームや配信アプリの基本的なアプリ内通貨の呼び名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92847,7 +93534,8 @@
     "question_text": {
       "en": "Which niconico feature lets viewers shoot a barrage of comments at once?",
       "ja": "ニコニコ動画でコメントを一斉に大量に流す機能は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92887,7 +93575,8 @@
     "question_text": {
       "en": "Which niconico video commenting style scrolls comments from right to left?",
       "ja": "ニコニコ動画でコメントが右から左へ流れる方式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92927,7 +93616,8 @@
     "question_text": {
       "en": "Which general English term refers to live text conversation in a stream?",
       "ja": "ライブ配信で文字会話を行う一般的な英語の名称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -92967,7 +93657,8 @@
     "question_text": {
       "en": "Which VTuber title refers to the head of a student council, used by Shirogane Noel?",
       "ja": "白銀ノエルが使う「会長」を意味するVTuber呼称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93007,7 +93698,8 @@
     "question_text": {
       "en": "Which Japanese title meaning 'group leader' is used as a nickname for Shirogane Noel?",
       "ja": "白銀ノエルの愛称として使われる「団長」を意味する呼称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93047,7 +93739,8 @@
     "question_text": {
       "en": "Which Japanese title meaning 'company president' is used as a nickname for Houshou Marine?",
       "ja": "宝鐘マリンの愛称として使われる「社長」を意味する呼称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93333,7 +94026,8 @@
     "question_text": {
       "en": "Which Hololive English Myth member is themed after a phoenix and known as KFP?",
       "ja": "不死鳥がモチーフでKFPのファン名でも知られるホロライブEN Mythのメンバーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93373,7 +94067,8 @@
     "question_text": {
       "en": "Which Nijisanji VTuber is famous as one of the original gen 1 members and was known as 'Mito-chan'?",
       "ja": "にじさんじ1期生で「ミトちゃん」として親しまれてきたメンバーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93413,7 +94108,8 @@
     "question_text": {
       "en": "Which Nijisanji female VTuber is known for collabs with Honma Himawari as a duo?",
       "ja": "本間ひまわりとのコンビでも知られるにじさんじの女性ライバーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93453,7 +94149,8 @@
     "question_text": {
       "en": "Which Nijisanji VTuber pairs with Sasaki Saku in the 'Saku and Hima' duo?",
       "ja": "「咲ひま」コンビで笹木咲とペアになるにじさんじのメンバーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93493,7 +94190,8 @@
     "question_text": {
       "en": "Which Nijisanji male duo consists of two top streamers known as 'ChroNoiR'?",
       "ja": "「ChroNoiR」として知られるにじさんじのトップ配信者2人組は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93533,7 +94231,8 @@
     "question_text": {
       "en": "Which Nijisanji male duo combines 'Kanae' with the lawyer-themed VTuber?",
       "ja": "叶と弁護士キャラのVTuberが組むにじさんじのコンビは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93573,7 +94272,8 @@
     "question_text": {
       "en": "Which Nijisanji collab pair brings together the vampire-themed Kuzuha and the gen 1 chairperson?",
       "ja": "吸血鬼キャラの葛葉と1期生委員長によるコラボペアは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93613,7 +94313,8 @@
     "question_text": {
       "en": "Which manga and anime by Hajime Isayama features humans fighting giant humanoids?",
       "ja": "諫山創による人類と巨人の戦いを描いた漫画・アニメは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93653,7 +94354,8 @@
     "question_text": {
       "en": "Which long-running Shonen Jump manga features pirates searching for the ultimate treasure?",
       "ja": "海賊たちが究極の財宝を探す週刊少年ジャンプの長編漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93693,7 +94395,8 @@
     "question_text": {
       "en": "Which manga by Koyoharu Gotouge features a boy who joins a corps to slay demons after his family is attacked?",
       "ja": "家族を襲われた少年が鬼を狩る隊に入る、吾峠呼世晴の漫画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93733,7 +94436,8 @@
     "question_text": {
       "en": "Which English chat phrase means 'understood' or 'I see'?",
       "ja": "「了解」「わかった」を意味する英語チャットフレーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93773,7 +94477,8 @@
     "question_text": {
       "en": "Which Japanese script is used mainly for foreign loanwords?",
       "ja": "外来語を表すのに主に使われる日本語の文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93802,7 +94507,7 @@
         "en": "Dravidian",
         "ja": "ドラヴィダ諸語",
         "ja_typings": [
-          "dorabidashogo"
+          "doravidashogo"
         ]
       }
     ],
@@ -93813,7 +94518,8 @@
     "question_text": {
       "en": "Which controversial language family groups Turkic, Mongolic, and Tungusic?",
       "ja": "テュルク・モンゴル・ツングース諸語をまとめる仮説的な語族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93854,7 +94560,8 @@
     "question_text": {
       "en": "Which language has the most native speakers as a global lingua franca?",
       "ja": "世界共通語として最も広く使われている言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93895,7 +94602,8 @@
     "question_text": {
       "en": "Which part of speech connects words or clauses, like 'and' or 'but'?",
       "ja": "「そして」「しかし」のように語句や節をつなぐ品詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93911,8 +94619,7 @@
         "en": "Active voice",
         "ja": "能動態",
         "ja_typings": [
-          "nodoutai",
-          "nodotai"
+          "noudoutai"
         ]
       },
       {
@@ -93938,7 +94645,8 @@
     "question_text": {
       "en": "Which grammatical voice is neither active nor passive (e.g., Ancient Greek)?",
       "ja": "能動でも受動でもない、古典ギリシャ語などにある態は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -93978,7 +94686,8 @@
     "question_text": {
       "en": "Which Romance language is the official language of Italy?",
       "ja": "イタリアの公用語であるロマンス諸語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94019,7 +94728,8 @@
     "question_text": {
       "en": "Which romanization system for Mandarin was widely used before Pinyin?",
       "ja": "ピンイン以前に広く使われた中国語ローマ字表記は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94035,7 +94745,7 @@
         "en": "Metaphor",
         "ja": "隠喩",
         "ja_typings": [
-          "inyu"
+          "innyu"
         ]
       },
       {
@@ -94061,7 +94771,8 @@
     "question_text": {
       "en": "Which rhetorical device juxtaposes contrasting ideas in parallel structure?",
       "ja": "対立する語句を並列に置く修辞技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94092,7 +94803,7 @@
         "en": "Kun-yomi",
         "ja": "訓読み",
         "ja_typings": [
-          "kunyomi"
+          "kunnyomi"
         ]
       }
     ],
@@ -94103,7 +94814,8 @@
     "question_text": {
       "en": "Which Sino-Japanese reading reflects the pronunciation of Tang-era China?",
       "ja": "唐代の中国音を伝える漢字の音読みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94143,7 +94855,8 @@
     "question_text": {
       "en": "Which ancient Semitic script is the ancestor of most modern alphabets?",
       "ja": "現代のアルファベットの祖となった古代セム系文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94183,7 +94896,8 @@
     "question_text": {
       "en": "Which Romance language is co-official in Andorra and parts of Spain?",
       "ja": "アンドラとスペインの一部で公用語となるロマンス語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94223,7 +94937,8 @@
     "question_text": {
       "en": "What name is used for Chinese characters when used in Korean?",
       "ja": "韓国語で使われる漢字の呼称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94231,7 +94946,7 @@
         "en": "Dravidian",
         "ja": "ドラヴィダ語族",
         "ja_typings": [
-          "doravu~idagozoku"
+          "doravidagozoku"
         ]
       },
       {
@@ -94263,7 +94978,8 @@
     "question_text": {
       "en": "Which language family includes Tamil, Telugu, and Malayalam?",
       "ja": "タミル語・テルグ語・マラヤーラム語を含む語族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94304,7 +95020,8 @@
     "question_text": {
       "en": "What is a standardized set of letters used to write a language?",
       "ja": "言語を表記するために標準化された文字の集合は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94320,7 +95037,7 @@
         "en": "consonant cluster",
         "ja": "子音連結",
         "ja_typings": [
-          "shi'inrenketsu"
+          "shiinrenketsu"
         ]
       },
       {
@@ -94345,7 +95062,8 @@
     "question_text": {
       "en": "Which phonological phenomenon (e.g., in Turkish) requires vowels in a word to share features?",
       "ja": "トルコ語などで語内の母音が同じ特徴を持つ現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94387,7 +95105,8 @@
     "question_text": {
       "en": "Which branch of linguistics studies word formation?",
       "ja": "語の形成を研究する言語学の分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94427,7 +95146,8 @@
     "question_text": {
       "en": "What is the smallest unit of sound that distinguishes meaning?",
       "ja": "意味を区別する音声の最小単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94467,7 +95187,8 @@
     "question_text": {
       "en": "What is a unit of pronunciation having one vowel sound?",
       "ja": "母音を1つ含む発音の単位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94509,7 +95230,8 @@
     "question_text": {
       "en": "Which field studies the physical sounds of human speech?",
       "ja": "人間の言語音の物理的性質を扱う分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94551,7 +95273,8 @@
     "question_text": {
       "en": "What is the study of writing systems and their units?",
       "ja": "文字体系とその単位を研究する分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94591,7 +95314,8 @@
     "question_text": {
       "en": "Which script is used to write modern Standard Arabic?",
       "ja": "現代標準アラビア語を書くための文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94631,7 +95355,8 @@
     "question_text": {
       "en": "Which alphabet is used to write modern Greek?",
       "ja": "現代ギリシャ語を書くアルファベットは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94671,7 +95396,8 @@
     "question_text": {
       "en": "Which script is used to write modern Hebrew?",
       "ja": "現代ヘブライ語を書く文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94711,7 +95437,8 @@
     "question_text": {
       "en": "In which direction is English written?",
       "ja": "英語の文字を書く方向は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94751,7 +95478,8 @@
     "question_text": {
       "en": "In which direction is traditional vertical Japanese text read?",
       "ja": "日本語の伝統的な縦書きの読む方向は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94791,7 +95519,8 @@
     "question_text": {
       "en": "Which writing direction is used by Mongolian traditional script?",
       "ja": "モンゴル伝統文字の書字方向は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94833,7 +95562,8 @@
     "question_text": {
       "en": "Which part of speech modifies a noun, like 'red' or 'tall'?",
       "ja": "「赤い」「高い」のように名詞を修飾する品詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94874,7 +95604,8 @@
     "question_text": {
       "en": "In Japanese grammar, what part of speech only modifies nouns (e.g., kono, sono)?",
       "ja": "「この」「その」のように名詞だけを修飾する日本語の品詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94915,7 +95646,8 @@
     "question_text": {
       "en": "Which part of speech expresses emotion (e.g., 'oh!', 'wow!')?",
       "ja": "「あっ」「おお」のように感動を表す品詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94956,7 +95688,8 @@
     "question_text": {
       "en": "Which part of speech replaces a noun (e.g., 'he', 'she', 'it')?",
       "ja": "名詞の代わりに使われる品詞 (例: 彼、それ) は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -94997,7 +95730,8 @@
     "question_text": {
       "en": "What is Japanese honorific 'o-' / 'go-' prefix style called?",
       "ja": "日本語で「お」「ご」を付けて言葉を整える表現の名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95038,7 +95772,8 @@
     "question_text": {
       "en": "Which register of speech is used in informal conversation?",
       "ja": "日常会話で用いられる、くだけた言葉遣いは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95080,7 +95815,8 @@
     "question_text": {
       "en": "Which Japanese style is used in official documents and speeches?",
       "ja": "公的な文書や演説で用いられる日本語の文体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95122,7 +95858,8 @@
     "question_text": {
       "en": "What is the process of forming a new word by adding affixes?",
       "ja": "接辞を付けて新しい語を作る過程は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95164,7 +95901,8 @@
     "question_text": {
       "en": "What is the modification of a word to express grammatical features?",
       "ja": "語の文法的特徴を表すための変化は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95205,7 +95943,8 @@
     "question_text": {
       "en": "What is a diachronic change in pronunciation of a language called?",
       "ja": "時間とともに起こる言語の発音変化は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95246,7 +95985,8 @@
     "question_text": {
       "en": "What is the doubling of a consonant sound called (e.g., Japanese sokuon)?",
       "ja": "促音のように子音が重なる現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95289,7 +96029,8 @@
     "question_text": {
       "en": "What term refers to a vowel changing across related forms (e.g., sing/sang)?",
       "ja": "関連する語形で母音が変化する現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95330,7 +96071,8 @@
     "question_text": {
       "en": "What is the historical sound change in Japanese where word-internal sounds change for ease?",
       "ja": "日本語で発音が変化する音便現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95345,14 +96087,14 @@
         "en": "I-onbin",
         "ja": "イ音便",
         "ja_typings": [
-          "i-onbin"
+          "ionbin"
         ]
       },
       {
         "en": "U-onbin",
         "ja": "ウ音便",
         "ja_typings": [
-          "u-onbin"
+          "uonbin"
         ]
       },
       {
@@ -95370,7 +96112,8 @@
     "question_text": {
       "en": "Which Japanese sound change turns a consonant into a nasal (e.g., 'shinde')?",
       "ja": "日本語で子音が撥音に変化する音便は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95411,7 +96154,8 @@
     "question_text": {
       "en": "Which Japanese sandhi merges a final n with a following vowel (e.g., han'nou)?",
       "ja": "撥音が後続母音と結びついて生じる日本語の連音現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95455,7 +96199,8 @@
     "question_text": {
       "en": "Which grammatical aspect expresses completed action with present relevance?",
       "ja": "完了して現在に影響が残ることを示す相は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95496,7 +96241,8 @@
     "question_text": {
       "en": "Which tense refers to actions that already happened?",
       "ja": "すでに起こった出来事を示す時制は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95537,7 +96283,8 @@
     "question_text": {
       "en": "Which tense refers to actions yet to happen?",
       "ja": "これから起こる出来事を示す時制は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95579,7 +96326,8 @@
     "question_text": {
       "en": "Which grammatical category describes the flow of time within an action?",
       "ja": "動作の時間的な流れ方を表す文法カテゴリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95621,7 +96369,8 @@
     "question_text": {
       "en": "Which grammatical category distinguishes active and passive?",
       "ja": "能動と受動を区別する文法カテゴリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95663,7 +96412,8 @@
     "question_text": {
       "en": "Which grammatical category expresses attitude (e.g., command, wish)?",
       "ja": "話者の心的態度 (命令・願望など) を表す文法カテゴリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95704,7 +96454,8 @@
     "question_text": {
       "en": "Which Japanese verb form expresses 'can do' (e.g., yomeru)?",
       "ja": "「読める」のように「〜できる」を表す日本語の動詞形は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95744,7 +96495,8 @@
     "question_text": {
       "en": "Which language is the official language of France?",
       "ja": "フランスの公用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95784,7 +96536,8 @@
     "question_text": {
       "en": "Which language is the official language of the Netherlands?",
       "ja": "オランダの公用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -95865,7 +96618,8 @@
     "question_text": {
       "en": "Which Mexican Christmas tradition reenacts Mary and Joseph seeking lodging?",
       "ja": "メキシコでマリアとヨセフの宿探しを再現するクリスマス行事は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96153,7 +96907,8 @@
     "question_text": {
       "en": "Who is the most important playwright and theorist of Noh theatre?",
       "ja": "能の大成者として最も知られる劇作家・理論家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96194,7 +96949,8 @@
     "question_text": {
       "en": "Who is the master of haiku famous for 'Oku no Hosomichi'?",
       "ja": "『奥の細道』で知られる俳諧の巨匠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96238,7 +96994,8 @@
     "question_text": {
       "en": "Which Muromachi-era ink painter is known for landscapes like 'Long Landscape Scroll'?",
       "ja": "『山水長巻』で知られる室町時代の水墨画家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96335,7 +97092,7 @@
         "en": "Venice Film Festival",
         "ja": "ヴェネツィア国際映画祭",
         "ja_typings": [
-          "vu~enetsiakokusaieigasai"
+          "venetsiakokusaieigasai"
         ]
       },
       {
@@ -96360,7 +97117,8 @@
     "question_text": {
       "en": "Which French film festival awards the Palme d'Or?",
       "ja": "パルム・ドールを授与するフランスの映画祭は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96484,7 +97242,8 @@
     "question_text": {
       "en": "Which masked Japanese musical drama dates from the 14th century?",
       "ja": "14世紀から続く面を着けた日本の歌舞演劇は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96526,7 +97285,8 @@
     "question_text": {
       "en": "Which Japanese traditional puppet theatre uses three puppeteers per puppet?",
       "ja": "1体の人形を3人で操る日本の伝統人形劇は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96567,7 +97327,8 @@
     "question_text": {
       "en": "Which Japanese comic theatre is performed between Noh plays?",
       "ja": "能の演目の合間に上演される滑稽な日本の演劇は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96896,7 +97657,8 @@
     "question_text": {
       "en": "Which Chinese festival celebrates the harvest with mooncakes?",
       "ja": "月餅を食べて収穫を祝う中国の祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96938,7 +97700,8 @@
     "question_text": {
       "en": "Which Chinese festival features dragon boat races and zongzi?",
       "ja": "ドラゴンボートレースと粽が伝統の中国の祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -96980,7 +97743,8 @@
     "question_text": {
       "en": "Which Chinese festival is the tomb-sweeping day in early April?",
       "ja": "4月初旬に行われる墓参りの中国の祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97475,7 +98239,8 @@
     "question_text": {
       "en": "Which Paris Gothic cathedral has flying buttresses and famous gargoyles?",
       "ja": "フライング・バットレスとガーゴイルで有名なパリのゴシック大聖堂は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97519,7 +98284,8 @@
     "question_text": {
       "en": "Which German Gothic cathedral is the largest in northern Europe?",
       "ja": "北ヨーロッパ最大のゴシック大聖堂であるドイツの教会は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97563,7 +98329,8 @@
     "question_text": {
       "en": "Which Italian Gothic cathedral has more than 3,000 statues on its facade?",
       "ja": "3000体以上の彫像が並ぶイタリアのゴシック大聖堂は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97607,7 +98374,8 @@
     "question_text": {
       "en": "Which avant-garde school of ikebana was founded in 1927 by Teshigahara?",
       "ja": "1927年に勅使河原蒼風が創始したいけばなの流派は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97651,7 +98419,8 @@
     "question_text": {
       "en": "Which ikebana school pioneered the moribana shallow-container style?",
       "ja": "盛花を考案したいけばなの流派は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97695,7 +98464,8 @@
     "question_text": {
       "en": "Which ikebana school traces its origin to Emperor Saga at Daikaku-ji?",
       "ja": "嵯峨天皇と大覚寺に由来するいけばなの流派は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97776,7 +98546,8 @@
     "question_text": {
       "en": "Which is the holiest day of the Jewish year, the Day of Atonement?",
       "ja": "ユダヤ教で最も神聖な「贖罪の日」は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -97816,7 +98587,8 @@
     "question_text": {
       "en": "Which Jewish festival of lights lasts eight nights?",
       "ja": "8日間ろうそくを灯すユダヤ教の光の祭は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101022,7 +101794,8 @@
     "question_text": {
       "en": "Which portable storage device uses NAND flash and USB?",
       "ja": "NAND フラッシュと USB を使う携帯型ストレージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101062,7 +101835,8 @@
     "question_text": {
       "en": "Which storage uses lasers to read pits (e.g., CD, DVD)?",
       "ja": "レーザーでピットを読み取る光学記憶媒体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101431,7 +102205,8 @@
     "question_text": {
       "en": "Which medium carries data as light pulses through glass strands?",
       "ja": "ガラス繊維を通る光パルスでデータを伝える媒体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101660,7 +102435,7 @@
         "en": "Hash function",
         "ja": "ハッシュ関数",
         "ja_typings": [
-          "hasshukansu-"
+          "hasshukansuu"
         ]
       },
       {
@@ -101679,7 +102454,8 @@
     "question_text": {
       "en": "Which class of cryptography uses one shared key for encrypt and decrypt?",
       "ja": "暗号化と復号に同じ鍵を使う暗号方式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101720,7 +102496,8 @@
     "question_text": {
       "en": "Which technique hides messages inside other media (e.g., images)?",
       "ja": "画像などに情報を隠す技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101825,7 +102602,7 @@
         "en": "Hash function",
         "ja": "ハッシュ関数",
         "ja_typings": [
-          "hasshukansu-"
+          "hasshukansuu"
         ]
       },
       {
@@ -101843,7 +102620,8 @@
     "question_text": {
       "en": "Which kind of algorithm reduces data size for storage or transmission?",
       "ja": "保存や伝送のためにデータサイズを小さくするアルゴリズムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101858,7 +102636,7 @@
         "en": "Hash function",
         "ja": "ハッシュ関数",
         "ja_typings": [
-          "hasshukansu-"
+          "hasshukansuu"
         ]
       },
       {
@@ -101884,7 +102662,8 @@
     "question_text": {
       "en": "Which cryptographic technique proves message authenticity using a key pair?",
       "ja": "鍵ペアを用いてメッセージの真正性を証明する技術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -101900,7 +102679,7 @@
         "en": "Hash function",
         "ja": "ハッシュ関数",
         "ja_typings": [
-          "hasshukansu-"
+          "hasshukansuu"
         ]
       },
       {
@@ -101926,7 +102705,8 @@
     "question_text": {
       "en": "Which component produces sequences for cryptography and simulations?",
       "ja": "暗号やシミュレーションに使う列を生成する装置は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102011,7 +102791,8 @@
     "question_text": {
       "en": "Which river in South America has one of the largest drainage basins in the world?",
       "ja": "南米大陸を流れる世界最大級の流域面積を持つ川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102051,7 +102832,8 @@
     "question_text": {
       "en": "Which is the northernmost ocean on Earth?",
       "ja": "地球で最も北に位置する海洋は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102091,7 +102873,8 @@
     "question_text": {
       "en": "Which Hokkaido city is located in the Kamikawa Basin near the center of the island?",
       "ja": "北海道のほぼ中央にあり、上川盆地に位置する都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102213,7 +102996,8 @@
     "question_text": {
       "en": "Which ocean lies between Europe and the Americas?",
       "ja": "ヨーロッパとアメリカ大陸の間に広がる海洋は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102253,7 +103037,8 @@
     "question_text": {
       "en": "Which mountain range stretches across North Africa?",
       "ja": "北アフリカを横断する大山脈は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102461,7 +103246,8 @@
     "question_text": {
       "en": "Which is the third largest island in the world, located in Southeast Asia?",
       "ja": "東南アジアにある世界で3番目に大きい島は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102706,7 +103492,8 @@
     "question_text": {
       "en": "Baku, the capital of Azerbaijan, is located on which shore?",
       "ja": "アゼルバイジャンのバクーがあるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -102721,7 +103508,7 @@
         "en": "Ural Mountains",
         "ja": "ウラル山脈",
         "ja_typings": [
-          "ururusanmyaku"
+          "urarusanmyaku"
         ]
       },
       {
@@ -102746,7 +103533,8 @@
     "question_text": {
       "en": "Which mountain range lies between the Black Sea and the Caspian Sea?",
       "ja": "黒海とカスピ海の間に広がる山脈は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103073,7 +103861,8 @@
     "question_text": {
       "en": "Which Okinawan city is known for hosting many U.S. military bases?",
       "ja": "沖縄本島中部の都市で米軍基地が多いことで知られるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103156,7 +103945,8 @@
     "question_text": {
       "en": "Which is the world's largest island, an autonomous territory of Denmark?",
       "ja": "世界最大の島でデンマーク自治領なのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103237,7 +104027,8 @@
     "question_text": {
       "en": "Which Hokkaido port town is famous for its night view?",
       "ja": "北海道南部にある夜景が有名な港町は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103400,7 +104191,8 @@
     "question_text": {
       "en": "Which Special Administrative Region of southern China is a major financial hub?",
       "ja": "中国南部にある特別行政区で金融センターとして知られる都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103563,7 +104355,8 @@
     "question_text": {
       "en": "Which ocean lies between Africa and Australia?",
       "ja": "アフリカとオーストラリアの間に広がる海洋は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103604,7 +104397,8 @@
     "question_text": {
       "en": "Which is the main island of the Yaeyama Islands?",
       "ja": "八重山諸島の中心の島は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103648,7 +104442,8 @@
     "question_text": {
       "en": "Which is the longest river in Hokkaido?",
       "ja": "北海道で最長の川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103770,7 +104565,8 @@
     "question_text": {
       "en": "Which desert covers much of southern Africa?",
       "ja": "南部アフリカに広がる砂漠は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103811,7 +104607,8 @@
     "question_text": {
       "en": "Which bridge spans the Kanmon Strait between Honshu and Kyushu?",
       "ja": "本州と九州を結ぶ関門海峡にかかる橋は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103892,7 +104689,8 @@
     "question_text": {
       "en": "Which port town in eastern Hokkaido is famous for its fog?",
       "ja": "北海道道東にある霧で有名な港町は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103932,7 +104730,8 @@
     "question_text": {
       "en": "Which lake in Djibouti is the lowest point on land?",
       "ja": "ジブチにある世界で最も標高の低い湖は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -103972,7 +104771,8 @@
     "question_text": {
       "en": "Which Fukushima lake is the fourth largest in Japan?",
       "ja": "福島県にある日本で4番目に大きい湖は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104012,7 +104812,8 @@
     "question_text": {
       "en": "Which Ibaraki lake is the second largest in Japan?",
       "ja": "茨城県にある日本で2番目に大きい湖は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104052,7 +104853,8 @@
     "question_text": {
       "en": "Which is Japan's largest brackish lake, on Hokkaido's Sea of Okhotsk coast?",
       "ja": "北海道東部のオホーツク海に面した日本最大の汽水湖は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104176,7 +104978,8 @@
     "question_text": {
       "en": "Which is the fourth largest island in the world, off southeastern Africa?",
       "ja": "アフリカ南東沖にある世界で4番目に大きい島は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104380,7 +105183,8 @@
     "question_text": {
       "en": "Tel Aviv and Beirut both face which coastal region?",
       "ja": "イスラエルのテルアビブやレバノンのベイルートが面しているのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104465,7 +105269,8 @@
     "question_text": {
       "en": "Which great river runs north-south through the central United States?",
       "ja": "アメリカ中部を南北に貫く大河は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104628,7 +105433,8 @@
     "question_text": {
       "en": "Which Northern Japan Alps peak rises to 3190 meters?",
       "ja": "北アルプスにある標高3190mの山は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104668,7 +105474,8 @@
     "question_text": {
       "en": "Which is Africa's highest mountain, located in Tanzania?",
       "ja": "タンザニアにあるアフリカ最高峰は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104708,7 +105515,8 @@
     "question_text": {
       "en": "Which Southern Japan Alps peak is Japan's second highest at 3193 meters?",
       "ja": "南アルプスにある標高3193mで日本第2位の高峰は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104748,7 +105556,8 @@
     "question_text": {
       "en": "Which is the former name of North America's highest peak in Alaska?",
       "ja": "アラスカにある北米最高峰の旧称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104788,7 +105597,8 @@
     "question_text": {
       "en": "Which mountain range lies on the border between Uganda and DR Congo?",
       "ja": "ウガンダとコンゴ民主共和国の国境にある山は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104828,7 +105638,8 @@
     "question_text": {
       "en": "Which Northern Japan Alps peak is famous for its spear-like summit?",
       "ja": "北アルプスの槍状の山頂で知られる山は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104950,7 +105761,8 @@
     "question_text": {
       "en": "Which is the central city of northern Okinawa Island?",
       "ja": "沖縄本島北部の中心都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -104990,7 +105802,8 @@
     "question_text": {
       "en": "Which former Chinese capital lies on the lower Yangtze River?",
       "ja": "中国の旧首都で長江下流域にある都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105115,7 +105928,8 @@
     "question_text": {
       "en": "Which is the world's second largest island, split between Indonesia and Papua New Guinea?",
       "ja": "世界第2位の大きさを持つ島でインドネシアとパプアニューギニアに分かれているのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105294,7 +106108,7 @@
         "en": "Tokyo Bay Aqua-Line",
         "ja": "東京湾アクアライン",
         "ja_typings": [
-          "toukyouwanakurarain"
+          "toukyouwanakuarain"
         ]
       },
       {
@@ -105320,7 +106134,8 @@
     "question_text": {
       "en": "Which bridge connects Odaiba and Shibaura over Tokyo Bay?",
       "ja": "東京湾のお台場と芝浦を結ぶ橋は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105606,7 +106421,8 @@
     "question_text": {
       "en": "Which is China's largest city, located at the mouth of the Yangtze?",
       "ja": "中国最大の都市で長江河口の港湾都市は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105646,7 +106462,8 @@
     "question_text": {
       "en": "Which vast region covers eastern Russia?",
       "ja": "ロシア東部に広がる広大な地域は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105686,7 +106503,8 @@
     "question_text": {
       "en": "Which country at Africa's southern tip is home to Cape Town?",
       "ja": "ケープタウンを擁するアフリカ大陸南端の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105726,7 +106544,8 @@
     "question_text": {
       "en": "Which continent includes Brazil and Argentina?",
       "ja": "ブラジルやアルゼンチンを含む大陸は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105811,7 +106630,8 @@
     "question_text": {
       "en": "Which river flows from Nagano through Shizuoka into Enshu-nada Sea?",
       "ja": "長野県・静岡県を流れて遠州灘に注ぐ川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105901,7 +106721,7 @@
         "en": "Tokyo Bay Aqua-Line",
         "ja": "東京湾アクアライン",
         "ja_typings": [
-          "toukyouwanakurarain"
+          "toukyouwanakuarain"
         ]
       },
       {
@@ -105934,7 +106754,8 @@
     "question_text": {
       "en": "Which highway crosses Tokyo Bay between Tokyo area and Kanagawa?",
       "ja": "東京と神奈川を結ぶ東京湾を横断する道路は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -105978,7 +106799,8 @@
     "question_text": {
       "en": "Which Kanto Plain river has Japan's largest drainage basin?",
       "ja": "関東平野を流れる日本最大の流域面積を持つ川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106048,7 +106870,7 @@
         "en": "Qaidam Basin",
         "ja": "ツァイダム盆地",
         "ja_typings": [
-          "tsuaidamubonchi"
+          "tsaidamubonchi"
         ]
       }
     ],
@@ -106059,7 +106881,8 @@
     "question_text": {
       "en": "Which depression in China's Xinjiang region is the country's lowest point?",
       "ja": "中国新疆ウイグル自治区にある中国で最も低い場所は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106389,7 +107212,8 @@
     "question_text": {
       "en": "Which is Asia's longest river, flowing through China?",
       "ja": "中国を流れるアジア最長の川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106593,7 +107417,8 @@
     "question_text": {
       "en": "How many distinct values can be represented with 8 bits?",
       "ja": "8ビット整数で表現できる値の総数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106920,7 +107745,8 @@
     "question_text": {
       "en": "Which low-level language directly represents CPU instructions?",
       "ja": "CPUの命令を直接表現する低水準言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -106960,7 +107786,8 @@
     "question_text": {
       "en": "What is the operation of setting a value into a variable called?",
       "ja": "プログラミングで変数に値を入れる操作は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107000,7 +107827,8 @@
     "question_text": {
       "en": "Which profiling metric shows the average number of times a function ran?",
       "ja": "プロファイラで関数の平均実行回数を示す指標は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107040,7 +107868,8 @@
     "question_text": {
       "en": "Which graph traversal explores all neighbors level by level?",
       "ja": "グラフ探索で全方向に広く探索する手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107244,7 +108073,8 @@
     "question_text": {
       "en": "Which bitwise operation returns 1 if either bit is 1?",
       "ja": "ビット単位で「どちらかが1なら1」を取る演算は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107448,7 +108278,8 @@
     "question_text": {
       "en": "Which structured language was developed on UNIX in the 1970s?",
       "ja": "UNIX上で生まれた構造化プログラミング言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107529,7 +108360,8 @@
     "question_text": {
       "en": "Which programming language was designed in 1959 for business processing?",
       "ja": "事務処理用に1959年に作られた言語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107692,7 +108524,8 @@
     "question_text": {
       "en": "What category does HTTP 4xx status code belong to?",
       "ja": "HTTPの4xx系ステータスコードが意味するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107773,7 +108606,8 @@
     "question_text": {
       "en": "Which graph traversal explores as deep as possible first?",
       "ja": "グラフ探索でできるだけ深く進むのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -107899,7 +108733,8 @@
     "question_text": {
       "en": "Which numeral system uses digits 0 through 9?",
       "ja": "0から9までの記号を使う数値表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108021,7 +108856,8 @@
     "question_text": {
       "en": "Which term describes a language whose types are determined at runtime?",
       "ja": "実行時に型が決まる言語の性質を表す語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108061,7 +108897,8 @@
     "question_text": {
       "en": "Which OOP concept hides internal state and exposes a public interface?",
       "ja": "オブジェクト指向で内部状態を隠す概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108470,7 +109307,8 @@
     "question_text": {
       "en": "Which data structure represents relations with nodes and edges?",
       "ja": "ノードとエッジで関係を表すデータ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108637,7 +109475,8 @@
     "question_text": {
       "en": "Which numeral system uses digits 0-9 and A-F?",
       "ja": "0からF までの記号を使う数値表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108718,7 +109557,8 @@
     "question_text": {
       "en": "Which term describes objects that cannot be modified after creation?",
       "ja": "一度作ったら変更できない性質を表す語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108815,7 +109655,7 @@
         "en": "It indicates return values",
         "ja": "戻り値を表す",
         "ja_typings": [
-          "modoriatewohyousu"
+          "modorichiwohyousu"
         ]
       },
       {
@@ -108840,7 +109680,8 @@
     "question_text": {
       "en": "What does the `#` symbol indicate in Python?",
       "ja": "Pythonで `#` 記号の役割は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108848,7 +109689,7 @@
         "en": "It indicates return values",
         "ja": "戻り値を表す",
         "ja_typings": [
-          "modoriatewohyousu"
+          "modorichiwohyousu"
         ]
       },
       {
@@ -108880,7 +109721,8 @@
     "question_text": {
       "en": "What does the `->` arrow indicate in a function signature?",
       "ja": "関数定義で `->` 記号が示すのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -108902,7 +109744,7 @@
         "en": "It indicates return values",
         "ja": "戻り値を表す",
         "ja_typings": [
-          "modoriatewohyousu"
+          "modorichiwohyousu"
         ]
       },
       {
@@ -108920,7 +109762,8 @@
     "question_text": {
       "en": "What does the `:` colon indicate in TypeScript annotations like `: number`?",
       "ja": "TypeScriptで `: number` のように書く記号 `:` の役割は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109329,7 +110172,8 @@
     "question_text": {
       "en": "Which logical operation returns true only when both operands are true?",
       "ja": "ビット単位で「両方1のときだけ1」を取る演算の論理版は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109451,7 +110295,8 @@
     "question_text": {
       "en": "Which form of instructions is directly executed by the CPU?",
       "ja": "CPUが直接実行できるバイナリ表現の命令は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109507,7 +110352,7 @@
         "en": "Segmentation Fault",
         "ja": "セグメンテーション違反",
         "ja_typings": [
-          "segumente-shonihan"
+          "segumente-shonnihan"
         ]
       },
       {
@@ -109532,7 +110377,8 @@
     "question_text": {
       "en": "Which bug refers to memory that is never released?",
       "ja": "解放されないメモリが蓄積する不具合は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109572,7 +110418,8 @@
     "question_text": {
       "en": "Which profiling metric shows how much memory the program uses?",
       "ja": "プロファイラで「メモリの使用量」を示す指標は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -109601,7 +110448,7 @@
         "en": "Insertion Sort",
         "ja": "挿入ソート",
         "ja_typings": [
-          "so-nyuuso-to"
+          "sounyuuso-to"
         ]
       }
     ],
@@ -109612,7 +110459,8 @@
     "question_text": {
       "en": "Which divide-and-conquer stable sort guarantees O(n log n)?",
       "ja": "分割統治法による安定ソートでO(n log n)を保証するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110107,7 +110955,8 @@
     "question_text": {
       "en": "Which numeral system uses digits 0-7?",
       "ja": "0から7までの数字で表す進数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110352,7 +111201,8 @@
     "question_text": {
       "en": "Which OOP concept lets one interface serve many implementations?",
       "ja": "オブジェクト指向で同じインタフェースで多様な振る舞いをする概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110515,7 +111365,8 @@
     "question_text": {
       "en": "Which data structure follows FIFO (first-in, first-out)?",
       "ja": "FIFO方式で出し入れするデータ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110596,7 +111447,8 @@
     "question_text": {
       "en": "What is the meaning of the HTTP 3xx status family?",
       "ja": "HTTPで別URLに転送することを表す3xx系の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110768,7 +111620,7 @@
         "en": "Segmentation Fault",
         "ja": "セグメンテーション違反",
         "ja_typings": [
-          "segumente-shonihan"
+          "segumente-shonnihan"
         ]
       },
       {
@@ -110800,7 +111652,8 @@
     "question_text": {
       "en": "Which error is typically caused by invalid memory access?",
       "ja": "不正なメモリアクセスで発生する典型的なエラーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110922,7 +111775,8 @@
     "question_text": {
       "en": "Which file maps minified code back to the original source?",
       "ja": "ミニファイされたコードと元のコードを対応付けるファイルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110962,7 +111816,8 @@
     "question_text": {
       "en": "Which data structure follows LIFO (last-in, first-out)?",
       "ja": "LIFO方式で出し入れするデータ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -110984,7 +111839,7 @@
         "en": "Segmentation Fault",
         "ja": "セグメンテーション違反",
         "ja_typings": [
-          "segumente-shonihan"
+          "segumente-shonnihan"
         ]
       },
       {
@@ -111002,7 +111857,8 @@
     "question_text": {
       "en": "Which error occurs when the call stack exceeds its limit?",
       "ja": "スタック領域が溢れたときに起きるエラーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111042,7 +111898,8 @@
     "question_text": {
       "en": "Which term describes a language whose types are checked at compile time?",
       "ja": "コンパイル時に型が決まる言語の性質を表す語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111082,7 +111939,8 @@
     "question_text": {
       "en": "What is the meaning of the HTTP 2xx status family?",
       "ja": "HTTPの2xx系ステータスコードのカテゴリ名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -111286,7 +112144,8 @@
     "question_text": {
       "en": "Which data structure represents hierarchical relations with nodes and branches?",
       "ja": "節点と枝で階層構造を表すデータ構造は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112187,7 +113046,8 @@
     "question_text": {
       "en": "Which HTTP status family message says credentials are required?",
       "ja": "認証情報が必要であることを示す HTTP メッセージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112268,7 +113128,8 @@
     "question_text": {
       "en": "Which scheme sends username:password Base64-encoded in HTTP headers?",
       "ja": "ユーザー名とパスワードを Base64 で送る HTTP 認証方式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112317,14 +113178,14 @@
         "en": "Built on UDP",
         "ja": "UDP上に構築",
         "ja_typings": [
-          "udpjounikoutiku"
+          "udpjounikouchiku"
         ]
       },
       {
         "en": "Built on TCP",
         "ja": "TCP上に構築",
         "ja_typings": [
-          "tcpjounikoutiku"
+          "tcpjounikouchiku"
         ]
       },
       {
@@ -112349,7 +113210,8 @@
     "question_text": {
       "en": "Which phrase describes the QUIC protocol's transport choice?",
       "ja": "QUIC プロトコルのトランスポート選択を表す表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112553,7 +113415,8 @@
     "question_text": {
       "en": "What collective name describes libraries like Bootstrap and Tailwind?",
       "ja": "Bootstrap や Tailwind のようなライブラリ群の総称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -112839,7 +113702,8 @@
     "question_text": {
       "en": "Which authentication scheme hashes credentials with a server nonce?",
       "ja": "サーバーのノンスで資格情報をハッシュ化する認証方式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113043,7 +113907,8 @@
     "question_text": {
       "en": "Which HTTP status message says the server refuses to authorize the request?",
       "ja": "サーバーが認可を拒否することを示す HTTP メッセージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113288,7 +114153,8 @@
     "question_text": {
       "en": "Which HTTP status message indicates an unexpected server-side failure?",
       "ja": "サーバー側で予期しない失敗が起きたことを示す HTTP メッセージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113533,7 +114399,8 @@
     "question_text": {
       "en": "Which technique keeps an HTTP request open until the server has data?",
       "ja": "サーバーにデータが届くまで HTTP リクエストを開いたままにする手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -113589,14 +114456,14 @@
         "en": "Optional encryption",
         "ja": "暗号化任意",
         "ja_typings": [
-          "angoukanin'i"
+          "angoukaninni"
         ]
       },
       {
         "en": "Built on UDP",
         "ja": "UDP上に構築",
         "ja_typings": [
-          "udpjounikoutiku"
+          "udpjounikouchiku"
         ]
       },
       {
@@ -113614,7 +114481,8 @@
     "question_text": {
       "en": "Which phrase describes HTTPS being required with no plaintext fallback?",
       "ja": "平文へのフォールバックなしに HTTPS を必須とする方針を表す表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114064,7 +114932,8 @@
     "question_text": {
       "en": "Which HTTP status message says the request was processed successfully?",
       "ja": "リクエストが正常に処理されたことを示す HTTP メッセージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114104,7 +114973,8 @@
     "question_text": {
       "en": "Which HTTP status message indicates the URL has no matching resource?",
       "ja": "URL に該当するリソースが無いことを示す HTTP メッセージは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114432,7 +115302,8 @@
     "question_text": {
       "en": "Which attack steals or reuses a valid user session token?",
       "ja": "正規のセッショントークンを盗んだり再利用する攻撃は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -114741,7 +115612,7 @@
         "en": "Built on UDP",
         "ja": "UDP上に構築",
         "ja_typings": [
-          "udpjounikoutiku"
+          "udpjounikouchiku"
         ]
       },
       {
@@ -114759,7 +115630,8 @@
     "question_text": {
       "en": "Which phrase describes HTTP/1.1 as human-readable on the wire?",
       "ja": "HTTP/1.1 が人間可読な形式で送られることを表す表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116152,7 +117024,8 @@
     "question_text": {
       "en": "Which Public Safety Devil Hunter partners with Denji in Chainsaw Man?",
       "ja": "チェンソーマンでデンジと組む公安のデビルハンターは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116193,7 +117066,8 @@
     "question_text": {
       "en": "Which veteran voice actor is known for Ryo Saeba in City Hunter?",
       "ja": "シティーハンターの冴羽獠を演じたベテラン声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116365,7 +117239,7 @@
         "en": "Asuka Langley Soryu",
         "ja": "惣流・アスカ・ラングレー",
         "ja_typings": [
-          "souryuuasukarangure-"
+          "souryuu/asuka/rangure-"
         ]
       },
       {
@@ -116379,7 +117253,7 @@
         "en": "Mari Makinami",
         "ja": "真希波・マリ",
         "ja_typings": [
-          "makinamimari"
+          "makinami/mari"
         ]
       },
       {
@@ -116398,7 +117272,8 @@
     "question_text": {
       "en": "Which redheaded Eva pilot is designated the Second Child?",
       "ja": "セカンドチルドレンに指定された赤毛のエヴァパイロットは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116439,7 +117314,8 @@
     "question_text": {
       "en": "Which deep-voiced veteran voice actor is associated with characters like Dorf and General Revil?",
       "ja": "ドルフやレビル将軍などで知られる重低音のベテラン声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116488,7 +117364,7 @@
         "en": "Chimera Shadow Garden",
         "ja": "嵌合暗翳庭",
         "ja_typings": [
-          "kangouan'eitei"
+          "kangouanneitei"
         ]
       },
       {
@@ -116520,7 +117396,8 @@
     "question_text": {
       "en": "Which Domain Expansion belongs to Megumi Fushiguro in Jujutsu Kaisen?",
       "ja": "呪術廻戦で伏黒恵が使う領域展開の名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116549,7 +117426,7 @@
         "en": "Chimera Shadow Garden",
         "ja": "嵌合暗翳庭",
         "ja_typings": [
-          "kangouan'eitei"
+          "kangouanneitei"
         ]
       }
     ],
@@ -116560,7 +117437,8 @@
     "question_text": {
       "en": "Which Hashira's Domain Expansion name belongs to Muzan-adjacent foe Akaza? (decoy set: which name from JJK's signature domains is *not* in JJK?)",
       "ja": "呪術廻戦の代表的領域展開のうち、上弦ぽいけど実在しない名前はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116568,7 +117446,7 @@
         "en": "Fujiko F. Fujio",
         "ja": "藤子・F・不二雄",
         "ja_typings": [
-          "hujikofhujio"
+          "fujiko/f/fujio"
         ]
       },
       {
@@ -116600,7 +117478,8 @@
     "question_text": {
       "en": "Which manga artist created Doraemon as one half of his duo pen name?",
       "ja": "コンビ筆名の片割れとしてドラえもんを描いた漫画家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116640,7 +117519,8 @@
     "question_text": {
       "en": "Which studio produced Neon Genesis Evangelion in the 1990s?",
       "ja": "1990 年代に新世紀エヴァンゲリオンを制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116680,7 +117560,8 @@
     "question_text": {
       "en": "Which manga author created Jujutsu Kaisen?",
       "ja": "呪術廻戦の原作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116702,7 +117583,7 @@
         "en": "Josuke Higashikata",
         "ja": "東方仗助",
         "ja_typings": [
-          "higasikatajousuke"
+          "higashikatajousuke"
         ]
       },
       {
@@ -116720,7 +117601,8 @@
     "question_text": {
       "en": "Which blond protagonist of JoJo Part 5 wants to become a Gang-Star?",
       "ja": "ジョジョ第5部でギャングのトップを目指す金髪の主人公は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116760,7 +117642,8 @@
     "question_text": {
       "en": "Which manga author created Attack on Titan?",
       "ja": "進撃の巨人の原作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116800,7 +117683,8 @@
     "question_text": {
       "en": "Which Gainax co-founder directed the original Neon Genesis Evangelion?",
       "ja": "新世紀エヴァンゲリオンを監督した Gainax の共同創業者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116840,7 +117724,8 @@
     "question_text": {
       "en": "Which wild boar-headed Demon Slayer fights with twin nichirin blades?",
       "ja": "猪の頭をかぶり、二刀流で戦う鬼殺隊士は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116880,7 +117765,8 @@
     "question_text": {
       "en": "Which Ghibli co-founder directed Grave of the Fireflies?",
       "ja": "火垂るの墓を監督したジブリの共同創業者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116920,7 +117806,8 @@
     "question_text": {
       "en": "Which 19th-century English gentleman is the first JoJo of Part 1?",
       "ja": "第1部の主人公にあたる 19 世紀イギリス紳士のジョジョは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -116928,7 +117815,7 @@
         "en": "Josuke Higashikata",
         "ja": "東方仗助",
         "ja_typings": [
-          "higasikatajousuke"
+          "higashikatajousuke"
         ]
       },
       {
@@ -116960,7 +117847,8 @@
     "question_text": {
       "en": "Which pompadour-haired Part 4 hero protects Morioh from Stand users?",
       "ja": "杜王町を守るリーゼント髪のジョジョ第4部の主人公は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117041,7 +117929,8 @@
     "question_text": {
       "en": "Which voice actor for Tobio Kageyama in Haikyu!! also voices many shōnen leads?",
       "ja": "ハイキュー!! の影山飛雄役を演じた声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117081,7 +117970,8 @@
     "question_text": {
       "en": "Which silver-haired ninja with a Sharingan eye leads Team 7 in Naruto?",
       "ja": "ナルトで第七班を率いる写輪眼を持つ銀髪の忍は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117163,7 +118053,8 @@
     "question_text": {
       "en": "Which Tsuguko of the Insect Hashira wields a sword with two crescent blades?",
       "ja": "蟲柱の継子で二日月型の刀を使う鬼殺隊士は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117203,7 +118094,8 @@
     "question_text": {
       "en": "Which explosive-quirk classmate of Deku calls himself the future No.1 hero?",
       "ja": "デクの同級生で爆破個性を持ち、未来の No.1 を自称するのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117226,7 +118118,7 @@
         "en": "Asuka Langley Soryu",
         "ja": "惣流・アスカ・ラングレー",
         "ja_typings": [
-          "souryuuasukarangure-"
+          "souryuu/asuka/rangure-"
         ]
       },
       {
@@ -117244,7 +118136,8 @@
     "question_text": {
       "en": "Which gray-haired Evangelion pilot is designated the Fifth Child?",
       "ja": "フィフスチルドレンに指定された灰色の髪のエヴァパイロットは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117285,7 +118178,8 @@
     "question_text": {
       "en": "Which voice actor was famous for booming villains like Raoh in Fist of the North Star?",
       "ja": "北斗の拳のラオウ等の威厳ある悪役で知られた声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117325,7 +118219,8 @@
     "question_text": {
       "en": "Which manga author created My Hero Academia?",
       "ja": "僕のヒーローアカデミアの原作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117365,7 +118260,8 @@
     "question_text": {
       "en": "Which voice actor for L (Death Note) is also known for Echizen in Prince of Tennis?",
       "ja": "デスノートのＬや越前リョーマを演じた声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117446,7 +118342,8 @@
     "question_text": {
       "en": "Which white-haired detective in Death Note uses the alias 'L'?",
       "ja": "デスノートで L を名乗る白髪交じりの探偵の本名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117543,7 +118440,7 @@
         "en": "Chimera Shadow Garden",
         "ja": "嵌合暗翳庭",
         "ja_typings": [
-          "kangouan'eitei"
+          "kangouanneitei"
         ]
       },
       {
@@ -117568,7 +118465,8 @@
     "question_text": {
       "en": "Which Domain Expansion belongs to Ryomen Sukuna in Jujutsu Kaisen?",
       "ja": "呪術廻戦で両面宿儺が使う領域展開の名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117608,7 +118506,8 @@
     "question_text": {
       "en": "Which director helmed Summer Wars and Mirai (Mirai no Mirai)?",
       "ja": "サマーウォーズや未来のミライを監督したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117648,7 +118547,8 @@
     "question_text": {
       "en": "Which director helmed Ghost in the Shell (1995)?",
       "ja": "1995 年の劇場版『攻殻機動隊』を監督したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117688,7 +118588,8 @@
     "question_text": {
       "en": "Which longtime Japanese voice actress played Krillin and Luffy?",
       "ja": "クリリンやルフィを演じた長年の女性声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117696,7 +118597,7 @@
         "en": "Megumi Fushiguro",
         "ja": "伏黒恵",
         "ja_typings": [
-          "fukuromegumi"
+          "fushiguromegumi"
         ]
       },
       {
@@ -117728,7 +118629,8 @@
     "question_text": {
       "en": "Which shadow-summoning sorcerer is the Ten Shadows user in JJK?",
       "ja": "呪術廻戦で十種影法術を使う影使いの呪術師は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117768,7 +118670,8 @@
     "question_text": {
       "en": "Which prolific voice actress played Rei Ayanami and Faye Valentine?",
       "ja": "綾波レイやフェイ・バレンタインを演じた女性声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117808,7 +118711,8 @@
     "question_text": {
       "en": "Which voice actress is associated with Shinji Ikari and Sailor Uranus?",
       "ja": "碇シンジや天王はるかを演じた女性声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117848,7 +118752,8 @@
     "question_text": {
       "en": "Which voice actress played Revy in Black Lagoon and Winry in FMA?",
       "ja": "ブラックラグーンのレヴィや FMA のウィンリィを演じた女性声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117929,7 +118834,8 @@
     "question_text": {
       "en": "Which voice actress plays Conan Edogawa in Detective Conan?",
       "ja": "名探偵コナンで江戸川コナンを演じる女性声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -117969,7 +118875,8 @@
     "question_text": {
       "en": "Which Death Note heroine becomes the second Kira out of love for Light?",
       "ja": "デスノートでライトへの愛から第二のキラになるヒロインは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118010,7 +118917,8 @@
     "question_text": {
       "en": "Which Demon Slayer Love Hashira fights with a uniquely flexible katana?",
       "ja": "鬼殺隊の恋柱で柔軟な刀を扱うのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118092,7 +119000,8 @@
     "question_text": {
       "en": "Which pink-clad demon-girl in a box is Tanjiro's younger sister?",
       "ja": "炭治郎の妹で、箱に入った桃色の鬼の少女は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118107,7 +119016,7 @@
         "en": "Megumi Fushiguro",
         "ja": "伏黒恵",
         "ja_typings": [
-          "fukuromegumi"
+          "fushiguromegumi"
         ]
       },
       {
@@ -118121,7 +119030,7 @@
         "en": "Maki Zenin",
         "ja": "禪院真希",
         "ja_typings": [
-          "zen'inmaki"
+          "zenninmaki"
         ]
       }
     ],
@@ -118132,7 +119041,8 @@
     "question_text": {
       "en": "Which hammer-wielding female student of Tokyo Jujutsu High wears short hair?",
       "ja": "東京呪術高専所属で金槌を扱うショートヘアの女子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118172,7 +119082,8 @@
     "question_text": {
       "en": "Which voice actress is the original Doraemon (1979–2005)?",
       "ja": "1979 年版のオリジナル・ドラえもんを演じた声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118212,7 +119123,8 @@
     "question_text": {
       "en": "Which Bleach heroine is Ichigo's longtime crush with healing powers?",
       "ja": "BLEACH で一護の幼馴染にあたる治癒能力者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118234,7 +119146,7 @@
         "en": "Fujiko F. Fujio",
         "ja": "藤子・F・不二雄",
         "ja_typings": [
-          "hujikofhujio"
+          "fujiko/f/fujio"
         ]
       },
       {
@@ -118252,7 +119164,8 @@
     "question_text": {
       "en": "Which manga artist is called 'the God of Manga' for works like Astro Boy?",
       "ja": "鉄腕アトムなどで「漫画の神様」と呼ばれる漫画家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118349,7 +119262,7 @@
         "en": "Asuka Langley Soryu",
         "ja": "惣流・アスカ・ラングレー",
         "ja_typings": [
-          "souryuuasukarangure-"
+          "souryuu/asuka/rangure-"
         ]
       },
       {
@@ -118364,7 +119277,7 @@
         "en": "Mari Makinami",
         "ja": "真希波・マリ",
         "ja_typings": [
-          "makinamimari"
+          "makinami/mari"
         ]
       }
     ],
@@ -118375,7 +119288,8 @@
     "question_text": {
       "en": "Which blue-haired Eva pilot is designated the First Child?",
       "ja": "ファーストチルドレンに指定された青髪のエヴァパイロットは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118390,7 +119304,7 @@
         "en": "Slice of life",
         "ja": "日常系",
         "ja_typings": [
-          "nitijoukei"
+          "nichijoukei"
         ]
       },
       {
@@ -118415,7 +119329,8 @@
     "question_text": {
       "en": "Which anime genre is the term for love-comedy series?",
       "ja": "恋愛コメディ系のアニメジャンルを指す英語表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118537,7 +119452,8 @@
     "question_text": {
       "en": "Which black-haired shinigami lieutenant lent her powers to Ichigo in Bleach?",
       "ja": "BLEACH で一護に死神の力を貸した黒髪の死神は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118577,7 +119493,8 @@
     "question_text": {
       "en": "Which apple-loving shinigami drops the Death Note in the human world?",
       "ja": "リンゴ好きで人間界にデスノートを落とした死神は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118658,7 +119575,8 @@
     "question_text": {
       "en": "Which raven-haired prodigy rival to Naruto wields the Sharingan?",
       "ja": "ナルトのライバルで写輪眼を持つ黒髪の天才忍者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118673,7 +119591,7 @@
         "en": "Megumi Fushiguro",
         "ja": "伏黒恵",
         "ja_typings": [
-          "fukuromegumi"
+          "fushiguromegumi"
         ]
       },
       {
@@ -118698,7 +119616,8 @@
     "question_text": {
       "en": "Which white-haired strongest jujutsu sorcerer wears a blindfold?",
       "ja": "目隠しを巻いた最強の呪術師は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118738,7 +119657,8 @@
     "question_text": {
       "en": "Which director helmed Perfect Blue and Paprika before his early death?",
       "ja": "パーフェクトブルーやパプリカを監督した、夭折のアニメ監督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118820,7 +119740,8 @@
     "question_text": {
       "en": "Which Insect Hashira fights with poison-laced thrust attacks?",
       "ja": "毒を仕込んだ突き技で戦う蟲柱は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118842,7 +119763,7 @@
         "en": "Fujiko F. Fujio",
         "ja": "藤子・F・不二雄",
         "ja_typings": [
-          "hujikofhujio"
+          "fujiko/f/fujio"
         ]
       },
       {
@@ -118860,7 +119781,8 @@
     "question_text": {
       "en": "Which manga artist created Kamen Rider and Cyborg 009?",
       "ja": "仮面ライダーやサイボーグ009を創造した漫画家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118900,7 +119822,8 @@
     "question_text": {
       "en": "Which half-and-half-haired classmate of Deku has both fire and ice quirks?",
       "ja": "デクの同級生で炎と氷の両方の個性を持つハーフカラー髪のヒーローは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118908,7 +119831,7 @@
         "en": "Slice of life",
         "ja": "日常系",
         "ja_typings": [
-          "nitijoukei"
+          "nichijoukei"
         ]
       },
       {
@@ -118940,7 +119863,8 @@
     "question_text": {
       "en": "Which anime genre label describes laid-back everyday-life shows?",
       "ja": "日々の生活をのんびり描くアニメのジャンル英語表記は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -118955,7 +119879,7 @@
         "en": "Slice of life",
         "ja": "日常系",
         "ja_typings": [
-          "nitijoukei"
+          "nichijoukei"
         ]
       },
       {
@@ -118980,7 +119904,8 @@
     "question_text": {
       "en": "Which broad anime genre covers Haikyu!!, Slam Dunk, and Captain Tsubasa?",
       "ja": "ハイキュー!! や SLAM DUNK、キャプテン翼を含む広いジャンルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119020,7 +119945,8 @@
     "question_text": {
       "en": "Which Tokyo-based studio produced Spirited Away and Princess Mononoke?",
       "ja": "千と千尋の神隠しやもののけ姫を制作した東京のスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119101,7 +120027,8 @@
     "question_text": {
       "en": "Which studio is the historical home of Gundam, Cowboy Bebop, and Code Geass?",
       "ja": "ガンダム、カウボーイビバップ、コードギアスの伝統的な制作スタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119141,7 +120068,8 @@
     "question_text": {
       "en": "Which manga author created Chainsaw Man and Fire Punch?",
       "ja": "チェンソーマンとファイアパンチの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119181,7 +120109,8 @@
     "question_text": {
       "en": "Which black-haired Nekoma captain in Haikyu!! tangles with Karasuno?",
       "ja": "ハイキュー!! で烏野と戦う音駒高校の黒髪キャプテンは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119210,7 +120139,7 @@
         "en": "Chimera Shadow Garden",
         "ja": "嵌合暗翳庭",
         "ja_typings": [
-          "kangouan'eitei"
+          "kangouanneitei"
         ]
       }
     ],
@@ -119221,7 +120150,8 @@
     "question_text": {
       "en": "Which Jujutsu Kaisen domain belongs to Kenjaku and traps targets in time?",
       "ja": "呪術廻戦で羂索が用いる時間制圧の領域展開は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119261,7 +120191,8 @@
     "question_text": {
       "en": "Which Karasuno setter has prodigious aim and a fierce temper in Haikyu!!?",
       "ja": "ハイキュー!! の烏野のセッターで気性の荒い天才は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119301,7 +120232,8 @@
     "question_text": {
       "en": "Which classic anime studio is famous for Dragon Ball, Sailor Moon, and One Piece?",
       "ja": "ドラゴンボール、セーラームーン、ワンピースを制作した老舗スタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119342,7 +120274,8 @@
     "question_text": {
       "en": "Which iconic voice actor played Amuro Ray and Tuxedo Mask?",
       "ja": "アムロ・レイやタキシード仮面を演じた往年の男性声優は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119382,7 +120315,8 @@
     "question_text": {
       "en": "Which Aoba Johsai setter rivals Kageyama as 'the Grand King' in Haikyu!!?",
       "ja": "ハイキュー!! で影山のライバル、青葉城西の「大王様」と呼ばれるセッターは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119422,7 +120356,8 @@
     "question_text": {
       "en": "Which busty blonde Sannin becomes the Fifth Hokage in Naruto?",
       "ja": "ナルトで五代目火影に就任する金髪・巨乳の伝説の三忍は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119444,7 +120379,7 @@
         "en": "Chimera Shadow Garden",
         "ja": "嵌合暗翳庭",
         "ja_typings": [
-          "kangouan'eitei"
+          "kangouanneitei"
         ]
       },
       {
@@ -119462,7 +120397,8 @@
     "question_text": {
       "en": "Which Gojo domain forces total sensory input on everyone inside it?",
       "ja": "五条悟の領域展開で内部の全員に膨大な情報を流し込むのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119502,7 +120438,8 @@
     "question_text": {
       "en": "Which Bleach Quincy archer is one of Ichigo's school friends?",
       "ja": "BLEACH で一護のクラスメイトの滅却師の弓使いは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119583,7 +120520,8 @@
     "question_text": {
       "en": "Which studio produced Attack on Titan seasons 1–3?",
       "ja": "進撃の巨人 シーズン1～3を制作したスタジオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119664,7 +120602,8 @@
     "question_text": {
       "en": "Which masked maternal-uncle bodyguard of young Gaara dies in early Naruto?",
       "ja": "ナルト初期で幼少の我愛羅の世話役だった仮面の母方の叔父は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119745,7 +120684,8 @@
     "question_text": {
       "en": "Which veteran director created Mobile Suit Gundam and is called the 'father of Gundam'?",
       "ja": "機動戦士ガンダムを生み「ガンダムの父」と呼ばれる監督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119826,7 +120766,8 @@
     "question_text": {
       "en": "Which cowardly thunder-breathing Demon Slayer is in love with Nezuko?",
       "ja": "禰豆子に惚れている雷の呼吸の臆病な鬼殺隊士は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -119989,7 +120930,8 @@
     "question_text": {
       "en": "Who is the bald assassin protagonist of the Hitman series?",
       "ja": "ヒットマンシリーズの主人公である禿頭の暗殺者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120029,7 +120971,8 @@
     "question_text": {
       "en": "Who is the Tojo Clan captain who Kiryu fought in Yakuza?",
       "ja": "龍が如くで桐生が戦う東城会の若頭は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120233,7 +121176,8 @@
     "question_text": {
       "en": "Which Korean MMORPG known for graphics was made by Pearl Abyss?",
       "ja": "パールアビスが開発した韓国産MMORPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -120725,7 +121669,8 @@
     "question_text": {
       "en": "Which Kojima Productions delivery game features Sam Bridges?",
       "ja": "サム・ブリッジズが配達するコジマプロの作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121093,7 +122038,8 @@
     "question_text": {
       "en": "Which classic Sony Online MMORPG predated World of Warcraft?",
       "ja": "WoW登場以前のソニー製代表的MMORPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121174,7 +122120,8 @@
     "question_text": {
       "en": "Which SEGA Sports Interactive series simulates soccer team management?",
       "ja": "セガが出すサッカークラブ経営シミュは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121297,7 +122244,8 @@
     "question_text": {
       "en": "Which Sucker Punch samurai game is set on a Mongol-invaded island?",
       "ja": "サッカーパンチ社の蒙古襲来を舞台にしたサムライ作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121337,7 +122285,8 @@
     "question_text": {
       "en": "Who founded Grasshopper Manufacture and directed No More Heroes?",
       "ja": "ノーモア★ヒーローズを生んだグラスホッパー創業者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121377,7 +122326,8 @@
     "question_text": {
       "en": "Who is the eyepatch-wearing Mad Dog of Shimano in Yakuza?",
       "ja": "龍が如くで眼帯姿の嶋野の狂犬は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121499,7 +122449,8 @@
     "question_text": {
       "en": "Who created the Game & Watch and Game Boy at Nintendo?",
       "ja": "ゲーム&ウオッチとゲームボーイの生みの親は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121539,7 +122490,8 @@
     "question_text": {
       "en": "Which action game genre is abbreviated H&S?",
       "ja": "ハクスラとも呼ばれるアクションゲームのジャンルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121579,7 +122531,8 @@
     "question_text": {
       "en": "Which Niantic AR game uses the Harry Potter universe?",
       "ja": "ナイアンティックのハリーポッターAR位置情報ゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121619,7 +122572,8 @@
     "question_text": {
       "en": "Which Supercell game has players running a small farm?",
       "ja": "スーパーセル製の農場経営モバイルゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121700,7 +122654,8 @@
     "question_text": {
       "en": "Who directed Bayonetta and founded PlatinumGames?",
       "ja": "ベヨネッタの監督でプラチナゲームズ創業者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121740,7 +122695,8 @@
     "question_text": {
       "en": "Who created Metal Gear Solid and Death Stranding?",
       "ja": "メタルギアやデス・ストランディングの作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121780,7 +122736,8 @@
     "question_text": {
       "en": "Who created the Final Fantasy series at Square?",
       "ja": "ファイナルファンタジーシリーズの生みの親は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121820,7 +122777,8 @@
     "question_text": {
       "en": "Which HoYoverse space-themed turn-based RPG launched in 2023?",
       "ja": "ホヨバースの2023年宇宙ターン制RPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121860,7 +122818,8 @@
     "question_text": {
       "en": "Who is the protagonist of Yakuza: Like a Dragon?",
       "ja": "龍が如く7の主人公は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121900,7 +122859,8 @@
     "question_text": {
       "en": "Which Niantic AR game predated Pokemon GO?",
       "ja": "ナイアンティックがポケモンGOより前に出した位置情報ARゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121940,7 +122900,8 @@
     "question_text": {
       "en": "Which Square board-game series features Dragon Quest characters?",
       "ja": "ドラクエキャラが登場するスクウェアの双六ゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -121969,7 +122930,7 @@
         "en": "Sly Cooper",
         "ja": "怪盗スライ",
         "ja_typings": [
-          "kaitousuraikuupaa"
+          "kaitousurai"
         ]
       }
     ],
@@ -121980,7 +122941,8 @@
     "question_text": {
       "en": "Which Naughty Dog PS2 platformer pairs a boy with a furry sidekick?",
       "ja": "ノーティードッグのPS2ジャンプアクションは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122020,7 +122982,8 @@
     "question_text": {
       "en": "Who created Mega Man at Capcom?",
       "ja": "カプコンでロックマンを生んだ人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122060,7 +123023,8 @@
     "question_text": {
       "en": "Who created the original Dragon Quest game system at Chunsoft?",
       "ja": "ドラクエ初代のプログラマでチュンソフト創業者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122100,7 +123064,8 @@
     "question_text": {
       "en": "Which Smilegate MMORPG with isometric view launched globally in 2022?",
       "ja": "スマイルゲートの2022年世界配信トップダウンMMORPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122222,7 +123187,8 @@
     "question_text": {
       "en": "Which Nintendo party game series features minigame board play?",
       "ja": "ミニゲーム集の任天堂パーティーゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122262,7 +123228,8 @@
     "question_text": {
       "en": "Who directed Super Smash Bros. and Kirby?",
       "ja": "スマブラやカービィの生みの親は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122343,7 +123310,8 @@
     "question_text": {
       "en": "Which Capcom blue-armored robot hero series began in 1987?",
       "ja": "1987年に始まった青い鎧のカプコンロボットは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122383,7 +123351,8 @@
     "question_text": {
       "en": "Which Konami baseball series features pixel-style players?",
       "ja": "燃えろプロ野球の二頭身プロ野球ゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122424,7 +123393,8 @@
     "question_text": {
       "en": "Which Capcom action series has hunters slaying giant beasts?",
       "ja": "巨大モンスターを狩るカプコン代表作は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122505,7 +123475,8 @@
     "question_text": {
       "en": "Who is the Final Fantasy XIII director at Square Enix?",
       "ja": "FF13シリーズの監督を務めたスクエニ社員は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122750,7 +123721,8 @@
     "question_text": {
       "en": "Which Niantic walking-AR app uses Pikmin to track steps?",
       "ja": "ピクミンが歩数を彩るナイアンティックの散歩アプリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122954,7 +123926,8 @@
     "question_text": {
       "en": "Which Konami baseball series is abbreviated as Pro Spi?",
       "ja": "プロスピと略されるコナミ野球ゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -122994,7 +123967,8 @@
     "question_text": {
       "en": "Which Konami simulation series is the official Pro Yakyu game?",
       "ja": "プロ野球の正式ライセンスを持つコナミの本格野球シミュは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123198,7 +124172,8 @@
     "question_text": {
       "en": "Which genre includes StarCraft and Age of Empires?",
       "ja": "StarCraftやAge of Empiresのジャンル名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123309,7 +124284,7 @@
         "en": "Sly Cooper",
         "ja": "怪盗スライ",
         "ja_typings": [
-          "kaitousuraikuupaa"
+          "kaitousurai"
         ]
       }
     ],
@@ -123320,7 +124295,8 @@
     "question_text": {
       "en": "Which Insomniac PS series pairs a lombax with a robot?",
       "ja": "ロンバックスとロボットが冒険するインソムニアックの作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123401,7 +124377,8 @@
     "question_text": {
       "en": "Which Marvelous farming RPG was once called Harvest Moon overseas?",
       "ja": "海外でハーベストムーン名義だった牧場経営RPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123441,7 +124418,8 @@
     "question_text": {
       "en": "Which Sega series features the Imperial Floral Assault Troupe?",
       "ja": "帝国華撃団が活躍するセガの作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123481,7 +124459,8 @@
     "question_text": {
       "en": "Who is the bald Splinter Cell stealth agent?",
       "ja": "スプリンターセルの主人公の禿頭スパイは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123521,7 +124500,8 @@
     "question_text": {
       "en": "Who was the Nintendo president and HAL Laboratory programmer?",
       "ja": "任天堂社長を務めた元HAL研プログラマは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123561,7 +124541,8 @@
     "question_text": {
       "en": "Who founded Game Freak and created Pokemon?",
       "ja": "ゲームフリークを創業しポケモンを生んだ人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123602,7 +124583,8 @@
     "question_text": {
       "en": "Which FromSoftware Sengoku-era stealth-action game won Game of the Year 2019?",
       "ja": "2019年GOTYのフロムソフトウェア戦国忍者ゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123642,7 +124624,8 @@
     "question_text": {
       "en": "Which Capcom series features over-the-top Sengoku warriors?",
       "ja": "派手な戦国武将アクションのカプコン作は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -123764,7 +124747,8 @@
     "question_text": {
       "en": "Who directed Resident Evil 1 and founded Tango Gameworks?",
       "ja": "バイオハザード1の監督でタンゴ創業者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124009,7 +124993,8 @@
     "question_text": {
       "en": "Which Marvelous farm simulation is the rebrand of Bokujou Monogatari?",
       "ja": "牧場物語の海外向け新ブランド名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124131,7 +125116,8 @@
     "question_text": {
       "en": "Who is the Final Fantasy character designer behind Kingdom Hearts?",
       "ja": "キングダムハーツのキャラデザを担当したFF美術家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124212,7 +125198,8 @@
     "question_text": {
       "en": "Which classic Hasbro board game simulates birth-to-retirement?",
       "ja": "誕生から引退までを辿るハズブロのボードゲームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124220,7 +125207,7 @@
         "en": "The Legend of Zelda: Skyward Sword",
         "ja": "ゼルダの伝説 スカイウォードソード",
         "ja_typings": [
-          "zerudanodensetsusukaiwa-dosa-do"
+          "zerudanodensetsusukaiwo-doso-do"
         ]
       },
       {
@@ -124252,7 +125239,8 @@
     "question_text": {
       "en": "Which Zelda title introduced motion-controlled sword combat on Wii?",
       "ja": "Wiiで剣のモーション操作を導入したゼルダは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124267,7 +125255,7 @@
         "en": "The Legend of Zelda: Skyward Sword",
         "ja": "ゼルダの伝説 スカイウォードソード",
         "ja_typings": [
-          "zerudanodensetsusukaiwa-dosa-do"
+          "zerudanodensetsusukaiwo-doso-do"
         ]
       },
       {
@@ -124292,7 +125280,8 @@
     "question_text": {
       "en": "Which 2023 Switch Zelda sequel features a sky-falling Hyrule?",
       "ja": "2023年発売のスイッチのゼルダ続編は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124307,7 +125296,7 @@
         "en": "The Legend of Zelda: Skyward Sword",
         "ja": "ゼルダの伝説 スカイウォードソード",
         "ja_typings": [
-          "zerudanodensetsusukaiwa-dosa-do"
+          "zerudanodensetsusukaiwo-doso-do"
         ]
       },
       {
@@ -124332,7 +125321,8 @@
     "question_text": {
       "en": "Which 2006 Wii/GC Zelda features Link transforming into a wolf?",
       "ja": "リンクが狼になる2006年のゼルダ作品は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124373,7 +125363,8 @@
     "question_text": {
       "en": "Which Square Enix series stars Lara Croft as a treasure hunter?",
       "ja": "ララ・クロフトが活躍するスクエニの冒険シリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124413,7 +125404,8 @@
     "question_text": {
       "en": "Who is the founder of Team Ninja and director of Ninja Gaiden?",
       "ja": "Team Ninja創設者でニンジャガイデン監督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124453,7 +125445,8 @@
     "question_text": {
       "en": "Which Hotta Studio open-world MMORPG resembles Genshin Impact?",
       "ja": "原神に類似した中国産オープンワールドMMORPGは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124493,7 +125486,8 @@
     "question_text": {
       "en": "Which strategy genre is abbreviated TBS?",
       "ja": "TBSと略される戦略ゲームのジャンルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124738,7 +125732,8 @@
     "question_text": {
       "en": "Which Konami soccer series was rebranded to eFootball?",
       "ja": "eFootballに改名されたコナミのサッカーシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124901,7 +125896,8 @@
     "question_text": {
       "en": "Who is the creator of the Dragon Quest series?",
       "ja": "ドラゴンクエストシリーズの生みの親は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124941,7 +125937,8 @@
     "question_text": {
       "en": "Who programmed Sonic the Hedgehog at Sega?",
       "ja": "セガのソニックを生んだプログラマは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -124981,7 +125978,8 @@
     "question_text": {
       "en": "In which year did the French Revolution begin?",
       "ja": "フランス革命が勃発した年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125021,7 +126019,8 @@
     "question_text": {
       "en": "In which year did the War of 1812 between the US and Britain begin?",
       "ja": "米英戦争が始まった年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125061,7 +126060,8 @@
     "question_text": {
       "en": "In which year did the American Civil War end?",
       "ja": "アメリカ南北戦争が終結した年は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125101,7 +126101,8 @@
     "question_text": {
       "en": "Which Islamic caliphate ruled from Baghdad starting in 750?",
       "ja": "750年からバグダッドで統治したイスラム王朝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125142,7 +126143,8 @@
     "question_text": {
       "en": "Which Russian envoy arrived in Nemuro in 1792 demanding trade with Japan?",
       "ja": "1792年に根室に来航し通商を要求したロシア使節は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125305,7 +126307,8 @@
     "question_text": {
       "en": "Which 1941 Japanese strike brought the US into WWII?",
       "ja": "1941年に米国を参戦させた日本の奇襲は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125345,7 +126348,8 @@
     "question_text": {
       "en": "Which 1942-43 battle marked the turning point on the Eastern Front?",
       "ja": "1942-43年東部戦線の転換点となった戦いは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125353,7 +126357,7 @@
         "en": "Behistun Inscription",
         "ja": "ベヒストゥン碑文",
         "ja_typings": [
-          "behisutunhibun"
+          "behisutwunhibun"
         ]
       },
       {
@@ -125385,7 +126389,8 @@
     "question_text": {
       "en": "Which Iranian trilingual inscription helped decipher cuneiform?",
       "ja": "楔形文字解読の鍵となったイランの三言語碑文は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125507,7 +126512,8 @@
     "question_text": {
       "en": "Which 1900 anti-foreign uprising in China was suppressed by an eight-nation alliance?",
       "ja": "1900年に8カ国連合軍が鎮圧した中国の排外運動は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125588,7 +126594,8 @@
     "question_text": {
       "en": "Which gunpowder weapon revolutionized warfare in the late Middle Ages?",
       "ja": "中世末期に戦争を変えた火薬兵器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125628,7 +126635,8 @@
     "question_text": {
       "en": "Which Wei king during China's Three Kingdoms period is known as a brilliant strategist?",
       "ja": "三国志で魏を築いた知将は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125668,7 +126676,8 @@
     "question_text": {
       "en": "Which ancient siege weapon hurled stones using torsion or counterweight?",
       "ja": "投石で城を攻めた古代の兵器は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125751,7 +126760,8 @@
     "question_text": {
       "en": "Who united the Franks and converted to Christianity around 496?",
       "ja": "フランク王国を統一しキリスト教に改宗した王は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125766,7 +126776,7 @@
         "en": "Behistun Inscription",
         "ja": "ベヒストゥン碑文",
         "ja_typings": [
-          "behisutunhibun"
+          "behisutwunhibun"
         ]
       },
       {
@@ -125791,7 +126801,8 @@
     "question_text": {
       "en": "Which Babylonian stele inscribed an eye-for-an-eye law code?",
       "ja": "目には目をで知られるバビロニアの法典碑は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125831,7 +126842,8 @@
     "question_text": {
       "en": "On which Mediterranean island was Napoleon Bonaparte born?",
       "ja": "ナポレオン・ボナパルトの生まれた地中海の島は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125871,7 +126883,8 @@
     "question_text": {
       "en": "Which medieval ranged weapon was banned by the Church for use against Christians?",
       "ja": "中世に教会が同胞使用を禁じた飛び道具は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125911,7 +126924,8 @@
     "question_text": {
       "en": "Which Central European country split into Czech Republic and Slovakia in 1993?",
       "ja": "1993年にチェコとスロバキアに分かれた中欧の国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125951,7 +126965,8 @@
     "question_text": {
       "en": "Who led China's reform and opening-up policy from 1978?",
       "ja": "1978年から中国の改革開放を主導した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -125991,7 +127006,8 @@
     "question_text": {
       "en": "Which country existed as the German Democratic Republic until 1990?",
       "ja": "1990年まで存在したドイツ民主共和国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126113,7 +127129,8 @@
     "question_text": {
       "en": "Which country experienced the Revolution of 1789?",
       "ja": "1789年に大革命が起きた国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126347,7 +127364,7 @@
         "en": "Behistun Inscription",
         "ja": "ベヒストゥン碑文",
         "ja_typings": [
-          "behisutunhibun"
+          "behisutwunhibun"
         ]
       }
     ],
@@ -126358,7 +127375,8 @@
     "question_text": {
       "en": "Which massive fortification stretches across northern China?",
       "ja": "中国北部に延々と続く大要塞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126398,7 +127416,8 @@
     "question_text": {
       "en": "Who led the Underground Railroad freeing slaves before the Civil War?",
       "ja": "南北戦争以前に地下鉄道で奴隷を救った活動家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126438,7 +127457,8 @@
     "question_text": {
       "en": "Which 1858 treaty opened more Japanese ports to American trade?",
       "ja": "1858年に米国との通商を認めた条約は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126480,7 +127500,8 @@
     "question_text": {
       "en": "Which English king had six wives and broke with Rome?",
       "ja": "6人の妃を持ちローマ教会と決別した英国王は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126643,7 +127664,8 @@
     "question_text": {
       "en": "Which 14th-15th century war was fought between England and France?",
       "ja": "14-15世紀のイングランドとフランスの長期戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126683,7 +127705,8 @@
     "question_text": {
       "en": "Which Cold War metaphor did Churchill coin for Europe's divide?",
       "ja": "チャーチルが欧州の分断に用いた冷戦のメタファーは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126753,7 +127776,7 @@
         "en": "Mori Terumoto",
         "ja": "毛利輝元",
         "ja_typings": [
-          "moriterumoto"
+          "mouriterumoto"
         ]
       }
     ],
@@ -126764,7 +127787,8 @@
     "question_text": {
       "en": "Who commanded the Western Army at the Battle of Sekigahara?",
       "ja": "関ヶ原で西軍を率いた武将は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126804,7 +127828,8 @@
     "question_text": {
       "en": "Who led the Meiji Restoration government and founded the Liberal Party?",
       "ja": "明治政府の元勲で自由党を結成したのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126844,7 +127869,8 @@
     "question_text": {
       "en": "Which ancient province of Japan houses the famous grand shrine?",
       "ja": "出雲大社のある日本の旧国名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -126925,7 +127951,8 @@
     "question_text": {
       "en": "Which French theologian led the Reformation in Geneva?",
       "ja": "ジュネーブで宗教改革を率いたフランス出身の神学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127006,7 +128033,8 @@
     "question_text": {
       "en": "Who founded the Red Army and was exiled by Stalin?",
       "ja": "赤軍を組織しスターリンに追放された革命家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127087,7 +128115,8 @@
     "question_text": {
       "en": "Which French defensive fortification was built before WWII?",
       "ja": "第二次大戦前にフランスが築いた防衛線は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127127,7 +128156,8 @@
     "question_text": {
       "en": "Who was the Nation of Islam minister assassinated in 1965?",
       "ja": "1965年に暗殺されたネーション・オブ・イスラムの活動家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127209,7 +128239,8 @@
     "question_text": {
       "en": "Which French nobleman aided the American Revolution as a general?",
       "ja": "アメリカ独立戦争で将軍として参戦したフランス貴族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127249,7 +128280,8 @@
     "question_text": {
       "en": "Who led the US civil rights movement and gave the 'I Have a Dream' speech?",
       "ja": "「私には夢がある」演説を行った米公民権運動家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127290,7 +128322,8 @@
     "question_text": {
       "en": "Who led the radical phase of the French Revolution's Reign of Terror?",
       "ja": "フランス革命の恐怖政治を主導した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127421,7 +128454,7 @@
         "en": "Mori Terumoto",
         "ja": "毛利輝元",
         "ja_typings": [
-          "moriterumoto"
+          "mouriterumoto"
         ]
       },
       {
@@ -127453,7 +128486,8 @@
     "question_text": {
       "en": "Who was the Mori clan leader and titular head of the Western Army at Sekigahara?",
       "ja": "関ヶ原で西軍総大将を務めた毛利家当主は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127493,7 +128527,8 @@
     "question_text": {
       "en": "Which Islamic empire ruled India from 1526 to the 19th century?",
       "ja": "1526年から19世紀までインドを支配したイスラム王朝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127533,7 +128568,8 @@
     "question_text": {
       "en": "Who was the founder of Pakistan?",
       "ja": "パキスタン建国の父と呼ばれる人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127548,7 +128584,7 @@
         "en": "Peace of Westphalia",
         "ja": "ウェストファリア条約",
         "ja_typings": [
-          "uesutofariajouyaku"
+          "wesutofariajouyaku"
         ]
       },
       {
@@ -127573,7 +128609,8 @@
     "question_text": {
       "en": "Which 1938 pact ceded the Sudetenland to Nazi Germany?",
       "ja": "1938年にズデーテン地方をナチスに割譲した協定は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127613,7 +128650,8 @@
     "question_text": {
       "en": "Which chemical element has the symbol Na?",
       "ja": "元素記号Naで表される元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127654,7 +128692,8 @@
     "question_text": {
       "en": "Who was Emperor of France during the Second Empire?",
       "ja": "フランス第二帝政の皇帝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127735,7 +128774,8 @@
     "question_text": {
       "en": "Which African river was central to ancient Egyptian civilization?",
       "ja": "古代エジプト文明を育んだアフリカの大河は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127775,7 +128815,8 @@
     "question_text": {
       "en": "Which 1972 detente summit was held in Moscow between US and USSR?",
       "ja": "1972年にモスクワで行われた米ソ緊張緩和の首脳会談は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127815,7 +128856,8 @@
     "question_text": {
       "en": "Who founded Waseda University and served as Prime Minister of Japan?",
       "ja": "早稲田大学を創設し首相も務めた人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127857,7 +128899,8 @@
     "question_text": {
       "en": "Who was crowned the first Holy Roman Emperor in 962?",
       "ja": "962年に神聖ローマ皇帝に戴冠した君主は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127879,7 +128922,7 @@
         "en": "Behistun Inscription",
         "ja": "ベヒストゥン碑文",
         "ja_typings": [
-          "behisutunhibun"
+          "behisutwunhibun"
         ]
       },
       {
@@ -127897,7 +128940,8 @@
     "question_text": {
       "en": "Which ancient Egyptian stone records the early dynasties' kings?",
       "ja": "古代エジプト初期王朝史を刻む石碑は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127905,7 +128949,7 @@
         "en": "Peace of Westphalia",
         "ja": "ウェストファリア条約",
         "ja_typings": [
-          "uesutofariajouyaku"
+          "wesutofariajouyaku"
         ]
       },
       {
@@ -127937,7 +128981,8 @@
     "question_text": {
       "en": "Which 1648 treaty ended the Thirty Years' War?",
       "ja": "1648年に三十年戦争を終結させた条約は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -127979,7 +129024,8 @@
     "question_text": {
       "en": "Who founded the Carolingian dynasty by deposing the last Merovingian king?",
       "ja": "メロヴィング朝最後の王を廃しカロリング朝を開いたのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128060,7 +129106,8 @@
     "question_text": {
       "en": "Which 1945 declaration demanded Japan's unconditional surrender?",
       "ja": "1945年に日本に無条件降伏を求めた宣言は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128182,7 +129229,8 @@
     "question_text": {
       "en": "Which 1985-88 summit thawed the Cold War between US and USSR?",
       "ja": "1985-88年に冷戦終結に向かった米ソ首脳会談は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128222,7 +129270,8 @@
     "question_text": {
       "en": "Which European river flows through Germany and the Netherlands to the North Sea?",
       "ja": "ドイツからオランダを経て北海に注ぐ欧州の大河は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128262,7 +129311,8 @@
     "question_text": {
       "en": "Which Persian Shia empire rose in 1501 in Iran?",
       "ja": "1501年にイランで興ったシーア派ペルシア王朝は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128343,7 +129393,8 @@
     "question_text": {
       "en": "Which Italian island was a kingdom that united Italy in the 19th century?",
       "ja": "19世紀イタリア統一の核となった島の王国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128383,7 +129434,8 @@
     "question_text": {
       "en": "Which 1856-60 war pitted Britain and France against Qing China?",
       "ja": "1856-60年に英仏が清と戦った戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128464,7 +129516,8 @@
     "question_text": {
       "en": "Who was the king of Wu during the Three Kingdoms period?",
       "ja": "三国志で呉を建てた君主は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128504,7 +129557,8 @@
     "question_text": {
       "en": "Who founded the Republic of China in 1912?",
       "ja": "1912年に中華民国を建てた人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128544,7 +129598,8 @@
     "question_text": {
       "en": "Which mid-19th century Christian-inspired uprising shook the Qing dynasty?",
       "ja": "19世紀半ばに清朝を揺るがしたキリスト教系大反乱は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128584,7 +129639,8 @@
     "question_text": {
       "en": "Who was the Kai daimyo nicknamed 'Tiger of Kai' in Sengoku Japan?",
       "ja": "甲斐の虎と呼ばれた戦国大名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128625,7 +129681,8 @@
     "question_text": {
       "en": "Which French diplomat served Napoleon and represented France at Vienna?",
       "ja": "ナポレオンに仕えウィーン会議でフランス代表となった外交官は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128665,7 +129722,8 @@
     "question_text": {
       "en": "Which 1618-1648 war devastated Central Europe over religion and politics?",
       "ja": "1618-1648年に中欧を荒廃させた宗教戦争は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128828,7 +129886,8 @@
     "question_text": {
       "en": "Which river flows through Rome?",
       "ja": "ローマを流れる川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128869,7 +129928,8 @@
     "question_text": {
       "en": "Who was the Turco-Mongol conqueror who founded an empire in 14th-century Central Asia?",
       "ja": "14世紀中央アジアに大帝国を築いたトルコ・モンゴル系の征服者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128909,7 +129969,8 @@
     "question_text": {
       "en": "Who founded the Tokugawa shogunate after Sekigahara?",
       "ja": "関ヶ原の戦い後に江戸幕府を開いた人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -128990,7 +130051,8 @@
     "question_text": {
       "en": "Who unified Japan as Taiko in the late 16th century?",
       "ja": "16世紀末に太閤として日本を統一した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129030,7 +130092,8 @@
     "question_text": {
       "en": "Which 1951 treaty ended the Allied occupation of Japan?",
       "ja": "1951年に連合国の占領を終わらせた日本の条約は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129045,7 +130108,7 @@
         "en": "Peace of Westphalia",
         "ja": "ウェストファリア条約",
         "ja_typings": [
-          "uesutofariajouyaku"
+          "wesutofariajouyaku"
         ]
       },
       {
@@ -129070,7 +130133,8 @@
     "question_text": {
       "en": "Which 1713 treaty ended the War of the Spanish Succession?",
       "ja": "1713年にスペイン継承戦争を終結させた条約は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129110,7 +130174,8 @@
     "question_text": {
       "en": "Which 1945 Potsdam meeting featured these Allied leaders?",
       "ja": "1945年ポツダム会談で対面した米ソの指導者ペアは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129150,7 +130215,8 @@
     "question_text": {
       "en": "Which 1776 document declared American independence from Britain?",
       "ja": "1776年に英国からの独立を宣した文書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129165,7 +130231,7 @@
         "en": "Mori Terumoto",
         "ja": "毛利輝元",
         "ja_typings": [
-          "moriterumoto"
+          "mouriterumoto"
         ]
       },
       {
@@ -129190,7 +130256,8 @@
     "question_text": {
       "en": "Who was the Uesugi clan head who fought Tokugawa in 1600?",
       "ja": "1600年に徳川と対立した上杉家当主は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129271,7 +130338,8 @@
     "question_text": {
       "en": "Which country gained independence on July 4, 1776?",
       "ja": "1776年7月4日に独立を宣した国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129300,7 +130368,7 @@
         "en": "Peace of Westphalia",
         "ja": "ウェストファリア条約",
         "ja_typings": [
-          "uesutofariajouyaku"
+          "wesutofariajouyaku"
         ]
       }
     ],
@@ -129311,7 +130379,8 @@
     "question_text": {
       "en": "Which 1948 UN document outlines fundamental human rights?",
       "ja": "1948年に国連が採択した人権の基本文書は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129351,7 +130420,8 @@
     "question_text": {
       "en": "Which 16th-17th century conflicts pitted Catholics against Protestants in France?",
       "ja": "16-17世紀フランスでカトリックとプロテスタントが争った内戦は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129391,7 +130461,8 @@
     "question_text": {
       "en": "Who was the Meiji-era army marshal and twice Prime Minister of Japan?",
       "ja": "明治の元帥陸軍大将で二度首相となった人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129431,7 +130502,8 @@
     "question_text": {
       "en": "Which early Japanese polity centered around the Nara basin in the 4th-7th century?",
       "ja": "4-7世紀に奈良盆地を中心に栄えた日本の政権は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129472,7 +130544,8 @@
     "question_text": {
       "en": "Which Russian admiral arrived in Nagasaki in 1853 seeking trade?",
       "ja": "1853年に長崎に来航した露提督は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129553,7 +130626,8 @@
     "question_text": {
       "en": "Which Balkan federation broke apart in the 1990s into multiple states?",
       "ja": "1990年代に複数国家に分裂したバルカンの連邦は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129634,7 +130708,8 @@
     "question_text": {
       "en": "Who served as the first Premier of the People's Republic of China?",
       "ja": "中華人民共和国の初代国務院総理は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129674,7 +130749,8 @@
     "question_text": {
       "en": "Who was the chief strategist of Shu in China's Three Kingdoms period?",
       "ja": "三国志で蜀の軍師として活躍した人物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129682,31 +130758,28 @@
         "en": "Abel Prize",
         "ja": "アーベル賞",
         "ja_typings": [
-          "a-beruxsiyou",
-          "a-beluxsyou"
+          "a-berushou"
         ]
       },
       {
         "en": "Fields Medal",
         "ja": "フィールズ賞",
         "ja_typings": [
-          "fi-ruzuxsiyou",
-          "fixi-luzusyou"
+          "fi-ruzushou"
         ]
       },
       {
         "en": "Wolf Prize",
         "ja": "ウルフ賞",
         "ja_typings": [
-          "uruhuxsiyou",
-          "uluhusyou"
+          "urufushou"
         ]
       },
       {
         "en": "Turing Award",
         "ja": "チューリング賞",
         "ja_typings": [
-          "chixyu-ringuxsiyou"
+          "chu-ringushou"
         ]
       }
     ],
@@ -129717,7 +130790,8 @@
     "question_text": {
       "en": "Which is a major international mathematics award named after a Norwegian mathematician?",
       "ja": "ノルウェーの数学者にちなんで名づけられた、数学の国際的な賞はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129757,7 +130831,8 @@
     "question_text": {
       "en": "Which branch of mathematics studies geometric objects defined by polynomial equations?",
       "ja": "多項式で定義される図形を扱う数学の分野はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129797,7 +130872,8 @@
     "question_text": {
       "en": "Which branch of mathematics deals with limits, derivatives and integrals?",
       "ja": "極限・微分・積分を扱う数学の分野はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -129942,14 +131018,14 @@
         "en": "Central limit theorem",
         "ja": "中心極限定理",
         "ja_typings": [
-          "tixyuusinkyokugenteiri"
+          "chuushinkyokugenteiri"
         ]
       },
       {
         "en": "Chebyshev's inequality",
         "ja": "チェビシェフの不等式",
         "ja_typings": [
-          "chiebisiehunohutousiki"
+          "chebishefunofutoushiki"
         ]
       }
     ],
@@ -129960,7 +131036,8 @@
     "question_text": {
       "en": "Which theorem in probability updates a probability given new evidence?",
       "ja": "新しい情報をもとに確率を更新する確率論の定理はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130000,7 +131077,8 @@
     "question_text": {
       "en": "Which special function in mathematics is denoted B(x,y)?",
       "ja": "B(x,y)で表される数学の特殊関数はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130172,29 +131250,28 @@
         "en": "Chebyshev's inequality",
         "ja": "チェビシェフの不等式",
         "ja_typings": [
-          "chiebisiehunohutousiki"
+          "chebishefunofutoushiki"
         ]
       },
       {
         "en": "Markov's inequality",
         "ja": "マルコフの不等式",
         "ja_typings": [
-          "marukohunohutousiki"
+          "marukofunofutoushiki"
         ]
       },
       {
         "en": "Jensen's inequality",
         "ja": "イェンセンの不等式",
         "ja_typings": [
-          "ixensennohutousiki",
-          "yensennnohutousiki"
+          "iensennofutoushiki"
         ]
       },
       {
         "en": "Cauchy-Schwarz inequality",
         "ja": "コーシー・シュワルツの不等式",
         "ja_typings": [
-          "ko-shi--/shiyuwarutunohutousiki"
+          "ko-shi-/shuwarutsunofutoushiki"
         ]
       }
     ],
@@ -130205,7 +131282,8 @@
     "question_text": {
       "en": "Which inequality bounds the probability that a random variable deviates from its mean?",
       "ja": "確率変数が平均から外れる確率を抑える不等式はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130245,7 +131323,8 @@
     "question_text": {
       "en": "Which type of polygon has at least one interior angle greater than 180°?",
       "ja": "内角に180°より大きい角がある多角形はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130267,7 +131346,7 @@
         "en": "Star polygon",
         "ja": "星型多角形",
         "ja_typings": [
-          "hosigatatakakukei"
+          "hoshigatatakakukei"
         ]
       },
       {
@@ -130285,7 +131364,8 @@
     "question_text": {
       "en": "Which type of polygon has all interior angles less than 180°?",
       "ja": "全ての内角が180°未満である多角形はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130407,7 +131487,8 @@
     "question_text": {
       "en": "Which generalized function, introduced by Dirac, equals zero except at one point?",
       "ja": "ディラックが導入した、1点以外でゼロとなる超関数はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130570,7 +131651,8 @@
     "question_text": {
       "en": "Which operation breaks a number into a product of primes?",
       "ja": "ある数を素数の積に分ける操作はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130674,8 +131756,7 @@
         "en": "Mapping",
         "ja": "写像",
         "ja_typings": [
-          "siyazou",
-          "syazou"
+          "shazou"
         ]
       },
       {
@@ -130693,7 +131774,8 @@
     "question_text": {
       "en": "Which mathematical concept assigns each input exactly one output?",
       "ja": "各入力にちょうど1つの出力を対応させる概念はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130774,7 +131856,8 @@
     "question_text": {
       "en": "Which function, denoted Γ(x), generalizes the factorial to real numbers?",
       "ja": "階乗を実数に拡張した Γ(x) で表される関数はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -130896,7 +131979,8 @@
     "question_text": {
       "en": "Which famous ratio is approximately 1.618?",
       "ja": "約1.618の値を持つ有名な比はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131075,7 +132159,7 @@
         "en": "Parabola",
         "ja": "放物線",
         "ja_typings": [
-          "houbutusen"
+          "houbutsusen"
         ]
       },
       {
@@ -131100,7 +132184,8 @@
     "question_text": {
       "en": "Which conic section is the graph of y = 1/x?",
       "ja": "y = 1/x のグラフが描く円錐曲線はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131141,7 +132226,8 @@
     "question_text": {
       "en": "Which calculus operation finds the area under a curve?",
       "ja": "曲線の下の面積を求める微積分の操作はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131320,7 +132406,7 @@
         "en": "Central limit theorem",
         "ja": "中心極限定理",
         "ja_typings": [
-          "tixyuusinkyokugenteiri"
+          "chuushinkyokugenteiri"
         ]
       },
       {
@@ -131334,7 +132420,7 @@
         "en": "Chebyshev's inequality",
         "ja": "チェビシェフの不等式",
         "ja_typings": [
-          "chiebisiehunohutousiki"
+          "chebishefunofutoushiki"
         ]
       }
     ],
@@ -131345,7 +132431,8 @@
     "question_text": {
       "en": "Which theorem says sample averages converge to the expected value?",
       "ja": "標本平均が期待値に収束することを述べる定理はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131415,8 +132502,7 @@
         "en": "Series",
         "ja": "級数",
         "ja_typings": [
-          "kiyuusuu",
-          "kyusuu"
+          "kyuusuu"
         ]
       }
     ],
@@ -131427,7 +132513,8 @@
     "question_text": {
       "en": "Which calculus concept is the value a function approaches near a point?",
       "ja": "ある点に近づけたときの値を表す微積分の概念はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131483,7 +132570,7 @@
         "en": "Exponential curve",
         "ja": "指数曲線",
         "ja_typings": [
-          "sisuukyokusen"
+          "shisuukyokusen"
         ]
       },
       {
@@ -131508,7 +132595,8 @@
     "question_text": {
       "en": "Which curve is the graph of y = log x?",
       "ja": "y = log x のグラフが描く曲線はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131516,8 +132604,7 @@
         "en": "Mapping",
         "ja": "写像",
         "ja_typings": [
-          "siyazou",
-          "syazou"
+          "shazou"
         ]
       },
       {
@@ -131549,7 +132636,8 @@
     "question_text": {
       "en": "Which concept assigns each element of one set to an element of another?",
       "ja": "ある集合の各要素を別の集合の要素に対応させる概念はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131630,7 +132718,8 @@
     "question_text": {
       "en": "Which branch of mathematics studies properties of integers?",
       "ja": "整数の性質を研究する数学の分野はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131700,8 +132789,7 @@
         "en": "Mapping",
         "ja": "写像",
         "ja_typings": [
-          "siyazou",
-          "syazou"
+          "shazou"
         ]
       }
     ],
@@ -131712,7 +132800,8 @@
     "question_text": {
       "en": "Which mathematical concept combines elements like +, ×, ∘?",
       "ja": "+ や × のように要素を組み合わせる数学的概念はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131815,7 +132904,7 @@
         "en": "Euclidean theorem",
         "ja": "ユークリッドの定理",
         "ja_typings": [
-          "yu-kuriltudonoteiri"
+          "yu-kuriddonoteiri"
         ]
       },
       {
@@ -131833,7 +132922,8 @@
     "question_text": {
       "en": "Which theorem states a² + b² = c² for right triangles?",
       "ja": "直角三角形で a² + b² = c² が成り立つ定理はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -131896,8 +132986,7 @@
         "en": "Mapping",
         "ja": "写像",
         "ja_typings": [
-          "siyazou",
-          "syazou"
+          "shazou"
         ]
       },
       {
@@ -131915,7 +133004,8 @@
     "question_text": {
       "en": "Which mathematical concept connects elements without requiring a unique image?",
       "ja": "1対多も許す、要素同士の対応を表す数学概念はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132060,7 +133150,7 @@
         "en": "Exponential curve",
         "ja": "指数曲線",
         "ja_typings": [
-          "sisuukyokusen"
+          "shisuukyokusen"
         ]
       },
       {
@@ -132078,7 +133168,8 @@
     "question_text": {
       "en": "Which S-shaped curve is widely used in neural network activations?",
       "ja": "ニューラルネットの活性化関数で使われるS字曲線はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132107,7 +133198,7 @@
         "en": "Convex polygon",
         "ja": "凸多角形",
         "ja_typings": [
-          "totutakakukei"
+          "totsutakakukei"
         ]
       }
     ],
@@ -132118,7 +133209,8 @@
     "question_text": {
       "en": "Which type of polygon has the same shape but different size as another?",
       "ja": "形が同じで大きさが異なる多角形を何という?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132208,28 +133300,28 @@
         "en": "Turing Award",
         "ja": "チューリング賞",
         "ja_typings": [
-          "chixyu-ringuxsiyou"
+          "chu-ringushou"
         ]
       },
       {
         "en": "Fields Medal",
         "ja": "フィールズ賞",
         "ja_typings": [
-          "fi-ruzuxsiyou"
+          "fi-ruzushou"
         ]
       },
       {
         "en": "Abel Prize",
         "ja": "アーベル賞",
         "ja_typings": [
-          "a-beruxsiyou"
+          "a-berushou"
         ]
       },
       {
         "en": "Wolf Prize",
         "ja": "ウルフ賞",
         "ja_typings": [
-          "uruhuxsiyou"
+          "urufushou"
         ]
       }
     ],
@@ -132240,7 +133332,8 @@
     "question_text": {
       "en": "Which prize is the highest honor in computer science, given by the ACM?",
       "ja": "ACM が授与する計算機科学最高の賞はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132269,8 +133362,7 @@
         "en": "Matrix",
         "ja": "行列",
         "ja_typings": [
-          "gyouretu",
-          "gyouletu"
+          "gyouretsu"
         ]
       }
     ],
@@ -132281,7 +133373,8 @@
     "question_text": {
       "en": "Which mathematical object has both magnitude and direction?",
       "ja": "大きさと向きを持つ数学的対象はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132330,29 +133423,28 @@
         "en": "Wolf Prize",
         "ja": "ウルフ賞",
         "ja_typings": [
-          "uruhuxsiyou",
-          "uluhusyou"
+          "urufushou"
         ]
       },
       {
         "en": "Abel Prize",
         "ja": "アーベル賞",
         "ja_typings": [
-          "a-beruxsiyou"
+          "a-berushou"
         ]
       },
       {
         "en": "Fields Medal",
         "ja": "フィールズ賞",
         "ja_typings": [
-          "fi-ruzuxsiyou"
+          "fi-ruzushou"
         ]
       },
       {
         "en": "Turing Award",
         "ja": "チューリング賞",
         "ja_typings": [
-          "chixyu-ringuxsiyou"
+          "chu-ringushou"
         ]
       }
     ],
@@ -132363,7 +133455,8 @@
     "question_text": {
       "en": "Which Israeli prize is given for outstanding achievements in mathematics and the arts?",
       "ja": "数学や芸術での業績に贈られるイスラエルの賞はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132407,7 +133500,8 @@
     "question_text": {
       "en": "How many wheels does a unicycle have?",
       "ja": "一輪車のタイヤは何輪?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132447,7 +133541,8 @@
     "question_text": {
       "en": "How many months are in a year?",
       "ja": "1年は何か月?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132491,7 +133586,8 @@
     "question_text": {
       "en": "How many wheels does a bicycle have?",
       "ja": "自転車のタイヤは何輪?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132535,7 +133631,8 @@
     "question_text": {
       "en": "How many fingers does a typical human have in total?",
       "ja": "人の指は両手で何本?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132577,7 +133674,8 @@
     "question_text": {
       "en": "About how long is a full marathon?",
       "ja": "フルマラソンの距離はおよそ何km?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132617,7 +133715,8 @@
     "question_text": {
       "en": "How many days does April have?",
       "ja": "4月は何日まで?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132661,7 +133760,8 @@
     "question_text": {
       "en": "About how long is a half marathon?",
       "ja": "ハーフマラソンの距離はおよそ何km?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132694,10 +133794,7 @@
         "en": "12 minutes",
         "ja": "12分",
         "ja_typings": [
-          "12hun",
-          "12pun",
-          "12bun",
-          "juunihun"
+          "12fun"
         ]
       }
     ],
@@ -132708,7 +133805,8 @@
     "question_text": {
       "en": "How long is one period in a high school basketball game?",
       "ja": "高校バスケのクォーター1ピリオドは何分?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132785,9 +133883,7 @@
         "en": "45 minutes",
         "ja": "45分",
         "ja_typings": [
-          "45hun",
-          "45pun",
-          "45bun"
+          "45fun"
         ]
       }
     ],
@@ -132798,7 +133894,8 @@
     "question_text": {
       "en": "How long is one half in a college basketball game (NCAA men)?",
       "ja": "NCAA男子バスケのハーフは何分?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132842,7 +133939,8 @@
     "question_text": {
       "en": "About how fast does a 100m sprinter run in km/h?",
       "ja": "100m走の世界トップ選手のおよその速度は時速何km?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -132887,7 +133985,8 @@
     "question_text": {
       "en": "How long is one half of a soccer match?",
       "ja": "サッカーの前半・後半は何分?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133182,14 +134281,14 @@
         "en": "China",
         "ja": "中国",
         "ja_typings": [
-          "tixyuugoku"
+          "chuugoku"
         ]
       },
       {
         "en": "United States",
         "ja": "アメリカ合衆国",
         "ja_typings": [
-          "amerikagatusiyuukoku"
+          "amerikagasshuukoku"
         ]
       },
       {
@@ -133214,7 +134313,8 @@
     "question_text": {
       "en": "Which country has the world's largest population alongside India?",
       "ja": "インドと並んで世界最大級の人口を持つ国はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133297,7 +134397,8 @@
     "question_text": {
       "en": "What is the official language of the Netherlands?",
       "ja": "オランダの公用語はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133380,7 +134481,8 @@
     "question_text": {
       "en": "Which plant family includes peas and beans?",
       "ja": "エンドウやマメを含む植物の科はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133586,7 +134688,8 @@
     "question_text": {
       "en": "Which Japanese bacteriologist appears on the 1000-yen note?",
       "ja": "1000円札の肖像となった日本の細菌学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133669,7 +134772,8 @@
     "question_text": {
       "en": "Which Japanese chemist first isolated adrenaline?",
       "ja": "アドレナリンを世界で初めて結晶化した日本の化学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133692,7 +134796,7 @@
         "en": "Shibasaburo Kitasato",
         "ja": "北里柴三郎",
         "ja_typings": [
-          "kitasatosibasaburou"
+          "kitasatoshibasaburou"
         ]
       },
       {
@@ -133710,7 +134814,8 @@
     "question_text": {
       "en": "Which Japanese bacteriologist discovered the dysentery bacillus?",
       "ja": "赤痢菌を発見した日本の細菌学者は誰?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -133793,7 +134898,8 @@
     "question_text": {
       "en": "Which plant family includes magnolias?",
       "ja": "モクレンやコブシを含む植物の科はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134039,7 +135145,8 @@
     "question_text": {
       "en": "Which vegetable is purple-leaved and used in coleslaw and salads?",
       "ja": "紫色の葉でサラダやコールスローに使う野菜はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134054,7 +135161,7 @@
         "en": "Red cabbage",
         "ja": "紫キャベツ",
         "ja_typings": [
-          "murasakikiyabetu"
+          "murasakikyabetsu"
         ]
       },
       {
@@ -134079,7 +135186,8 @@
     "question_text": {
       "en": "Which small red root vegetable is often called the salad radish?",
       "ja": "サラダによく使う小さな赤い根菜はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134307,7 +135415,7 @@
         "en": "Danish",
         "ja": "デンマーク語",
         "ja_typings": [
-          "denma--kugo"
+          "denma-kugo"
         ]
       },
       {
@@ -134326,7 +135434,8 @@
     "question_text": {
       "en": "What is the official language of Sweden?",
       "ja": "スウェーデンの公用語はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134407,7 +135516,8 @@
     "question_text": {
       "en": "Which plant family includes tea and camellia?",
       "ja": "ツバキやチャを含む植物の科はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134497,7 +135607,7 @@
         "en": "United States",
         "ja": "アメリカ合衆国",
         "ja_typings": [
-          "amerikagatusiyuukoku"
+          "amerikagasshuukoku"
         ]
       },
       {
@@ -134529,7 +135639,8 @@
     "question_text": {
       "en": "Which country has its capital at Washington, D.C.?",
       "ja": "首都がワシントンD.C.の国はどこ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134613,7 +135724,8 @@
     "question_text": {
       "en": "Frogs and salamanders belong to which class of animals?",
       "ja": "カエルやサンショウウオが属する動物の綱はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134653,7 +135765,8 @@
     "question_text": {
       "en": "How often are the Summer Olympics normally held?",
       "ja": "夏季オリンピックは通常何年ごとに開催される?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134693,7 +135806,8 @@
     "question_text": {
       "en": "How often is the World Athletics Championships held in odd years (recently)?",
       "ja": "近年、世界陸上は何年ごとに開催される?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134722,7 +135836,7 @@
         "en": "torch flame",
         "ja": "松明の炎",
         "ja_typings": [
-          "taimatunohonoo"
+          "taimatsunohonoo"
         ]
       }
     ],
@@ -134733,7 +135847,8 @@
     "question_text": {
       "en": "What does the kanji 電 (as in 電光) literally depict?",
       "ja": "「電光石火」の「電光」が指すのはどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134756,14 +135871,14 @@
         "en": "temple guardian",
         "ja": "寺院の守護神",
         "ja_typings": [
-          "jiinnosiyugosin"
+          "jiinnoshugoshin"
         ]
       },
       {
         "en": "running deer",
         "ja": "走る鹿",
         "ja_typings": [
-          "hasiruxsika"
+          "hashirushika"
         ]
       }
     ],
@@ -134774,7 +135889,8 @@
     "question_text": {
       "en": "What does the kanji 韋 in 韋駄天 originally evoke as an image?",
       "ja": "「韋駄天走り」のもとになるイメージはどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134814,7 +135930,8 @@
     "question_text": {
       "en": "In baseball, hitting four doubles in a single game is colloquially what?",
       "ja": "野球で1試合に二塁打を4本打つことを何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134854,7 +135971,8 @@
     "question_text": {
       "en": "In baseball, what do you call hitting four home runs in one game?",
       "ja": "野球で1試合に本塁打を4本打つことを何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134935,7 +136053,8 @@
     "question_text": {
       "en": "What part of a plant typically develops from a fertilized flower and contains seeds?",
       "ja": "受粉した花が成熟してできる、種子を含む部分はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -134978,7 +136097,8 @@
     "question_text": {
       "en": "Which sense allows some animals to navigate using Earth's field?",
       "ja": "地磁気を使ってナビゲーションする動物が持つ感覚はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135018,7 +136138,8 @@
     "question_text": {
       "en": "Which food group is the primary source of animal protein in many diets?",
       "ja": "多くの食生活で動物性たんぱく質の主な供給源はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135041,7 +136162,7 @@
         "en": "echolocation",
         "ja": "反響定位",
         "ja_typings": [
-          "hankiyouteii"
+          "hankyouteii"
         ]
       },
       {
@@ -135059,7 +136180,8 @@
     "question_text": {
       "en": "Which ability lets owls and cats hunt in very low light?",
       "ja": "フクロウやネコが暗所で狩りができる視覚能力はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135157,14 +136279,14 @@
         "en": "amphibians",
         "ja": "両生類",
         "ja_typings": [
-          "riyouseirui"
+          "ryouseirui"
         ]
       },
       {
         "en": "mammals",
         "ja": "哺乳類",
         "ja_typings": [
-          "honiyuurui"
+          "honyuurui"
         ]
       },
       {
@@ -135183,7 +136305,8 @@
     "question_text": {
       "en": "Snakes, turtles and lizards belong to which class of animals?",
       "ja": "ヘビ・カメ・トカゲが属する動物の綱はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135206,7 +136329,7 @@
         "en": "night vision",
         "ja": "夜視力",
         "ja_typings": [
-          "yasiriyoku"
+          "yashiryoku"
         ]
       },
       {
@@ -135225,7 +136348,8 @@
     "question_text": {
       "en": "Which sense do dogs use exceptionally well to track prey or people?",
       "ja": "犬が獲物や人を追跡するときに特に優れている感覚はどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135240,7 +136364,7 @@
         "en": "perfect inning",
         "ja": "完全イニング",
         "ja_typings": [
-          "kanzeniningu"
+          "kanzenniningu"
         ]
       },
       {
@@ -135265,7 +136389,8 @@
     "question_text": {
       "en": "In baseball, getting three strikeouts in one inning is called what?",
       "ja": "野球で1イニングに3つ三振を取ることを何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135305,7 +136430,8 @@
     "question_text": {
       "en": "What does an arrow leave behind in flight, often used as an idiom?",
       "ja": "矢が飛んだ後に残るとされる、慣用句にもなるものはどれ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -135837,7 +136963,8 @@
     "question_text": {
       "en": "Which high-speed memory sits between the CPU and main memory?",
       "ja": "CPUと主記憶の間にある高速メモリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136433,7 +137560,7 @@
         "en": "Search function",
         "ja": "検索関数",
         "ja_typings": [
-          "kennsakukansuu"
+          "kensakukansuu"
         ]
       },
       {
@@ -136451,7 +137578,8 @@
     "question_text": {
       "en": "Which function maps arbitrary data to a fixed-size value?",
       "ja": "任意のデータを固定長の値に変換する関数は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -136778,7 +137906,8 @@
     "question_text": {
       "en": "Which memory directly accessed by the CPU during execution?",
       "ja": "CPUが実行中に直接アクセスする記憶領域は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138048,7 +139177,8 @@
     "question_text": {
       "en": "Which OS technique uses disk to extend addressable memory?",
       "ja": "ディスクを使って利用可能なメモリを拡張するOSの仕組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138252,7 +139382,8 @@
     "question_text": {
       "en": "Which is roughly the average winter temperature at the South Pole?",
       "ja": "南極の冬の平均気温に近いのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138292,7 +139423,8 @@
     "question_text": {
       "en": "Which temperature is physically impossible since absolute zero is -273 degrees?",
       "ja": "絶対零度がマイナス273度であるため物理的にあり得ない温度は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138332,7 +139464,8 @@
     "question_text": {
       "en": "At which Celsius temperature does pure water freeze at 1 atm?",
       "ja": "1気圧で純水が凍る摂氏温度は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138372,7 +139505,8 @@
     "question_text": {
       "en": "Which Celsius temperature is typical for a comfortable room?",
       "ja": "快適な室温として典型的な摂氏温度は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138412,7 +139546,8 @@
     "question_text": {
       "en": "Which Celsius temperature is considered a hot summer day in Japan?",
       "ja": "日本で真夏日の目安となる摂氏温度は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138452,7 +139587,8 @@
     "question_text": {
       "en": "Which Celsius temperature is classified as an extremely hot day in Japan?",
       "ja": "日本で猛暑日と分類される摂氏温度の目安は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138492,7 +139628,8 @@
     "question_text": {
       "en": "Which ABO blood type has antigen A on red blood cells?",
       "ja": "赤血球にA抗原を持つABO式血液型は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138532,7 +139669,8 @@
     "question_text": {
       "en": "Which lightweight metal has atomic number 13?",
       "ja": "原子番号13番の軽い金属は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138654,7 +139792,8 @@
     "question_text": {
       "en": "Which polar atmospheric phenomenon shows colorful curtains of light?",
       "ja": "極地で色とりどりの光のカーテンが見える大気現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138694,7 +139833,8 @@
     "question_text": {
       "en": "Which ABO blood type has antigen B on red blood cells?",
       "ja": "赤血球にB抗原を持つABO式血液型は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138784,7 +139924,7 @@
         "en": "Carbon",
         "ja": "炭素",
         "ja_typings": [
-          "tannso"
+          "tanso"
         ]
       },
       {
@@ -138817,7 +139957,8 @@
     "question_text": {
       "en": "Which element with symbol C is the basis of organic chemistry?",
       "ja": "有機化学の基盤となる元素記号Cの元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138839,7 +139980,7 @@
         "en": "Natural gas",
         "ja": "天然ガス",
         "ja_typings": [
-          "tennenngasu"
+          "tennnengasu"
         ]
       },
       {
@@ -138857,7 +139998,8 @@
     "question_text": {
       "en": "Which fossil fuel is a black sedimentary rock burned for energy?",
       "ja": "黒い堆積岩でエネルギー源として燃やされる化石燃料は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -138865,28 +140007,28 @@
         "en": "Combustion",
         "ja": "燃焼",
         "ja_typings": [
-          "nennshou"
+          "nenshou"
         ]
       },
       {
         "en": "Oxidation",
         "ja": "酸化",
         "ja_typings": [
-          "sannka"
+          "sanka"
         ]
       },
       {
         "en": "Reduction",
         "ja": "還元",
         "ja_typings": [
-          "kanngen"
+          "kangen"
         ]
       },
       {
         "en": "Electrolysis",
         "ja": "電気分解",
         "ja_typings": [
-          "dennkibunnkai"
+          "denkibunkai"
         ]
       }
     ],
@@ -138897,7 +140039,8 @@
     "question_text": {
       "en": "Which chemical reaction with oxygen produces heat and light?",
       "ja": "酸素と反応して熱と光を出す化学反応は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139028,7 +140171,7 @@
         "en": "Electromagnetic force",
         "ja": "電磁気力",
         "ja_typings": [
-          "dennjikiryoku"
+          "denjikiryoku"
         ]
       },
       {
@@ -139060,7 +140203,8 @@
     "question_text": {
       "en": "Which fundamental force acts between electrically charged particles?",
       "ja": "電荷を持つ粒子の間に働く基本相互作用は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139182,7 +140326,8 @@
     "question_text": {
       "en": "Which force resists motion between surfaces in contact?",
       "ja": "接触する面の運動を妨げる力は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139263,7 +140408,8 @@
     "question_text": {
       "en": "Which attractive force pulls objects toward the Earth?",
       "ja": "地球が物体を引き寄せる力は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139304,7 +140450,8 @@
     "question_text": {
       "en": "Which Japanese bacteriologist studied yellow fever and is on the 1000 yen note?",
       "ja": "黄熱病を研究し千円札の肖像にもなった日本の細菌学者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139427,7 +140574,8 @@
     "question_text": {
       "en": "Which element has atomic number 1 and symbol H?",
       "ja": "原子番号1番で記号Hの元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139476,7 +140624,7 @@
         "en": "Interference",
         "ja": "干渉",
         "ja_typings": [
-          "kannshou"
+          "kanshou"
         ]
       },
       {
@@ -139490,7 +140638,7 @@
         "en": "Reflection",
         "ja": "反射",
         "ja_typings": [
-          "hannsha"
+          "hansha"
         ]
       },
       {
@@ -139508,7 +140656,8 @@
     "question_text": {
       "en": "Which wave phenomenon results from superposition producing reinforcement and cancellation?",
       "ja": "波の重ね合わせで強め合いや打ち消しが起きる現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139564,7 +140713,7 @@
         "en": "Triassic",
         "ja": "三畳紀",
         "ja_typings": [
-          "sannjouki"
+          "sanjouki"
         ]
       },
       {
@@ -139578,7 +140727,7 @@
         "en": "Cambrian",
         "ja": "カンブリア紀",
         "ja_typings": [
-          "kannburiaki"
+          "kanburiaki"
         ]
       }
     ],
@@ -139589,7 +140738,8 @@
     "question_text": {
       "en": "Which Mesozoic geological period is famous for large dinosaurs?",
       "ja": "大型恐竜で有名な中生代の地質時代は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139670,7 +140820,8 @@
     "question_text": {
       "en": "Which disturbance of Earth's magnetic field is caused by solar wind?",
       "ja": "太陽風によって生じる地球磁場の擾乱は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139710,7 +140861,8 @@
     "question_text": {
       "en": "Which optical phenomenon makes distant objects appear distorted over hot ground?",
       "ja": "熱い地面の上で遠くの物体が歪んで見える光学現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139759,7 +140911,7 @@
         "en": "Natural gas",
         "ja": "天然ガス",
         "ja_typings": [
-          "tennenngasu"
+          "tennnengasu"
         ]
       },
       {
@@ -139791,7 +140943,8 @@
     "question_text": {
       "en": "Which fossil fuel is primarily composed of methane?",
       "ja": "主にメタンからなる化石燃料は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139831,7 +140984,8 @@
     "question_text": {
       "en": "Which electrically neutral subatomic particle is found in atomic nuclei?",
       "ja": "原子核に含まれる電気的に中性の粒子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139855,14 +141009,14 @@
         "en": "Combustion",
         "ja": "燃焼",
         "ja_typings": [
-          "nennshou"
+          "nenshou"
         ]
       },
       {
         "en": "Electrolysis",
         "ja": "電気分解",
         "ja_typings": [
-          "dennkibunnkai"
+          "denkibunkai"
         ]
       }
     ],
@@ -139873,7 +141027,8 @@
     "question_text": {
       "en": "Which type of reaction occurs in the Sun's core?",
       "ja": "太陽の中心で起きている反応の種類は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139913,7 +141068,8 @@
     "question_text": {
       "en": "Which ABO blood type has neither A nor B antigen?",
       "ja": "A抗原もB抗原も持たないABO式血液型は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -139976,7 +141132,7 @@
         "en": "Natural gas",
         "ja": "天然ガス",
         "ja_typings": [
-          "tennenngasu"
+          "tennnengasu"
         ]
       },
       {
@@ -139994,7 +141150,8 @@
     "question_text": {
       "en": "Which fossil fuel is refined into gasoline and diesel?",
       "ja": "ガソリンや軽油に精製される化石燃料は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140016,7 +141173,7 @@
         "en": "Carbon",
         "ja": "炭素",
         "ja_typings": [
-          "tannso"
+          "tanso"
         ]
       },
       {
@@ -140035,7 +141192,8 @@
     "question_text": {
       "en": "Which element with symbol O is essential for respiration?",
       "ja": "呼吸に不可欠な記号Oの元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140043,14 +141201,14 @@
         "en": "Paleogene",
         "ja": "古第三紀",
         "ja_typings": [
-          "kodaisannki"
+          "kodaisanki"
         ]
       },
       {
         "en": "Neogene",
         "ja": "新第三紀",
         "ja_typings": [
-          "shinndaisannki"
+          "shindaisanki"
         ]
       },
       {
@@ -140075,7 +141233,8 @@
     "question_text": {
       "en": "Which Cenozoic geological period followed the Cretaceous?",
       "ja": "白亜紀のあとに続く新生代の地質時代は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140156,7 +141315,8 @@
     "question_text": {
       "en": "Which elementary particle is the quantum of light?",
       "ja": "光の量子に相当する素粒子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140196,7 +141356,8 @@
     "question_text": {
       "en": "Which positively charged particle is found in atomic nuclei?",
       "ja": "原子核に含まれる正電荷の粒子は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140277,7 +141438,8 @@
     "question_text": {
       "en": "Which color is produced by mixing red and blue light?",
       "ja": "赤い光と青い光を混ぜると見える色は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140317,7 +141479,8 @@
     "question_text": {
       "en": "Which optical phenomenon appears as a colored arc after rain?",
       "ja": "雨上がりに見える色の弧の光学現象は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140407,7 +141570,7 @@
         "en": "Seismic intensity",
         "ja": "震度",
         "ja_typings": [
-          "shinndo"
+          "shindo"
         ]
       },
       {
@@ -140439,7 +141602,8 @@
     "question_text": {
       "en": "Which Japanese scale measures the strength of shaking at a location?",
       "ja": "ある地点での揺れの強さを表す日本の尺度は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140454,7 +141618,7 @@
         "en": "Carbon",
         "ja": "炭素",
         "ja_typings": [
-          "tannso"
+          "tanso"
         ]
       },
       {
@@ -140479,7 +141643,8 @@
     "question_text": {
       "en": "Which element with symbol Si is the main material of semiconductors?",
       "ja": "半導体の主材料となる記号Siの元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140519,7 +141684,8 @@
     "question_text": {
       "en": "Which is the brightest star in Earth's night sky?",
       "ja": "地球の夜空で最も明るく見える恒星は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140534,7 +141700,7 @@
         "en": "Carbon",
         "ja": "炭素",
         "ja_typings": [
-          "tannso"
+          "tanso"
         ]
       },
       {
@@ -140559,7 +141725,8 @@
     "question_text": {
       "en": "Which yellow element with symbol S is found near volcanoes?",
       "ja": "火山周辺で見られる記号Sの黄色い元素は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140567,7 +141734,7 @@
         "en": "Triassic",
         "ja": "三畳紀",
         "ja_typings": [
-          "sannjouki"
+          "sanjouki"
         ]
       },
       {
@@ -140599,7 +141766,8 @@
     "question_text": {
       "en": "Which Mesozoic period came right before the Jurassic?",
       "ja": "ジュラ紀の直前に位置する中生代の地質時代は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140639,7 +141807,8 @@
     "question_text": {
       "en": "Which color is the result of mixing all visible wavelengths of light equally?",
       "ja": "可視光のすべての波長を均等に混ぜたときに見える色は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140679,7 +141848,8 @@
     "question_text": {
       "en": "Which is the color of a ripe lemon?",
       "ja": "熟したレモンの色は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140760,7 +141930,8 @@
     "question_text": {
       "en": "Which hololive VTuber is known for music activities and is sometimes called the goddess of music?",
       "ja": "ホロライブで音楽活動を中心にする「ソング・フォー・ユー」を歌うVTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140882,7 +142053,8 @@
     "question_text": {
       "en": "Which Japanese word means 'storm' and is also a famous idol group name?",
       "ja": "「嵐」を意味し有名アイドルグループ名でもある言葉は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140922,7 +142094,8 @@
     "question_text": {
       "en": "What does the net abbreviation 'BTW' stand for?",
       "ja": "ネット略語「BTW」の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -140963,7 +142136,8 @@
     "question_text": {
       "en": "Which Japanese word means 'subtle' or 'so-so'?",
       "ja": "「微妙」を意味する日本語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141003,7 +142177,8 @@
     "question_text": {
       "en": "What is the name of the virtual currency used to cheer on Twitch?",
       "ja": "Twitchで配信者を応援するために使う仮想通貨は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141126,7 +142301,8 @@
     "question_text": {
       "en": "What is a streaming format where multiple VTubers appear together called?",
       "ja": "複数のVTuberが一緒に出演する配信形式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141329,7 +142505,8 @@
     "question_text": {
       "en": "What does the net abbreviation 'FYI' stand for?",
       "ja": "ネット略語「FYI」の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141451,7 +142628,8 @@
     "question_text": {
       "en": "Which Japanese word means 'trash' and is used as net slang?",
       "ja": "ネットスラングで「ゴミ」を意味する言葉は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141614,7 +142792,8 @@
     "question_text": {
       "en": "Which Nijisanji VTuber is the leader of the 'Iwagumi' generation and has cat ears?",
       "ja": "にじさんじの「岩組」のリーダーで猫耳のVTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141658,7 +142837,8 @@
     "question_text": {
       "en": "Which country is the headquarters of Hololive based in?",
       "ja": "ホロライブの本社がある国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141740,7 +142920,8 @@
     "question_text": {
       "en": "Which East Asian country borders Japan and has its own VTuber scene?",
       "ja": "日本の隣にあり独自のVTuber文化を持つ東アジアの国は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141780,7 +142961,8 @@
     "question_text": {
       "en": "Which Japanese word means 'mastermind' behind the scenes?",
       "ja": "陰で操る黒幕を意味する日本語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141820,7 +143002,8 @@
     "question_text": {
       "en": "Which Nijisanji male duo became hugely popular as the 'ChroNoiR' unit?",
       "ja": "にじさんじでChroNoiRとして活動する男性デュオは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141860,7 +143043,8 @@
     "question_text": {
       "en": "What is the slang term for a stream of paid YouTube Super Chat messages?",
       "ja": "YouTubeのスーパーチャットの俗称は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -141982,7 +143166,8 @@
     "question_text": {
       "en": "Which English word borrowed into Japanese means 'message'?",
       "ja": "「メッセージ」を意味するドイツ語由来の言葉で、見本市の意味もある語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142022,7 +143207,8 @@
     "question_text": {
       "en": "Which Hololive VTuber has blue twintails and is famous for the 'Aqua Crew'?",
       "ja": "ホロライブで青いツインテールが特徴のVTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142044,7 +143230,7 @@
         "en": "Reaction douga",
         "ja": "リアクション動画",
         "ja_typings": [
-          "riakushondo-ga"
+          "riakushondouga"
         ]
       },
       {
@@ -142062,7 +143248,8 @@
     "question_text": {
       "en": "What do you call replaying another streamer's broadcast on your own channel?",
       "ja": "他人の配信を自分の画面で同時に映す配信形式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142102,7 +143289,8 @@
     "question_text": {
       "en": "Which Hololive VTuber has purple hair and is the younger sister of Yozora Mel?",
       "ja": "ホロライブの紫髪のVTuberで、夜空メルの妹分とされるのは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142142,7 +143330,8 @@
     "question_text": {
       "en": "Which Hololive VTuber has red oni horns and is part of 'Yo-rappers'?",
       "ja": "赤い鬼の角が特徴のホロライブVTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142183,7 +143372,8 @@
     "question_text": {
       "en": "What was the name of NHK's traditional New Year's Eve singing contest, parodied on Niconico?",
       "ja": "NHK紅白歌合戦をパロディしたニコニコ動画の年末イベントは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142224,7 +143414,8 @@
     "question_text": {
       "en": "What is the slang term for a die-hard Niconico Douga fan?",
       "ja": "ニコニコ動画に熱中する人を指すスラングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142264,7 +143455,8 @@
     "question_text": {
       "en": "What is the annual Niconico user festival held in Makuhari called?",
       "ja": "幕張メッセで行われるニコニコ動画のリアルイベントは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142304,7 +143496,8 @@
     "question_text": {
       "en": "Which Atlus RPG series features Shadows and the Velvet Room?",
       "ja": "アトラスのRPGで「ベルベットルーム」が登場するシリーズは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142386,7 +143579,8 @@
     "question_text": {
       "en": "What kind of video shows a streamer's responses to other content?",
       "ja": "他の動画や配信に対する反応を撮った動画は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142426,7 +143620,8 @@
     "question_text": {
       "en": "What is the slang term for spamming the same comment repeatedly?",
       "ja": "同じコメントを何度も連投することを指すスラングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142466,7 +143661,8 @@
     "question_text": {
       "en": "Which Hololive VTuber is a robot girl voiced as a tinkerer who builds Robohouse?",
       "ja": "ホロライブのロボット娘で工作好きなVTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142506,7 +143702,8 @@
     "question_text": {
       "en": "Which Hololive VTuber is a white fox-girl and 'gamers' group member?",
       "ja": "ホロライブGAMERSの白い狐のVTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142628,7 +143825,8 @@
     "question_text": {
       "en": "What do you call unsolicited junk messages on the internet?",
       "ja": "ネット上の迷惑な大量メッセージのことを何という?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142750,7 +143948,8 @@
     "question_text": {
       "en": "What does the net abbreviation 'TBH' stand for?",
       "ja": "ネット略語「TBH」の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142790,7 +143989,8 @@
     "question_text": {
       "en": "Which Japanese word refers to the 'soul' inside a VTuber avatar?",
       "ja": "VTuberのアバターの中の人(魂)を指す日本語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142830,7 +144030,8 @@
     "question_text": {
       "en": "Which male VTuber is known as the leader of 'Tasokare Hotel' and 774 inc?",
       "ja": "774inc.に所属し「黄昏ホテル」で知られる男性VTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142941,7 +144142,7 @@
         "en": "Nicochu",
         "ja": "ニコ厨",
         "ja_typings": [
-          "nikochu"
+          "nikochuu"
         ]
       }
     ],
@@ -142952,7 +144153,8 @@
     "question_text": {
       "en": "Which short-form video app is owned by ByteDance and popular for dance trends?",
       "ja": "ByteDanceが運営するショート動画アプリは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -142992,7 +144194,8 @@
     "question_text": {
       "en": "What is the annual Niconico gaming festival called?",
       "ja": "ニコニコが主催するゲームのリアルイベントは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143021,7 +144224,7 @@
         "en": "Nicochu",
         "ja": "ニコ厨",
         "ja_typings": [
-          "nikochu"
+          "nikochuu"
         ]
       }
     ],
@@ -143032,7 +144235,8 @@
     "question_text": {
       "en": "Which Amazon-owned live streaming platform is centered on gaming?",
       "ja": "Amazon傘下のゲーム配信に強いストリーミングサービスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143072,7 +144276,8 @@
     "question_text": {
       "en": "Which Hololive VTuber is a bunny girl famous for 'peko peko peko'?",
       "ja": "「ぺこぺこぺこ」で有名なホロライブのバニーVTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143094,7 +144299,7 @@
         "en": "Reaction douga",
         "ja": "リアクション動画",
         "ja_typings": [
-          "riakushondo-ga"
+          "riakushondouga"
         ]
       },
       {
@@ -143112,7 +144317,8 @@
     "question_text": {
       "en": "What kind of software changes the pitch or tone of a streamer's voice?",
       "ja": "配信者の声を加工するソフトウェアの一般名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143152,7 +144358,8 @@
     "question_text": {
       "en": "Which early .LIVE VTuber is known as a quiet aesthetic singer with long hair?",
       "ja": "アイドル部の長髪で物静かな歌姫VTuberは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143181,7 +144388,7 @@
         "en": "Nicochu",
         "ja": "ニコ厨",
         "ja_typings": [
-          "nikochu"
+          "nikochuu"
         ]
       }
     ],
@@ -143192,7 +144399,8 @@
     "question_text": {
       "en": "Which Google-owned video platform is the largest in the world?",
       "ja": "Googleが運営する世界最大の動画共有サイトは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143232,7 +144440,8 @@
     "question_text": {
       "en": "Which Japanese word means 'weakling' and is often shouted by streamers?",
       "ja": "「雑魚」を意味し配信者がよく叫ぶスラングは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143354,7 +144563,8 @@
     "question_text": {
       "en": "Which ancient Mesoamerican civilization built Tenochtitlan?",
       "ja": "テノチティトランを築いた古代メソアメリカ文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143394,7 +144604,8 @@
     "question_text": {
       "en": "What is the central sacred book of Christianity called?",
       "ja": "キリスト教の聖典は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143516,7 +144727,8 @@
     "question_text": {
       "en": "Which major river flows through Tibet, India and Bangladesh?",
       "ja": "チベット、インド、バングラデシュを流れる大河は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143556,7 +144768,8 @@
     "question_text": {
       "en": "Which planned city, designed by Oscar Niemeyer, is the capital of Brazil?",
       "ja": "オスカー・ニーマイヤー設計のブラジルの計画都市の首都は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143678,7 +144891,8 @@
     "question_text": {
       "en": "Which Parisian iron landmark was built for the 1889 World's Fair?",
       "ja": "1889年パリ万博のために建てられた鉄の塔は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143841,7 +145055,8 @@
     "question_text": {
       "en": "Which American architect designed Fallingwater and the Guggenheim Museum?",
       "ja": "落水荘やグッゲンハイム美術館を設計したアメリカの建築家は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -143881,7 +145096,8 @@
     "question_text": {
       "en": "Which traditional Japanese wooden footwear has a raised platform on two 'teeth'?",
       "ja": "二本歯の台がある日本の伝統的な木の履物は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144003,7 +145219,8 @@
     "question_text": {
       "en": "Which major South Asian river gave its name to an ancient civilization in Pakistan?",
       "ja": "パキスタンを流れ古代文明の名にもなった大河は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144126,7 +145343,8 @@
     "question_text": {
       "en": "Which sumo rank is the fourth-highest, ranked just below Sekiwake?",
       "ja": "大相撲の番付で関脇のすぐ下の地位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144166,7 +145384,8 @@
     "question_text": {
       "en": "Which Israeli self-defense martial art was developed for military use?",
       "ja": "イスラエル軍で生まれた自己防衛のための格闘術は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144247,7 +145466,8 @@
     "question_text": {
       "en": "Which famous Paris museum houses the Mona Lisa?",
       "ja": "モナ・リザを所蔵するパリの美術館は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144287,7 +145507,8 @@
     "question_text": {
       "en": "Which ancient Mesoamerican civilization is known for Chichen Itza and the Long Count calendar?",
       "ja": "チチェン・イッツァや長期暦で知られる古代メソアメリカ文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144327,7 +145548,8 @@
     "question_text": {
       "en": "Which soft leather shoe is associated with Native American tradition?",
       "ja": "ネイティブアメリカンの伝統的な柔らかい革靴は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144367,7 +145589,8 @@
     "question_text": {
       "en": "Which is considered the earliest known major civilization of Mesoamerica, predating the Maya?",
       "ja": "マヤ文明より古い、メソアメリカ最古とされる文明は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144408,7 +145631,8 @@
     "question_text": {
       "en": "Which sumo rank is the second-highest, just below Yokozuna?",
       "ja": "大相撲の番付で横綱のすぐ下の地位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144448,7 +145672,8 @@
     "question_text": {
       "en": "Which ancient Roman temple in Rome has a famous dome and oculus?",
       "ja": "ローマにあるドームと天窓で有名な古代神殿は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144488,7 +145713,8 @@
     "question_text": {
       "en": "Which Jewish holiday commemorates the Exodus from Egypt?",
       "ja": "ユダヤ教でエジプト脱出を記念する祭りは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144651,7 +145877,8 @@
     "question_text": {
       "en": "Which traditional wooden shoe is associated with France and the Netherlands?",
       "ja": "フランスやオランダの木製の伝統的な靴は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144691,7 +145918,8 @@
     "question_text": {
       "en": "Which sumo rank is the third-highest, just below Ozeki?",
       "ja": "大相撲の番付で大関のすぐ下の地位は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144813,7 +146041,8 @@
     "question_text": {
       "en": "Which Korean martial art is known for its powerful kicks and is an Olympic sport?",
       "ja": "強力な蹴りで知られ五輪競技にもなった韓国発祥の格闘技は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -144935,7 +146164,8 @@
     "question_text": {
       "en": "Which sacred Jewish scripture corresponds to the first five books of the Hebrew Bible?",
       "ja": "ヘブライ語聖書の最初の五書に当たるユダヤ教の聖典は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145016,7 +146246,8 @@
     "question_text": {
       "en": "Which ancient Indian sacred texts form the foundation of Hindu scripture?",
       "ja": "ヒンドゥー教の聖典の基礎となる古代インドの聖典は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -145097,7 +146328,8 @@
     "question_text": {
       "en": "Which sacred river of India flows through Delhi and joins the Ganges at Prayagraj?",
       "ja": "デリーを流れプラヤーグラージでガンジス川と合流するインドの聖なる川は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146859,7 +148091,8 @@
     "question_text": {
       "en": "What is the linguistic term for a bound morpheme attached to a word stem (prefix, suffix, infix)?",
       "ja": "語幹に付加される接頭辞・接尾辞などの拘束形態素を指す言語学用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146899,7 +148132,8 @@
     "question_text": {
       "en": "Which language family includes Arabic, Hebrew, and ancient Egyptian?",
       "ja": "アラビア語・ヘブライ語・古代エジプト語を含む語族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146939,7 +148173,8 @@
     "question_text": {
       "en": "Which part of speech in English includes \"can,\" \"will,\" \"must,\" and \"may\"?",
       "ja": "英語で can / will / must / may を含む品詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -146979,7 +148214,8 @@
     "question_text": {
       "en": "In Japanese kanji learning order, which direction is sometimes used in stroke order references?",
       "ja": "漢字の筆順の説明で、下から上へ書く方向性を指す表現は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147019,7 +148255,8 @@
     "question_text": {
       "en": "Which voice expresses that the subject causes someone or something else to perform an action?",
       "ja": "主語が他者に動作を行わせることを表す態(ヴォイス)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147059,7 +148296,8 @@
     "question_text": {
       "en": "What are the logographic characters borrowed from China and used in Japanese called in English?",
       "ja": "日本語で中国由来の表意文字である漢字を英語で何と呼ぶ?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147067,21 +148305,21 @@
         "en": "Customary reading",
         "ja": "慣用読み",
         "ja_typings": [
-          "kanyouyomi"
+          "kannyouyomi"
         ]
       },
       {
         "en": "On reading",
         "ja": "音読み",
         "ja_typings": [
-          "onyomi"
+          "onnyomi"
         ]
       },
       {
         "en": "Kun reading",
         "ja": "訓読み",
         "ja_typings": [
-          "kunyomi"
+          "kunnyomi"
         ]
       },
       {
@@ -147099,7 +148337,8 @@
     "question_text": {
       "en": "Which kanji reading is based on traditional convention rather than standard on/kun readings?",
       "ja": "音読み・訓読みの標準的な規則ではなく慣習に基づく漢字の読み方は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147139,7 +148378,8 @@
     "question_text": {
       "en": "Which alphabet is used for Russian, Bulgarian, and Serbian?",
       "ja": "ロシア語・ブルガリア語・セルビア語で用いられる文字体系は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147209,7 +148449,7 @@
         "en": "Metaphor",
         "ja": "隠喩",
         "ja_typings": [
-          "inyu"
+          "innyu"
         ]
       }
     ],
@@ -147220,7 +148460,8 @@
     "question_text": {
       "en": "What is the rhetorical device of omitting words that are understood from context?",
       "ja": "文脈から自明な語を省略する修辞技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147260,7 +148501,8 @@
     "question_text": {
       "en": "What is the final part of a Japanese conjugated word called?",
       "ja": "日本語の活用語の末尾(活用語尾)を指す語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147300,7 +148542,8 @@
     "question_text": {
       "en": "Which romanization system for Japanese was popularized by an American missionary's dictionary?",
       "ja": "米国人宣教師の辞典で普及した日本語のローマ字表記法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147340,7 +148583,8 @@
     "question_text": {
       "en": "Which language family includes English, Hindi, Russian, and Greek?",
       "ja": "英語・ヒンディー語・ロシア語・ギリシャ語を含む語族は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147380,7 +148624,8 @@
     "question_text": {
       "en": "What is the rhetorical device of reversing the usual word order for emphasis?",
       "ja": "強調のために通常の語順を入れ替える修辞技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147420,7 +148665,8 @@
     "question_text": {
       "en": "Which script is used to write the Khmer language of Cambodia?",
       "ja": "カンボジアのクメール語を書き表す文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147460,7 +148706,8 @@
     "question_text": {
       "en": "Which alphabet is used for English, French, Spanish, and most European languages?",
       "ja": "英語・フランス語・スペイン語など多くの欧州言語で使われる文字体系は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147468,7 +148715,7 @@
         "en": "Metaphor",
         "ja": "隠喩",
         "ja_typings": [
-          "inyu"
+          "innyu"
         ]
       },
       {
@@ -147482,7 +148729,7 @@
         "en": "Metonymy",
         "ja": "換喩",
         "ja_typings": [
-          "kanyu"
+          "kannyu"
         ]
       },
       {
@@ -147500,7 +148747,8 @@
     "question_text": {
       "en": "What is the rhetorical device of describing one thing as if it were another (e.g., \"Time is money\")?",
       "ja": "あるものを別のものに見立てて表現する修辞技法(例: 時は金なり)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147508,14 +148756,14 @@
         "en": "Metonymy",
         "ja": "換喩",
         "ja_typings": [
-          "kanyu"
+          "kannyu"
         ]
       },
       {
         "en": "Metaphor",
         "ja": "隠喩",
         "ja_typings": [
-          "inyu"
+          "innyu"
         ]
       },
       {
@@ -147540,7 +148788,8 @@
     "question_text": {
       "en": "Which rhetorical device substitutes a related concept for the name of a thing (e.g., \"the crown\" for monarchy)?",
       "ja": "事物の名を関連概念で置き換える修辞技法(例: 王冠が王権を指す)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147580,7 +148829,8 @@
     "question_text": {
       "en": "What is the final part of a Japanese noun's conjugational form called?",
       "ja": "日本語で名詞活用の語尾部分を指す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147620,7 +148870,8 @@
     "question_text": {
       "en": "Which Japanese part of speech marks grammatical relations like subject, object, and topic?",
       "ja": "主語・目的語・主題などの文法関係を示す日本語の品詞は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147660,7 +148911,8 @@
     "question_text": {
       "en": "Which voice expresses that the subject receives the action of the verb?",
       "ja": "主語が動作の受け手であることを表す態(ヴォイス)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147675,14 +148927,14 @@
         "en": "Metaphor",
         "ja": "隠喩",
         "ja_typings": [
-          "inyu"
+          "innyu"
         ]
       },
       {
         "en": "Metonymy",
         "ja": "換喩",
         "ja_typings": [
-          "kanyu"
+          "kannyu"
         ]
       },
       {
@@ -147700,7 +148952,8 @@
     "question_text": {
       "en": "What rhetorical device gives human qualities to non-human things?",
       "ja": "人ではないものに人間的性質を与える修辞技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147740,7 +148993,8 @@
     "question_text": {
       "en": "What is the polite style of Japanese using forms like \"desu\" and \"masu\" called?",
       "ja": "「です」「ます」を用いる日本語の丁寧な文体は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147780,7 +149034,8 @@
     "question_text": {
       "en": "Which Romance language is the official language of Portugal and Brazil?",
       "ja": "ポルトガルとブラジルの公用語であるロマンス諸語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147820,7 +149075,8 @@
     "question_text": {
       "en": "Which subfield of linguistics studies how context contributes to meaning?",
       "ja": "文脈が意味に与える影響を研究する言語学の下位分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147860,7 +149116,8 @@
     "question_text": {
       "en": "Which interdisciplinary field studies the mental processes involved in language use?",
       "ja": "言語使用に関わる心的過程を研究する学際分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147900,7 +149157,8 @@
     "question_text": {
       "en": "What is the Japanese phonological phenomenon where a voiceless consonant becomes voiced in compounds (e.g., hito + hito = hitobito)?",
       "ja": "複合語で清音が濁音化する日本語の音韻現象(例: ひと+ひと=ひとびと)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147929,7 +149187,7 @@
         "en": "Metaphor",
         "ja": "隠喩",
         "ja_typings": [
-          "inyu"
+          "innyu"
         ]
       }
     ],
@@ -147940,7 +149198,8 @@
     "question_text": {
       "en": "Which rhetorical device repeats words or phrases for emphasis?",
       "ja": "強調のために語句を繰り返す修辞技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -147980,7 +149239,8 @@
     "question_text": {
       "en": "What is the Japanese honorific style used to elevate the listener or referent called?",
       "ja": "聞き手や話題の人物を高める日本語の敬語スタイルは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148061,7 +149321,8 @@
     "question_text": {
       "en": "Which subfield of linguistics studies the relationship between language and society?",
       "ja": "言語と社会の関係を研究する言語学の下位分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148101,7 +149362,8 @@
     "question_text": {
       "en": "Which Romance language is the official language of Spain and most of Latin America?",
       "ja": "スペインおよびラテンアメリカの多くの国の公用語であるロマンス諸語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148141,7 +149403,8 @@
     "question_text": {
       "en": "What is the unchanging core part of a Japanese conjugated word called?",
       "ja": "日本語の活用語で変化しない中心部分を指す語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148156,7 +149419,7 @@
         "en": "Metonymy",
         "ja": "換喩",
         "ja_typings": [
-          "kanyu"
+          "kannyu"
         ]
       },
       {
@@ -148181,7 +149444,8 @@
     "question_text": {
       "en": "Which rhetorical device uses a part to represent the whole, or vice versa (e.g., \"all hands on deck\")?",
       "ja": "部分で全体を、あるいは全体で部分を表す修辞技法(例: \"all hands\" が船員を指す)は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148221,7 +149485,8 @@
     "question_text": {
       "en": "Which subfield of linguistics studies the rules governing sentence structure?",
       "ja": "文の構造を規定する規則を研究する言語学の下位分野は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148261,7 +149526,8 @@
     "question_text": {
       "en": "Which script is used to write the Thai language?",
       "ja": "タイ語を書き表す文字は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148342,7 +149608,8 @@
     "question_text": {
       "en": "Who created the manga \"Dragon Ball\"?",
       "ja": "漫画『ドラゴンボール』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148382,7 +149649,8 @@
     "question_text": {
       "en": "Who created the manga \"One Piece\"?",
       "ja": "漫画『ONE PIECE』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148390,14 +149658,14 @@
         "en": "Fujiko F. Fujio",
         "ja": "藤子・F・不二雄",
         "ja_typings": [
-          "fujikoffujio"
+          "fujiko/f/fujio"
         ]
       },
       {
         "en": "Fujiko Fujio A",
         "ja": "藤子不二雄A",
         "ja_typings": [
-          "fujikofujioa"
+          "fujikofujioe-"
         ]
       },
       {
@@ -148422,7 +149690,8 @@
     "question_text": {
       "en": "Which pen name was used by the duo behind \"Doraemon\"?",
       "ja": "『ドラえもん』を生んだコンビが用いたペンネームは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148437,7 +149706,7 @@
         "en": "Shueisha",
         "ja": "集英社",
         "ja_typings": [
-          "shueisha"
+          "shuueisha"
         ]
       },
       {
@@ -148462,7 +149731,8 @@
     "question_text": {
       "en": "Which Japanese publisher issues \"Weekly Manga Action\" and \"Manga Town\"?",
       "ja": "『漫画アクション』『漫画タウン』を発行する日本の出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148477,7 +149747,7 @@
         "en": "Shueisha",
         "ja": "集英社",
         "ja_typings": [
-          "shueisha"
+          "shuueisha"
         ]
       },
       {
@@ -148502,7 +149772,8 @@
     "question_text": {
       "en": "Which Japanese publisher issues \"Hana to Yume\" and \"LaLa\"?",
       "ja": "『花とゆめ』『LaLa』を発行する日本の出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148517,7 +149788,7 @@
         "en": "Shueisha",
         "ja": "集英社",
         "ja_typings": [
-          "shueisha"
+          "shuueisha"
         ]
       },
       {
@@ -148542,7 +149813,8 @@
     "question_text": {
       "en": "Which publisher issues \"Monthly Shonen Ace\" and is a major light novel publisher?",
       "ja": "『月刊少年エース』を発行しライトノベルでも大手の出版社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148582,7 +149854,8 @@
     "question_text": {
       "en": "Who created \"Akira\"?",
       "ja": "漫画『AKIRA』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148622,7 +149895,8 @@
     "question_text": {
       "en": "Who created \"Berserk\"?",
       "ja": "漫画『ベルセルク』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148662,7 +149936,8 @@
     "question_text": {
       "en": "Who created \"Ghost in the Shell\"?",
       "ja": "『攻殻機動隊』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148702,7 +149977,8 @@
     "question_text": {
       "en": "Who is the protagonist artist character of \"Glass Mask\" (Garasu no Kamen)?",
       "ja": "『ガラスの仮面』に登場する天才舞台女優のライバルの名は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148742,7 +150018,8 @@
     "question_text": {
       "en": "Which Japanese newspaper company is known for its economic and business news?",
       "ja": "経済・ビジネスニュースで知られる日本の新聞社は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148782,7 +150059,8 @@
     "question_text": {
       "en": "Who is the illustrator of \"Death Note\" and \"Bakuman\"?",
       "ja": "『DEATH NOTE』『バクマン。』の作画担当は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148822,7 +150100,8 @@
     "question_text": {
       "en": "Who created \"Chainsaw Man\"?",
       "ja": "『チェンソーマン』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148862,7 +150141,8 @@
     "question_text": {
       "en": "Who created \"Fist of the North Star\" as the artist?",
       "ja": "『北斗の拳』の作画担当は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148902,7 +150182,8 @@
     "question_text": {
       "en": "Which national daily Japanese newspaper is published by Mainichi Shimbun Holdings?",
       "ja": "毎日新聞社が発行する日本の全国紙は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148942,7 +150223,8 @@
     "question_text": {
       "en": "Which Japanese daily newspaper has the largest circulation, published by The Yomiuri Shimbun Holdings?",
       "ja": "発行部数が日本最大級の、読売新聞社が発行する全国紙は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -148982,7 +150264,8 @@
     "question_text": {
       "en": "Who is the writer of \"Death Note\" and \"Bakuman\"?",
       "ja": "『DEATH NOTE』『バクマン。』の原作担当は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -149022,7 +150305,8 @@
     "question_text": {
       "en": "Which Shogakukan magazine serialized \"InuYasha\" and \"Detective Conan\"?",
       "ja": "『犬夜叉』『名探偵コナン』を連載する小学館の漫画雑誌は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -149062,6 +150346,7 @@
     "question_text": {
       "en": "Who created \"Kingdom\"?",
       "ja": "漫画『キングダム』の作者は?"
-    }
+    },
+    "ja_reviewed": true
   }
 ]

--- a/data/questions_ja.json
+++ b/data/questions_ja.json
@@ -30503,7 +30503,8 @@
     "question_text": {
       "en": "Which OSI model layer is responsible for end-to-end communication and reliability?",
       "ja": "OSI 参照モデルでエンドツーエンドの通信と信頼性を担う層は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -30707,7 +30708,8 @@
     "question_text": {
       "en": "Which programming paradigm treats computation as evaluation of mathematical functions?",
       "ja": "計算を数学的関数の評価として扱うプログラミングパラダイムは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68598,7 +68600,7 @@
         "en": "Financial Operations",
         "ja": "クラウド財務運用",
         "ja_typings": [
-          "kuraudozaimuunyou"
+          "kuraudozaimuunnyou"
         ]
       },
       {
@@ -68630,7 +68632,8 @@
     "question_text": {
       "en": "What does FinOps stand for?",
       "ja": "FinOpsの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68711,7 +68714,8 @@
     "question_text": {
       "en": "What does SLO stand for?",
       "ja": "SLOの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68751,7 +68755,8 @@
     "question_text": {
       "en": "Which testing technique tries unexpected inputs?",
       "ja": "予期しない入力を試すテスト技法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68832,7 +68837,8 @@
     "question_text": {
       "en": "What does MTTR mean in SRE?",
       "ja": "SREの『MTTR』は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -68954,7 +68960,8 @@
     "question_text": {
       "en": "What does TDD stand for?",
       "ja": "TDDの意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69117,7 +69124,8 @@
     "question_text": {
       "en": "What does the term 'shift left' mean?",
       "ja": "『シフトレフト』の意味は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69132,7 +69140,7 @@
         "en": "Operations Key Reports",
         "ja": "運用報告",
         "ja_typings": [
-          "unyouhoukoku"
+          "unnyouhoukoku"
         ]
       },
       {
@@ -69157,7 +69165,8 @@
     "question_text": {
       "en": "Which framework defines OKRs?",
       "ja": "OKRsを定める枠組みは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69238,7 +69247,8 @@
     "question_text": {
       "en": "What is a feature flag?",
       "ja": "フィーチャーフラグとは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69278,7 +69288,8 @@
     "question_text": {
       "en": "Which methodology limits work in progress?",
       "ja": "進行中作業を制限する手法は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69318,7 +69329,8 @@
     "question_text": {
       "en": "Which test isolates a single function?",
       "ja": "単一機能を分離して試すテストは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69367,7 +69379,7 @@
         "en": "intentional failure injection",
         "ja": "意図的障害注入",
         "ja_typings": [
-          "itotekishougainyuunyuu"
+          "itotekishougaichuunyuu"
         ]
       },
       {
@@ -69399,7 +69411,8 @@
     "question_text": {
       "en": "What is 'chaos engineering' about?",
       "ja": "カオスエンジニアリングとは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69439,7 +69452,8 @@
     "question_text": {
       "en": "Which deployment uses identical environment swap?",
       "ja": "同一環境を切り替える展開は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69520,7 +69534,8 @@
     "question_text": {
       "en": "What is a SLA?",
       "ja": "SLAとは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69560,7 +69575,8 @@
     "question_text": {
       "en": "Which testing examines security flaws?",
       "ja": "セキュリティ欠陥を調べるテストは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -69641,7 +69657,8 @@
     "question_text": {
       "en": "What is a 'sidecar' pattern in K8s?",
       "ja": "K8sの『サイドカー』パターンとは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98005,7 +98022,8 @@
     "question_text": {
       "en": "Which non-functional requirement measures uptime of a system?",
       "ja": "システムの稼働率を示す非機能要件は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98291,7 +98309,8 @@
     "question_text": {
       "en": "Which DevOps practice automatically delivers code to production?",
       "ja": "コードを自動で本番にデリバリする DevOps プラクティスは?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98496,7 +98515,8 @@
     "question_text": {
       "en": "Which metric measures how often predictions are correct?",
       "ja": "予測の正答率を表す指標は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98537,7 +98557,8 @@
     "question_text": {
       "en": "Which security concept verifies the identity of a user?",
       "ja": "ユーザーの本人確認を行うセキュリティ概念は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98579,7 +98600,8 @@
     "question_text": {
       "en": "Which data property describes data surviving after the program ends?",
       "ja": "プログラム終了後もデータが保持される性質は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98621,7 +98643,8 @@
     "question_text": {
       "en": "Which non-functional requirement is about response time and throughput?",
       "ja": "応答時間やスループットを評価する非機能要件は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98662,7 +98685,8 @@
     "question_text": {
       "en": "Which non-functional requirement protects personal information?",
       "ja": "個人情報の保護に関する非機能要件は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -98784,7 +98808,8 @@
     "question_text": {
       "en": "Which project term marks a significant scheduled checkpoint?",
       "ja": "プロジェクトの重要な節目を示す用語は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [
@@ -99193,7 +99218,8 @@
     "question_text": {
       "en": "Which processing mode runs a job collectively at scheduled times?",
       "ja": "決まった時刻にまとめて処理する方式は?"
-    }
+    },
+    "ja_reviewed": true
   },
   {
     "choices": [

--- a/scripts/kanji_review.py
+++ b/scripts/kanji_review.py
@@ -172,6 +172,19 @@ def apply(verdicts_path: str) -> int:
     return 0
 
 
+def _strip_spurious_slashes(t: str) -> str:
+    """Drop bare `/` separators, mirroring `canonical_romaji`'s handling so
+    the result types the same kana. A lone `n` before `/`+(vowel/n/y) doubles
+    to `nn` (`kan/no` -> `kanno`-with-the-extra-n); an already-doubled `nn/`
+    is protected first so it never becomes `nnn` (matches the matcher's
+    sentinel trick in normalize.rs)."""
+    sentinel = "\x01"
+    t = t.replace("nn/", sentinel)
+    t = re.sub(r"n/([aiueoyn])", r"nn\1", t)
+    t = t.replace(sentinel, "nn")
+    return t.replace("/", "")
+
+
 def fix_spurious_slashes() -> int:
     """Remove `/` used as a bare word separator (lint rule P1).
 
@@ -190,16 +203,23 @@ def fix_spurious_slashes() -> int:
         for c in q.get("choices", []):
             ja = c.get("ja", "")
             allowed = ja.count("・") + ja.count("/")
+            typings = c.get("ja_typings") or []
             new_typings = []
-            for t in c.get("ja_typings") or []:
-                if t.count("/") > allowed:
-                    t2 = re.sub(r"n/([aiueoyn])", r"nn\1", t).replace("/", "")
+            for t in typings:
+                # Only auto-fix when the label justifies *no* slash at all
+                # (allowed == 0): then every `/` is spurious and safe to drop.
+                # If the label has a ・/literal `/` but the typing has *more*
+                # slashes than that, which to keep is ambiguous — leave it for
+                # a human (P1 lint still flags it) rather than risk stripping a
+                # legitimate ・ keystroke.
+                if allowed == 0 and "/" in t:
+                    t2 = _strip_spurious_slashes(t)
                     if t2 != t:
                         fixed += 1
                     new_typings.append(t2)
                 else:
                     new_typings.append(t)
-            if new_typings != (c.get("ja_typings") or []):
+            if new_typings != typings:
                 c["ja_typings"] = new_typings
     QUESTIONS_PATH.write_text(
         json.dumps(data, ensure_ascii=False, indent=2) + "\n",
@@ -244,8 +264,8 @@ def sync_en() -> int:
             qe["ja_reviewed"] = qa.get("ja_reviewed", False)
             changed += 1
         for ca, ce in zip(qa["choices"], qe["choices"]):
-            if ce.get("ja_typings") != ca.get("ja_typings"):
-                ce["ja_typings"] = ca.get("ja_typings")
+            if ce.get("ja_typings") != (ca.get("ja_typings") or []):
+                ce["ja_typings"] = ca.get("ja_typings") or []
                 changed += 1
     EN_PATH.write_text(
         json.dumps(en, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"

--- a/scripts/kanji_review.py
+++ b/scripts/kanji_review.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 QUESTIONS_PATH = ROOT / "data" / "questions_ja.json"
+EN_PATH = ROOT / "data" / "questions_en.json"
 
 KANJI_RE = re.compile(r"[一-鿿㐀-䶿]")
 
@@ -171,15 +172,130 @@ def apply(verdicts_path: str) -> int:
     return 0
 
 
+def fix_spurious_slashes() -> int:
+    """Remove `/` used as a bare word separator (lint rule P1).
+
+    The matcher (src/io/normalize.rs::canonical_romaji) keeps `/` and matches
+    it positionally — it is the keystroke for ・. A `/` with no ・ (or literal
+    `/`) in the label is unreachable, so blind-typing the reading can never
+    complete the answer. We strip such `/`, re-doubling a preceding lone `n`
+    to `nn` when it now lands before a vowel / `n` / `y` (e.g.
+    `kan/no/butei` -> `kannnobutei`), which is exactly what canonical_romaji
+    would have done at the `/`. Legitimate `/` (HTTP/1.1, らんま1/2) is left
+    untouched because the label carries a matching ・ or literal `/`.
+    """
+    data = load()
+    fixed = 0
+    for q in data:
+        for c in q.get("choices", []):
+            ja = c.get("ja", "")
+            allowed = ja.count("・") + ja.count("/")
+            new_typings = []
+            for t in c.get("ja_typings") or []:
+                if t.count("/") > allowed:
+                    t2 = re.sub(r"n/([aiueoyn])", r"nn\1", t).replace("/", "")
+                    if t2 != t:
+                        fixed += 1
+                    new_typings.append(t2)
+                else:
+                    new_typings.append(t)
+            if new_typings != (c.get("ja_typings") or []):
+                c["ja_typings"] = new_typings
+    QUESTIONS_PATH.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"spurious-slash typings fixed: {fixed}")
+    return 0
+
+
+def _choices_aligned(a: list[dict], b: list[dict]) -> bool:
+    """True if both files hold the same questions and choice labels in the
+    same order — the precondition for copying choice data positionally."""
+    if [q.get("id") for q in a] != [q.get("id") for q in b]:
+        return False
+    for qa, qb in zip(a, b):
+        ca, cb = qa.get("choices", []), qb.get("choices", [])
+        if [c.get("ja") for c in ca] != [c.get("ja") for c in cb]:
+            return False
+        if [c.get("en") for c in ca] != [c.get("en") for c in cb]:
+            return False
+    return True
+
+
+def sync_en() -> int:
+    """Copy the language-independent choice data (`ja_typings`) and
+    `ja_reviewed` from questions_ja.json into questions_en.json.
+
+    The two files hold the same questions and choices; only `question_text`
+    differs by language. The review pipeline (#134/#135) only edits the ja
+    file, so this propagates the result to the en file. Positional copy is
+    safe only when the choices align, which we assert first.
+    """
+    ja = load()
+    with EN_PATH.open(encoding="utf-8") as f:
+        en = json.load(f)
+    if not _choices_aligned(ja, en):
+        sys.stderr.write("ja/en questions or choice labels are not aligned; aborting\n")
+        return 1
+    changed = 0
+    for qa, qe in zip(ja, en):
+        if qe.get("ja_reviewed") != qa.get("ja_reviewed", False):
+            qe["ja_reviewed"] = qa.get("ja_reviewed", False)
+            changed += 1
+        for ca, ce in zip(qa["choices"], qe["choices"]):
+            if ce.get("ja_typings") != ca.get("ja_typings"):
+                ce["ja_typings"] = ca.get("ja_typings")
+                changed += 1
+    EN_PATH.write_text(
+        json.dumps(en, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    print(f"en fields synced from ja: {changed}")
+    return 0
+
+
+def verify_sync() -> int:
+    """CI gate: the two files' choice data (`ja_typings`) and `ja_reviewed`
+    must be identical, so a review applied to one is never lost on the other.
+    """
+    with QUESTIONS_PATH.open(encoding="utf-8") as f:
+        ja = json.load(f)
+    with EN_PATH.open(encoding="utf-8") as f:
+        en = json.load(f)
+    if not _choices_aligned(ja, en):
+        print("ja/en questions or choice labels are NOT aligned")
+        return 1
+    problems = []
+    for qa, qe in zip(ja, en):
+        if qa.get("ja_reviewed", False) != qe.get("ja_reviewed", False):
+            problems.append(f"{qa['id']}: ja_reviewed differs")
+        for i, (ca, ce) in enumerate(zip(qa["choices"], qe["choices"])):
+            if ca.get("ja_typings") != ce.get("ja_typings"):
+                problems.append(f"{qa['id']}#{i}: ja_typings differs")
+    print(f"ja/en choice-data sync problems: {len(problems)}")
+    for p in problems[:20]:
+        print(f"  {p}")
+    return 0 if not problems else 1
+
+
 def main() -> int:
+    if len(sys.argv) >= 2 and sys.argv[1] == "sync-en":
+        return sync_en()
+    if len(sys.argv) >= 2 and sys.argv[1] == "verify-sync":
+        return verify_sync()
     if len(sys.argv) >= 3 and sys.argv[1] == "extract":
         return extract(sys.argv[2])
     if len(sys.argv) >= 3 and sys.argv[1] == "apply":
         return apply(sys.argv[2])
+    if len(sys.argv) >= 2 and sys.argv[1] == "fix-slashes":
+        return fix_spurious_slashes()
     sys.stderr.write(
         "usage:\n"
         "  kanji_review.py extract <genre|qid-prefix|all>   > manifest.json\n"
         "  kanji_review.py apply <verdicts.json>\n"
+        "  kanji_review.py fix-slashes\n"
+        "  kanji_review.py sync-en       # copy ja_typings + ja_reviewed ja -> en\n"
+        "  kanji_review.py verify-sync   # CI gate: ja/en choice data identical\n"
     )
     return 2
 

--- a/scripts/kanji_review.py
+++ b/scripts/kanji_review.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""LLM-judge pipeline for kanji-bearing `ja_typings` (#134).
+
+kana / ASCII choices are verified deterministically by the
+`review-ja-typings` binary (#135). Kanji-bearing choices have ambiguous
+readings (compounds, proper nouns, number readings) that a reading engine
+like kakasi gets wrong ~95% of the time, so they need an LLM that can read
+the kanji *in context* (the `en` answer disambiguates e.g. 陽子 = proton
+`youshi` vs the name `youko`).
+
+This script does the deterministic halves; an LLM does the judgement in
+between:
+
+    extract <scope>      -> manifest.json   (choices an LLM must judge)
+      ... LLM produces verdicts.json ...
+    apply <verdicts.json>                    (rewrite typings / set ja_reviewed)
+
+`scope` is a genre name, a `q`-id prefix (e.g. `q013`), or `all`.
+
+A question is set `ja_reviewed=true` only when every one of its
+kanji-bearing choices has an `ok` (or successfully-applied `fix`) verdict.
+After `apply`, always re-run `lint-questions`, `review-ja-typings verify`
+and `scripts/lint_ja_typings.py` — a `fix` typing still has to pass the
+IME-strict form gate.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+QUESTIONS_PATH = ROOT / "data" / "questions_ja.json"
+
+KANJI_RE = re.compile(r"[一-鿿㐀-䶿]")
+
+
+def has_kanji(s: str) -> bool:
+    return bool(KANJI_RE.search(s))
+
+
+def in_scope(q: dict, scope: str) -> bool:
+    if scope == "all":
+        return True
+    if q.get("genre") == scope:
+        return True
+    qid = q.get("id", "")
+    return scope.startswith("q") and qid.startswith(scope)
+
+
+def load() -> list[dict]:
+    with QUESTIONS_PATH.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def extract(scope: str) -> int:
+    data = load()
+    manifest = []
+    for q in data:
+        if q.get("ja_reviewed", False) or not in_scope(q, scope):
+            continue
+        kanji_choices = [
+            {
+                "idx": i,
+                "ja": c.get("ja", ""),
+                "en": c.get("en", ""),
+                "stored": c.get("ja_typings") or [],
+            }
+            for i, c in enumerate(q.get("choices", []))
+            if has_kanji(c.get("ja", ""))
+        ]
+        if not kanji_choices:
+            continue
+        manifest.append(
+            {
+                "qid": q.get("id"),
+                "genre": q.get("genre"),
+                "question": q.get("question_text", {}).get("ja", ""),
+                "kanji_choices": kanji_choices,
+            }
+        )
+    json.dump(manifest, sys.stdout, ensure_ascii=False, indent=2)
+    print()
+    sys.stderr.write(
+        f"manifest: {len(manifest)} questions, "
+        f"{sum(len(m['kanji_choices']) for m in manifest)} kanji choices "
+        f"(scope={scope})\n"
+    )
+    return 0
+
+
+def apply(verdicts_path: str) -> int:
+    with open(verdicts_path, encoding="utf-8") as f:
+        verdicts = json.load(f)
+    # (qid, idx) -> verdict dict
+    table: dict[tuple[str, int], dict] = {}
+    for v in verdicts:
+        table[(v["qid"], int(v["idx"]))] = v
+
+    data = load()
+    confirmed = 0
+    fixed = 0
+    skipped_incomplete = 0
+    skipped_wrong = 0
+
+    for q in data:
+        if q.get("ja_reviewed", False):
+            continue
+        choices = q.get("choices", [])
+        kanji_idxs = [i for i, c in enumerate(choices) if has_kanji(c.get("ja", ""))]
+        if not kanji_idxs:
+            continue  # handled by review-ja-typings (#135)
+
+        # Every kanji choice must have a verdict, and none may be "wrong"
+        # (a "wrong" with no usable typing means the data is bad and a human
+        # must look — never auto-confirm it).
+        verdicts_here = [table.get((q["id"], i)) for i in kanji_idxs]
+        if any(v is None for v in verdicts_here):
+            skipped_incomplete += 1
+            continue
+        if any(v.get("verdict") == "wrong" for v in verdicts_here):
+            skipped_wrong += 1
+            continue
+
+        # Apply fixes, then confirm.
+        for i, v in zip(kanji_idxs, verdicts_here):
+            if v.get("verdict") == "fix":
+                typing = v.get("typing") or []
+                if not typing:
+                    skipped_wrong += 1
+                    break
+                choices[i]["ja_typings"] = list(typing)
+                fixed += 1
+        else:
+            q["ja_reviewed"] = True
+            confirmed += 1
+
+    QUESTIONS_PATH.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"questions confirmed (ja_reviewed=true): {confirmed}")
+    print(f"typings fixed                         : {fixed}")
+    print(f"skipped (verdict missing for a choice): {skipped_incomplete}")
+    print(f"skipped (a choice judged wrong)       : {skipped_wrong}")
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) >= 3 and sys.argv[1] == "extract":
+        return extract(sys.argv[2])
+    if len(sys.argv) >= 3 and sys.argv[1] == "apply":
+        return apply(sys.argv[2])
+    sys.stderr.write(
+        "usage:\n"
+        "  kanji_review.py extract <genre|qid-prefix|all>   > manifest.json\n"
+        "  kanji_review.py apply <verdicts.json>\n"
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kanji_review.py
+++ b/scripts/kanji_review.py
@@ -90,19 +90,30 @@ def extract(scope: str) -> int:
     return 0
 
 
+VALID_VERDICTS = {"ok", "fix", "wrong"}
+
+
 def apply(verdicts_path: str) -> int:
     with open(verdicts_path, encoding="utf-8") as f:
         verdicts = json.load(f)
-    # (qid, idx) -> verdict dict
+    # (qid, idx) -> verdict dict, with verdict normalised to lowercase.
     table: dict[tuple[str, int], dict] = {}
+    malformed = 0
     for v in verdicts:
-        table[(v["qid"], int(v["idx"]))] = v
+        try:
+            key = (v["qid"], int(v["idx"]))
+        except (KeyError, ValueError, TypeError):
+            malformed += 1
+            continue
+        v = dict(v)
+        v["verdict"] = str(v.get("verdict", "")).strip().lower()
+        table[key] = v
 
     data = load()
     confirmed = 0
     fixed = 0
     skipped_incomplete = 0
-    skipped_wrong = 0
+    skipped_problem = 0
 
     for q in data:
         if q.get("ja_reviewed", False):
@@ -112,29 +123,40 @@ def apply(verdicts_path: str) -> int:
         if not kanji_idxs:
             continue  # handled by review-ja-typings (#135)
 
-        # Every kanji choice must have a verdict, and none may be "wrong"
-        # (a "wrong" with no usable typing means the data is bad and a human
-        # must look — never auto-confirm it).
         verdicts_here = [table.get((q["id"], i)) for i in kanji_idxs]
-        if any(v is None for v in verdicts_here):
+
+        # Every kanji choice must have an *understood* verdict. A missing
+        # verdict or an unrecognised value (typo, wrong case, hand-edit) is
+        # treated as not-yet-judged — never silently confirmed.
+        if any(v is None or v["verdict"] not in VALID_VERDICTS for v in verdicts_here):
             skipped_incomplete += 1
             continue
-        if any(v.get("verdict") == "wrong" for v in verdicts_here):
-            skipped_wrong += 1
+        # A "wrong" verdict means a human must look — never auto-confirm.
+        if any(v["verdict"] == "wrong" for v in verdicts_here):
+            skipped_problem += 1
             continue
 
-        # Apply fixes, then confirm.
+        # Stage fixes first; only commit them once we know the whole question
+        # is confirmable. This keeps a skipped question completely untouched
+        # rather than leaving a half-applied typing behind.
+        pending_fixes: list[tuple[int, list[str]]] = []
+        bad = False
         for i, v in zip(kanji_idxs, verdicts_here):
-            if v.get("verdict") == "fix":
+            if v["verdict"] == "fix":
                 typing = v.get("typing") or []
-                if not typing:
-                    skipped_wrong += 1
+                if not typing or not all(isinstance(t, str) for t in typing):
+                    bad = True
                     break
-                choices[i]["ja_typings"] = list(typing)
-                fixed += 1
-        else:
-            q["ja_reviewed"] = True
-            confirmed += 1
+                pending_fixes.append((i, list(typing)))
+        if bad:
+            skipped_problem += 1
+            continue
+
+        for i, typing in pending_fixes:
+            choices[i]["ja_typings"] = typing
+            fixed += 1
+        q["ja_reviewed"] = True
+        confirmed += 1
 
     QUESTIONS_PATH.write_text(
         json.dumps(data, ensure_ascii=False, indent=2) + "\n",
@@ -142,8 +164,10 @@ def apply(verdicts_path: str) -> int:
     )
     print(f"questions confirmed (ja_reviewed=true): {confirmed}")
     print(f"typings fixed                         : {fixed}")
-    print(f"skipped (verdict missing for a choice): {skipped_incomplete}")
-    print(f"skipped (a choice judged wrong)       : {skipped_wrong}")
+    print(f"skipped (verdict missing/unknown)     : {skipped_incomplete}")
+    print(f"skipped (wrong / unusable fix)        : {skipped_problem}")
+    if malformed:
+        print(f"malformed verdict entries ignored     : {malformed}")
     return 0
 
 

--- a/scripts/lint_ja_typings.py
+++ b/scripts/lint_ja_typings.py
@@ -19,6 +19,7 @@ Categories detected:
   A1  ASCII / English-letter variant  (c++20, base64url, o(1), jinsei game)
   S1  全角 space inside typing
   S2  ・ retained as raw rather than `/`
+  P1  `/` used as a bare separator (more `/` than the label's ・ + literal `/`)
 
 Output: scripts/lint_report.json with per-violation entries.
 """
@@ -96,6 +97,16 @@ def categorise(ja: str, typing: str) -> list[str]:
     # S2 — raw ・ / fullwidth punct inside typing.
     if FORBIDDEN_RE.search(typing):
         cats.append("S2")
+    # P1 — a `/` in the typing not justified by the label. The matcher
+    # (src/io/normalize.rs::canonical_romaji) keeps `/` and matches it
+    # positionally: `/` is the keystroke for ・, and a literal `/` in the
+    # label types itself. A `/` used as a bare word separator (e.g.
+    # `tokugawa/iemochi` for 徳川家茂, which has no ・) is unreachable — the
+    # player typing the natural reading never presses `/`, so the answer
+    # can never be completed. Allow at most as many `/` as the label has
+    # ・ plus literal `/`.
+    if typing.count("/") > ja.count("・") + ja.count("/"):
+        cats.append("P1")
     return cats
 
 


### PR DESCRIPTION
## 関連 Issue
closes #134

## 背景
#135 で kana/ASCII は決定的に確定済み（2925→1330）。残る漢字 choice は読みが曖昧で kakasi は約95% 誤読するため、**LLM-judge** で確定する。

## パイプライン（再利用可・#136 のスキルから呼ぶ）
`scripts/kanji_review.py`:
- `extract <genre|qid-prefix|all>` → 未レビュー漢字 question を judge 用 manifest に（`ja` ラベル + `en` 意味 + stored typing。en で読み曖昧性を判定: 陽子=proton→youshi）
- `apply <verdicts.json>` → 全漢字 choice が ok/fix の question だけ `ja_reviewed=true`。fix は typing 置換、wrong/未判定があれば確定しない

### apply 安全化（独立レビュー指摘を反映）
- **M1**: verdict は `{ok,fix,wrong}` allowlist のみ受理。未知/欠落は未判定扱いで confirm しない
- **S1**: 壊れた verdict エントリは ignore + カウント報告
- **S2**: fix は stage→confirm 時のみ commit（skip question に half-applied を残さない）

## 結果（14 ジャンル独立サブエージェント判定）
- **1326 question 確定、360 typing 修正、未レビュー 2925→4**
- 修正種別: kunrei→Hepburn (si→shi/tu→tsu/tya→cha/hu→fu)、ん→nn 欠落の音節落ち（天王星 `tennousei`→`tennnousei`）、読み誤り（属性 `sokusei`→`zokusei`、注入 `nyuunyuu`→`chuunyuu`、毛利 `mori`→`mouri`、伏黒 `fukuro`→`fushiguro`）、中黒なしラベルの spurious `/` 除去、賞 `xsiyou`→`shou` 等
- **残 4 は人手判断（confirm せず）**: イド:インヴェイデッド(`:`)、黄金比φ×2(φキー入力曖昧)、英じゃ(英=えい/えん)

## 検証
- 構造差分は `ja_typings`(360)/`ja_reviewed`(1326) のみ・他フィールド不変・件数/順序不変
- ランダム15件の fix を目視確認、全て正しいかな
- lint-questions / review-ja-typings verify / lint_ja_typings 全 exit0・0 flagged
- cargo test 304+60+21 pass（`data_typings_are_prefix_typeable` 含む = 全 fix が prefix-typeable）